### PR TITLE
Add CNAME (throughstone.org)

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+throughstone.org


### PR DESCRIPTION
Sets the GitHub Pages custom domain by committing docs/CNAME (publishing source is main /docs). 🤖 Generated with [Claude Code](https://claude.com/claude-code)