### PR TITLE
Use domain email for maintainer contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,7 +30,7 @@ for this Code of Conduct and is available at:
 ## Reporting
 
 If you experience or witness unacceptable behavior, or have any concerns, please report it
-privately to the maintainer at **hershey@gmail.com**. All reports will be reviewed and
+privately to the maintainer at **hershey@throughstone.org**. All reports will be reviewed and
 handled with discretion. The maintainer is responsible for enforcement and will respect the
 privacy and safety of anyone who reports an issue.
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ reports, fixes, and ideas are genuinely welcome. A few starting points:
 - **Bugs and feature ideas** — open an [Issue](../../issues).
 - **Security reports** — please use the private channel in [SECURITY.md](SECURITY.md), not a
   public issue.
-- **Conduct concerns** — email **hershey@gmail.com** (see the [Code of Conduct](CODE_OF_CONDUCT.md)).
+- **Conduct concerns** — email **hershey@throughstone.org** (see the [Code of Conduct](CODE_OF_CONDUCT.md)).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Instead, use one of these private channels:
 
 - **Preferred:** GitHub's [private vulnerability reporting](../../security/advisories/new)
   ("Report a vulnerability" on the Security tab).
-- **Fallback:** email **hershey@gmail.com** with the details.
+- **Fallback:** email **hershey@throughstone.org** with the details.
 
 Please include enough information to reproduce the issue (affected file, steps, and impact).
 


### PR DESCRIPTION
Swaps the personal Gmail for hershey@throughstone.org in SECURITY.md, CODE_OF_CONDUCT.md, and README.md. 🤖 Generated with [Claude Code](https://claude.com/claude-code)