### PR TITLE
Strengthen testing guidance: ~80% coverage suggestion + per-step/substep test defaults

### DIFF
--- a/Code/{{PROJECT}}-docs/coding-standards/dart.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/dart.md
@@ -59,4 +59,4 @@ Per Effective Dart (the analyzer enforces most of it):
 - One behavior per test, named for the behavior (`rejects an expired token`). Mock at
   boundaries (network, storage, clock) with `mockito` or `mocktail` — not the unit under test.
 - Keep tests fast and deterministic; use `setUp`/`tearDown` for shared state. Cover behavior
-  and edge cases, not a coverage percentage.
+  and edge cases, not a coverage percentage — though ~80% unit-test coverage is a reasonable guide to aim for, not a gate.

--- a/Code/{{PROJECT}}-docs/coding-standards/go.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/go.md
@@ -64,4 +64,4 @@ where we're opinionated. Pin the linters in the repo so the standard is enforced
   helpers. Reach for `testify` only if the team wants it.
 - Keep the unit suite fast and deterministic; gate slow/integration tests behind
   `testing.Short()` or a build tag. Use `t.Parallel()` where safe. Cover behavior and edge
-  cases, not a coverage percentage.
+  cases, not a coverage percentage — though ~80% unit-test coverage is a reasonable guide to aim for, not a gate.

--- a/Code/{{PROJECT}}-docs/coding-standards/python.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/python.md
@@ -54,4 +54,4 @@ just documented.
 - Use fixtures for setup and `pytest.mark.parametrize` for cases. Mock at boundaries (I/O,
   network, clock) — don't mock the code under test.
 - Keep tests fast and deterministic; mark slow/integration tests so the fast suite stays
-  the default. Aim for coverage of behavior and edge cases, not a percentage target.
+  the default. Aim for coverage of behavior and edge cases, not a percentage target — though ~80% unit-test coverage is a reasonable guide to aim for, not a gate.

--- a/Code/{{PROJECT}}-docs/coding-standards/rust.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/rust.md
@@ -60,6 +60,7 @@ compiler's built-in lints enforce the case conventions (`clippy` adds more):
   alongside the code; **integration tests** in `tests/`; **doc tests** in `///` examples
   that double as verified documentation. Run with `cargo test`.
 - One behavior per test, named for the behavior (`rejects_expired_token`). Use `Result` in
-  tests so you can `?`. Keep tests fast and deterministic.
+  tests so you can `?`. Keep tests fast and deterministic. As a guide, ~80% unit-test
+  coverage is a reasonable thing to aim for — a suggestion, not a gate.
 - Use `#[should_panic]` sparingly (prefer asserting on a returned `Err`). Reach for helper
   crates (`rstest`, `proptest`) only if the team wants them.

--- a/Code/{{PROJECT}}-docs/coding-standards/typescript.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/typescript.md
@@ -64,4 +64,4 @@ not just documented.
 - Name tests for the behavior (`rejects an expired token`), not the function. Mock at
   boundaries (network, fs, clock) — not the unit under test.
 - Keep tests fast and deterministic; isolate slow/integration tests so the fast suite stays
-  the default. Cover behavior and edge cases, not a coverage percentage.
+  the default. Cover behavior and edge cases, not a coverage percentage — though ~80% unit-test coverage is a reasonable guide to aim for, not a gate.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -29,7 +29,9 @@ where the pieces have to work *together*.
 1. **Test tiers.** Define unit / integration / end-to-end for this project: what each
    covers and roughly the balance between them.
 2. **What must be covered.** The critical paths and risky areas that must have tests (not a
-   vanity coverage %). What's explicitly *not* worth testing heavily.
+   vanity coverage %). What's explicitly *not* worth testing heavily. As a rough guide you
+   can *aim* for ~80% unit-test coverage — a suggestion to steer by, not a gate; don't chase
+   the number at the expense of testing what matters.
 3. **Test data & isolation.** How tests get data (fixtures/factories) and stay isolated
    (e.g. a fresh DB/schema per test run) so they don't interfere.
 4. **Mocking strategy.** What to mock (external/third-party dependencies) vs. exercise for

--- a/Code/{{PROJECT}}-docs/templates/step-plan.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan.md
@@ -38,11 +38,16 @@
 ## Ground rules
 <!-- The working agreement for this STEP. e.g. "no code in this STEP", commit discipline,
      what 'done' means for a substep, review gates. -->
+- **Tests ship with the code.** Every substep that writes or changes code also writes the
+  tests for it and runs the relevant tests before it's done (see
+  `templates/substep-prompt.md`). Override per substep only with a stated reason.
 
 ## Definition of done
 <!-- Concrete, checkable criteria for the whole STEP. -->
 - [ ]
 - [ ]
+- [ ] All unit tests pass at the end of this STEP — ideally the full suite (unit +
+      integration/e2e). <!-- the default bar; narrow or widen with a stated reason -->
 - [ ] STEP review passed; STEP-index.md updated; STEP archived to prompts/.
 <!-- The "STEP review" is your team's standard PR / code review (a standard-practice gate the
      method doesn't redefine — see runbooks/collaboration.md), plus the doc-drift check from

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt.md
@@ -27,6 +27,11 @@
 
 ## Verification
 <!-- How to prove it's done and correct: tests to write/run, commands, checks. -->
+- **If this substep writes or changes code, write the tests that cover it** — the new
+  behavior and its failure modes. (Default; override only for a genuinely code-free substep,
+  e.g. docs/config, and say why.)
+- **Run the relevant tests before marking this substep done** — at minimum the tests that
+  exercise the code you touched. They must pass.
 
 ## Keeping the docs true  (always)
 <!-- The architecture docs are the source of truth for the design. Implementation drifts
@@ -47,6 +52,8 @@ Leaving the doc stale is a defect, not a follow-up.
 ## Definition of done
 - [ ]
 - [ ]
+- [ ] Code this substep wrote or changed is covered by tests, and the relevant tests pass.
+      <!-- default; drop only for a genuinely code-free substep -->
 - [ ] Any architecture decision this substep changed is reflected in the docs (Version Log
       bumped) or recorded in an ADR.
 

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt.md
@@ -27,9 +27,25 @@
 
 ## Verification
 <!-- How to prove it's done and correct: tests to write/run, commands, checks. -->
-- **If this substep writes or changes code, write the tests that cover it** — the new
-  behavior and its failure modes. (Default; override only for a genuinely code-free substep,
-  e.g. docs/config, and say why.)
+- **If this substep writes or changes code, write the tests that cover it** — not just the
+  happy path. (Default; override only for a genuinely code-free substep, e.g. docs/config,
+  and say why.)
+<!-- Kinds of cases to consider — cover the ones that apply, prune the rest:
+     - Happy path — the expected, valid case.
+     - Empty / zero / null / missing input — empty collections & strings, 0, null/None,
+       absent optional fields.
+     - Boundary values — min/max, first/last, off-by-one, size/length limits, overflow.
+     - Invalid / malformed input — wrong type, bad format, out-of-range — rejected cleanly.
+     - Error paths — failures surface correctly (right exception / error code / message);
+       partial work rolls back.
+     - Edge cases in logic — unusual-but-valid combinations, ordering, duplicates, conflicts.
+     - State & side effects — data persisted/updated correctly, no unintended mutation,
+       cleanup on failure.
+     - Concurrency & idempotency (where relevant) — repeated / parallel / out-of-order calls.
+     - External-dependency failure (where relevant) — timeouts / unavailable deps handled
+       (mock at the boundary).
+     - Security / authorization (where relevant) — unauthenticated / unauthorized access denied.
+     - Regression — when fixing a bug, add a test that reproduces it so it can't return. -->
 - **Run the relevant tests before marking this substep done** — at minimum the tests that
   exercise the code you touched. They must pass.
 


### PR DESCRIPTION
## Summary

Strengthens the testing guidance in the methodology templates, in response to a review of how Throughstone handles tests as code is built.

Three changes, all framed as **overridable defaults** (the user can drop or narrow them with a stated reason) so they don't fight special cases like the architecture STEP-1 or docs-only substeps:

1. **Suggest ~80% unit-test coverage as a non-binding guide** (`3b6938f`)
   Added a soft ~80% unit-test coverage suggestion where coverage is decided (Session 1.11) and in each language's coding-standards Testing section. Framed as a guide, not a gate, so it complements rather than replaces the existing behavior-first stance ("cover critical paths, not a vanity %").

2. **Bake per-substep / per-STEP test guidance into the authoring templates** (`8731222`)
   - `substep-prompt.md`: a code-writing substep also writes its tests, and runs the relevant tests (must pass) before it's done.
   - `step-plan.md`: a ground rule that tests ship with the code, and a Definition-of-done item that all unit tests pass at STEP end (ideally the full suite).

3. **Add a test-case-types menu to the substep template** (`bf8bb94`)
   A reference list of the kinds of cases to consider beyond the happy path: empty/zero/null/missing input, boundary values, invalid/malformed input, error paths, logic edge cases, state & side effects, concurrency/idempotency, dependency failure, security/authorization, and regression.

## Files touched

- `Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md`
- `Code/{{PROJECT}}-docs/templates/substep-prompt.md`
- `Code/{{PROJECT}}-docs/templates/step-plan.md`
- `Code/{{PROJECT}}-docs/coding-standards/{python,typescript,go,rust,dart}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
