### PR TITLE
Point asset generators at saved fonts

### DIFF
--- a/brand/BRAND.md
+++ b/brand/BRAND.md
@@ -138,8 +138,11 @@ geometric headings (more contemporary).
 **Type scale (suggested, rem):** 3.0 / 2.25 / 1.75 / 1.375 / 1.125 / 1.0 / 0.875.
 Line-height: 1.2 for display, 1.6 for body/prose.
 
-All faces are SIL Open Font License — free to embed and self-host. (Local copies for previews
-live in `brand/explore/fonts/`; the landing page may load them from Google Fonts.)
+All faces are SIL Open Font License — free to embed and self-host. The landing page self-hosts
+them from `brand/site/assets/fonts/` (mirrored in `docs/assets/fonts/`); the asset generators
+(`brand/logo/generate_logo.py`, `brand/social/generate_social.py`) read the same files, so the
+brand is fully reproducible from the repo — only a Python venv with `fonttools` + `pillow` is
+needed, no font downloads.
 
 ---
 

--- a/brand/logo/generate_logo.py
+++ b/brand/logo/generate_logo.py
@@ -12,7 +12,7 @@ from fontTools.pens.boundsPen import BoundsPen
 from fontTools.pens.transformPen import TransformPen
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-FONT = os.path.join(HERE, "..", "explore", "fonts", "Cinzel.ttf")
+FONT = os.path.join(HERE, "..", "site", "assets", "fonts", "Cinzel.ttf")
 OUT = HERE
 
 # ---- palette ----

--- a/brand/social/generate_social.py
+++ b/brand/social/generate_social.py
@@ -7,7 +7,7 @@ from fontTools.pens.svgPathPen import SVGPathPen
 from fontTools.pens.transformPen import TransformPen
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-FDIR = os.path.join(HERE, "..", "explore", "fonts")
+FDIR = os.path.join(HERE, "..", "site", "assets", "fonts")
 def fp(n): return os.path.join(FDIR, n)
 
 PAPER="#F4EEE2"; SAND="#DEC9A0"; OCHRE="#B07A35"; OCHRED="#8F6024"; MORTAR="#857667"; INK="#2A2521"
@@ -56,7 +56,7 @@ def wrap(text, font_path, size, maxw):
     if cur: lines.append(cur)
     return lines
 
-CINZEL=fp("Cinzel.ttf"); SPECTRAL=fp("Spectral.ttf"); SANS=fp("SourceSans3-400.ttf"); SANS600=fp("SourceSans3-600.ttf"); MONO=fp("IBMPlexMono-400.ttf")
+CINZEL=fp("Cinzel.ttf"); SANS=fp("SourceSans3-400.ttf"); SANS600=fp("SourceSans3-600.ttf"); MONO=fp("IBMPlexMono-400.ttf")
 
 # ----- mark wall (rows 16/30/58/72; row 44 left open for the stone) -----
 ROWS={


### PR DESCRIPTION
After `brand/explore/` was deleted, `generate_logo.py` and `generate_social.py` still pointed at the removed `../explore/fonts/` path. This repoints them at the four OFL fonts already committed in `brand/site/assets/fonts/` (Cinzel, Source Sans 3 400/600, IBM Plex Mono), drops the unused `Spectral.ttf` reference in the social generator, and updates the font note in `BRAND.md`.

Verified by running both generators in a fresh venv against the saved fonts: the output reproduces every committed SVG byte-for-byte. The brand is now fully reproducible from the repo (only a `fonttools` + `pillow` venv needed, no font downloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)