### PR TITLE
Strengthen documentation discipline across the method

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -79,8 +79,12 @@ pointers are committed files; see `METHOD.md` §7.) The repos are siblings:
 - `prompts/` — STEP plans + substep prompts.
 - `Code/{{PROJECT}}-*` — code repos, created as the architecture names them.
 
-`registries/repos.yml` is the canonical inventory. `scripts/setup-workspace.sh` sets up a
-new developer's machine (clones the siblings, writes the root pointers).
+`registries/repos.yml` is the canonical inventory **and the index to the repos** — each
+entry points to a repo whose **README is its "about"** (what it is, how to set it up; plus an
+`ARCHITECTURE.md` if it has deep internals). **Before working in a repo, read its README
+first** — the same way you read the architecture docs before a design change.
+`scripts/setup-workspace.sh` sets up a new developer's machine (clones the siblings, writes
+the root pointers).
 
 **Workspace-root hygiene:** the workspace root should contain only per-machine pointers
 and config (`CLAUDE.md`, `AGENTS.md`, `.claude/`), the repo folders (`Code/*`, `prompts/`),
@@ -94,7 +98,12 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
   rewrite an accepted ADR's decision — supersede it or append an amendment.
 - **Keep the docs true.** When implementation changes an architecture decision, update the
   affected `Code/{{PROJECT}}-docs/architecture/NN-*.md` and bump its Version Log, or write an
-  ADR — don't let the doc go stale (see `Code/{{PROJECT}}-docs/METHOD.md` §6).
+  ADR. New code counts too: a new component or repo may need the architecture overview /
+  `registries/repos.yml`, a new domain term the glossary — don't let a doc go stale (see
+  `Code/{{PROJECT}}-docs/METHOD.md` §6).
+- **Document code as you write it.** Every class, function, and method gets a docstring;
+  comment the *why* of non-obvious logic (see
+  `Code/{{PROJECT}}-docs/coding-standards/README.md`).
 - **Suggest a check-in every ~10–20 STEPs.** When about that many STEPs have passed since the
   last check-in, proactively propose inserting a **Check-in STEP** that runs
   `Code/{{PROJECT}}-docs/runbooks/check-in.md` (doc-drift reconciliation both ways + full

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -232,7 +232,11 @@ per-machine shell. The `init.sh` wizard sets this up for the first developer; se
 aren't created at bootstrap — they're stamped from
 `Code/{{PROJECT}}-docs/templates/repo-readme.md` once the architecture names them. (Or choose
 mono-repo-for-now in the wizard — see *Mono-repo for now* below.) For multi-repo projects,
-`registries/repos.yml` is the canonical inventory.
+`registries/repos.yml` is the canonical inventory. **Every repo carries a README explaining
+what it is** — its role and the slice of the system it owns — stamped from that template and
+filled in when the repo is scaffolded (with a matching one-line `description` in
+`registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
+its root for its internal design.
 
 **All durable content lives in a repo** — almost always `Code/{{PROJECT}}-docs/`. The
 workspace root holds only **per-machine** files: the pointer `CLAUDE.md` / `AGENTS.md`

--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -1,8 +1,8 @@
 # Coding Standards
 
 Per-language engineering standards for {{PROJECT}}: naming, layout, error handling,
-logging, testing conventions. Code substeps should reference the relevant standard so the
-codebase stays consistent regardless of who (or which agent) writes it.
+logging, documentation, and testing conventions. Code substeps should reference the relevant
+standard so the codebase stays consistent regardless of who (or which agent) writes it.
 
 ## How this works
 - Default standards for common languages ship with Throughstone (e.g. `python.md`,
@@ -15,6 +15,20 @@ codebase stays consistent regardless of who (or which agent) writes it.
   standards per language" decision in that session.)
 - If a standard reflects a decision (e.g. "we use X error-handling pattern because…"),
   link the ADR that records why.
+
+## Documentation & comments  (all languages)
+A project-wide rule; each language file shows the idiomatic *form* and the lint that
+enforces it.
+- **Docstrings are required on every class, method, and function** — public *and* private.
+  Say what it does, its parameters and return, and anything non-obvious about its contract.
+  Describe what the code **actually does**, not what you set out to write — a docstring that
+  drifts from the behavior misleads worse than silence. This is a gate: code without them
+  isn't done.
+- **Comment for the next reader.** As a guideline, expect roughly a comment every ~10 lines
+  of non-trivial code — a readability *suggestion*, not a counted requirement. Explain the
+  *why*; don't restate what the code already says. Cut narration (`// increment i`): it's
+  noise, and it goes stale.
+- **Keep comments and docstrings true** as the code changes — a stale one is worse than none.
 
 ## Files
 Defaults that ship with Throughstone. Keep the file(s) for the language(s) you use, prune

--- a/Code/{{PROJECT}}-docs/coding-standards/dart.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/dart.md
@@ -21,6 +21,12 @@ Per Effective Dart (the analyzer enforces most of it):
 - Acronyms are capitalized as words: `HttpRequest`, not `HTTPRequest`.
 - Names say what, not how. Booleans read as predicates (`isActive`, `hasAccess`).
 
+## Documentation
+- **Dartdoc `///` on every class, function, and method** (the project rule — see
+  [`README.md`](README.md)); `dart doc` renders them. The `public_member_api_docs` lint
+  enforces presence on the public API — carry the habit to private members.
+- Comment the *why*; let names and types carry the *what*.
+
 ## Project / module layout
 - Pub package: public API in `lib/`, implementation details in **`lib/src/`** (not imported
   directly by consumers); re-export the intended surface from `lib/<package>.dart`. Tests in

--- a/Code/{{PROJECT}}-docs/coding-standards/go.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/go.md
@@ -19,6 +19,13 @@ where we're opinionated. Pin the linters in the repo so the standard is enforced
 - Interfaces describing one method end in `-er` (`Reader`, `Stringer`). Errors: `ErrNotFound`
   for sentinels, `FooError` for types.
 
+## Documentation
+- **A doc comment on every type, func, and method — exported *and* unexported** (the project
+  rule — see [`README.md`](README.md); Go's own norm is exported-only, the project rule goes
+  further). Go style: begin with the identifier's name (`// Server handles …`); `go doc` /
+  godoc render these. `revive` / `golangci-lint` can flag missing ones.
+- Comment the *why* of non-obvious logic (and *why* an ignored error is safe — see below).
+
 ## Project / module layout
 - One module per repo (`go.mod` at root, module path = repo URL). Package per directory;
   the directory name is the package name.

--- a/Code/{{PROJECT}}-docs/coding-standards/python.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/python.md
@@ -19,6 +19,13 @@ just documented.
 - Names say what, not how: `active_users`, not `user_list`. Booleans read as predicates
   (`is_active`, `has_access`). No single-letter names except short-lived loop indices.
 
+## Documentation
+- **Docstrings on every module, class, function, and method** (the project rule — see
+  [`README.md`](README.md)). Triple-quoted, [PEP 257](https://peps.python.org/pep-0257/);
+  pick one style for structured fields (Google or NumPy) and apply it consistently. Ruff's
+  `pydocstyle` rules (`D`) can enforce presence.
+- Comment the *why* of non-obvious logic; let clear names and type hints carry the *what*.
+
 ## Project / module layout
 - **Layout:** for a packaged/distributable library, prefer the `src/` layout (package under
   `src/{{PROJECT}}/`, tests in a top-level `tests/`) — it keeps tests running against the

--- a/Code/{{PROJECT}}-docs/coding-standards/rust.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/rust.md
@@ -21,6 +21,13 @@ compiler's built-in lints enforce the case conventions (`clippy` adds more):
 - Acronyms are one word: `Uuid`, `HttpClient` — not `UUID`, `HTTPClient`.
 - Names say what, not how. Booleans read as predicates (`is_active`, `has_access`).
 
+## Documentation
+- **Doc comments (`///`) on every type, trait, function, and method — including private
+  items** (the project rule — see [`README.md`](README.md)). `///` docs double as **doc-tests**
+  (see Testing) and render with `cargo doc`. `#![warn(missing_docs)]` enforces them on the
+  public API; carry the habit to private items.
+- Comment the *why* of non-obvious logic; let types and names carry the *what*.
+
 ## Project / module layout
 - Cargo project: `src/main.rs` for a binary, `src/lib.rs` for a library; split modules into
   files/directories with `mod`. Use a **workspace** for multi-crate projects.

--- a/Code/{{PROJECT}}-docs/coding-standards/typescript.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/typescript.md
@@ -22,6 +22,12 @@ not just documented.
 - No `I`-prefix on interfaces and no `T`-prefix on types. Booleans read as predicates
   (`isActive`, `hasAccess`).
 
+## Documentation
+- **A TSDoc/JSDoc `/** … */` block on every class, function, and method** (the project rule
+  — see [`README.md`](README.md)) — `@param`/`@returns` where they add what the signature
+  doesn't. `eslint-plugin-jsdoc` can enforce presence and shape.
+- Comment the *why*; let types and names carry the *what*.
+
 ## Project / module layout
 - Source under `src/`, tests colocated (`foo.test.ts`) or in `__tests__/` — pick one and be
   consistent. Compiled output to `dist/` (gitignored).

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -1,6 +1,10 @@
 # Canonical repo inventory for {{PROJECT}} (multi-repo projects).
-# The source of truth for which repos exist and what each is. Update this whenever a repo
-# is created. Tooling/CI can read it to stay in sync. See METHOD.md §7.
+# The source of truth for which repos exist and what each is — and the index to their docs:
+# each entry's `location` points to a repo whose own README.md (plus an optional
+# ARCHITECTURE.md) is the detailed "about". To orient in a multi-repo project, read this map
+# first, then read the README of each repo you'll touch — the same way you read the
+# architecture docs before a design change. Update this whenever a repo is created. Tooling/CI
+# can read it to stay in sync. See METHOD.md §7.
 #
 # Mono-repo-for-now: the entries below are folders inside the single repo, not separate repos
 # yet — this inventory describes the post-split (multi-repo) target.

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -44,6 +44,18 @@ secrets handling actually in place; glossary (12) vs. the terms the code now use
 reconcile `architecture/README.md`'s index against the docs actually present (a row per doc,
 with its current version/status).
 
+Beyond the architecture docs, sweep three things that rot just as quietly:
+- **Repo READMEs** — every code repo has one, its **Overview** still describes what the repo
+  *is*, and the **Setup / Running / Testing** steps still work from a clean checkout. They're
+  stamped once at repo creation and otherwise never re-checked, so they're usually the stalest
+  doc a new contributor or agent hits first (and any `ARCHITECTURE.md` still matches the design).
+- **API contracts** — any published spec (OpenAPI / GraphQL / protobuf) still matches the
+  endpoints the service actually serves. A drifted contract breaks consumers silently, so
+  treat a mismatch as a real defect (fix the spec, or file a bug if the code is wrong).
+- **Docstrings** — spot-check that docstrings describe what the code *now does*, not what it
+  was first written to do. A docstring that lies is worse than none; fix it in place (a doc
+  fix, not a bug STEP).
+
 ## Part 2 — Run all tests  *(substep N.2)*
 - Run the **full** test suite (all repos), not just the area you last touched.
 - Record the result: pass/fail counts, anything skipped, and coverage if you track it.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
@@ -37,7 +37,10 @@ UI session (1.7) and the conditional Native-app session apply.
    (independent scaling, separate teams, isolation). Flag what the choice forecloses.
 4. **Boundaries & contracts.** For each boundary between components: what crosses it (an
    API call? an event/queue? a shared DB — usually avoid), sync vs async, who owns the data
-   on each side.
+   on each side. For any boundary that's an **API**, decide that its contract is a
+   **versioned artifact** — an OpenAPI / GraphQL schema / protobuf file in the owning repo,
+   not just prose — since it's what other components build against and the thing most likely
+   to break them when it drifts.
 5. **Key flows.** Walk through 1–2 important end-to-end scenarios and how components
    collaborate to serve them. This validates the boundaries.
 6. **High-level tech stack.** Languages/frameworks per component (detail lands in the
@@ -51,7 +54,8 @@ UI session (1.7) and the conditional Native-app session apply.
 Write `architecture/03-architecture-overview.md` (use `templates/architecture-doc.md`). Body:
 - **Client surfaces** (the recorded answer + what it gates)
 - **Component diagram** (ASCII) + a **component table**: name | responsibility | tech
-- **Boundaries & contracts** table
+- **Boundaries & contracts** table — and for each API boundary, where its spec lives (the
+  versioned OpenAPI / GraphQL / protobuf artifact that is the contract of record)
 - **Key flows** (numbered walk-throughs)
 - **Build vs. buy** notes
 

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -48,8 +48,11 @@ architecture changes and the remaining STEPs need re-planning.
    baseline (1.9) — including copying `templates/env-example.txt` into each repo as its
    `.env.example`, and adding a **stack-appropriate `.gitignore`** to each new code repo
    (language/build artifacts — `node_modules/`, `__pycache__/`, `target/`, `dist/`, … — plus
-   the `.env` / `.secrets/` secret-file block so local secrets never get committed). Confirm
-   the repo list and that they don't exist yet.
+   the `.env` / `.secrets/` secret-file block so local secrets never get committed). **Each
+   repo's README isn't just stamped — its role one-liner and Overview get filled in** (what
+   the repo is and the slice of the system it owns), and the repo gets a row in
+   `registries/repos.yml` with a one-line `description`; a repo isn't scaffolded until it can
+   explain itself. Confirm the repo list and that they don't exist yet.
 2. **The implementation STEP sequence.** Propose all the Phase-1 STEPs in dependency order.
    A typical shape:
    - **Scaffold** — repos, skeleton, CI, local run + the env/secrets baseline.

--- a/Code/{{PROJECT}}-docs/templates/repo-readme.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme.md
@@ -4,16 +4,24 @@
 > defines it, e.g. `{{PROJECT}}-docs/architecture/03-architecture-overview.md`.)
 
 <!--
-  Stamp a copy of this into each code repo as it's created. Keep the section headings
-  consistent across all repos so the project reads uniformly. Drop sections that don't
-  apply (e.g. no "API Endpoints" for a library), but keep the order.
+  Stamp a copy of this into each code repo as it's created — every repo, including in a
+  multi-repo design, must carry one. Keep the section headings consistent across all repos
+  so the project reads uniformly. Sections that don't apply can be dropped (e.g. no
+  "API / interface" for a library), but keep the order — and never drop the role one-liner
+  above or the Overview below: explaining what the repo *is* is the one non-negotiable part.
 -->
 
 ## Overview
 <!-- A short paragraph or two: what this repo does, the problem it owns within the system,
      how it relates to the other repos, and what a newcomer should understand before
      reading the code. Longer than the one-liner above, shorter than the architecture doc
-     (link that for the full picture). -->
+     (link that for the full picture). This section is required — a repo without it doesn't
+     explain itself.
+
+     For a repo with real internal complexity, a README paragraph isn't enough: add an
+     `ARCHITECTURE.md` at the repo root for its internal design — the main modules, key
+     flows, and *why* it's built this way (the codebase-level counterpart to the hub's
+     system-wide `architecture/` docs) — and link it from here. Skip it for a simple repo. -->
 
 ## Tech stack
 <!-- Language + version, framework, datastore(s), key libraries. -->
@@ -28,8 +36,9 @@
 <!-- How to start it locally, and how to verify it's up (health check, sample request). -->
 
 ## API / interface
-<!-- For a service: endpoint table (method, path, auth, description). For a library:
-     the public surface. Skip if not applicable. -->
+<!-- For a service: link the versioned spec (OpenAPI / GraphQL / protobuf) as the contract of
+     record, with a short endpoint table for orientation — don't duplicate the spec here.
+     For a library: the public surface. Skip if not applicable. -->
 
 ## Testing
 <!-- How to run the tests; the tiers (unit / integration / e2e) and what each covers. -->

--- a/Code/{{PROJECT}}-docs/templates/step-plan.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan.md
@@ -41,6 +41,8 @@
 - **Tests ship with the code.** Every substep that writes or changes code also writes the
   tests for it and runs the relevant tests before it's done (see
   `templates/substep-prompt.md`). Override per substep only with a stated reason.
+- **Code is documented as it's written.** Every class, function, and method gets a docstring;
+  comment the *why* of non-obvious logic (see `coding-standards/README.md`).
 
 ## Definition of done
 <!-- Concrete, checkable criteria for the whole STEP. -->

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt.md
@@ -13,11 +13,18 @@
      substep is responsible for. Enough that a fresh agent understands without history. -->
 
 ## Read these first
-<!-- Explicit list of files this substep depends on: architecture docs, ADRs, prior code,
-     coding standards. The agent should read these before doing anything. -->
+<!-- Start from the main docs this substep depends on, then follow the indexes to find
+     anything else relevant — don't try to read everything. The indexes point the way:
+       - architecture/README.md     — the architecture docs (what the system is)
+       - adr/README.md              — the decision records (why it's that way)
+       - coding-standards/README.md — the per-language standards
+       - registries/repos.yml       — the repo inventory; each repo's own README is its "about"
+     List the specific files this substep depends on below — including the README of each
+     repo this substep touches, read before you work in it. -->
 - architecture/NN-…
 - ADR-XXXX-…
 - coding-standards/…
+- <repo>/README.md  (for each repo this substep touches)
 
 ## Scope
 <!-- What this substep owns, and — just as important — what it does NOT touch. -->
@@ -60,6 +67,13 @@ just change the code:
 - **Significant or contested change:** write an **ADR** (`templates/adr.md`) and update the
   doc to match. If it overturns a settled assumption, consider **re-running** the relevant
   architecture session (`METHOD.md` §4).
+- **New code, even when it overturns nothing:** adding a component, repo, or public surface,
+  or coining a domain term, can outdate a doc that's still "correct." Update whatever's now
+  stale: the architecture overview (`architecture/03-*`) and `registries/repos.yml` for new
+  components/repos (a brand-new repo also gets a stamped **README whose Overview explains what
+  it is**); the **API spec** (OpenAPI / GraphQL / protobuf) when you add or change an endpoint;
+  the repo **README** when setup/run/test changes; the glossary (`architecture/12-*`) for new
+  terms.
 - **Secrets** stay out of the repo — local values live in the gitignored `.env` /
   `.secrets/` (see `architecture/06-*` and `09-*`); commit only `.env.example`.
 
@@ -70,8 +84,11 @@ Leaving the doc stale is a defect, not a follow-up.
 - [ ]
 - [ ] Code this substep wrote or changed is covered by tests, and the relevant tests pass.
       <!-- default; drop only for a genuinely code-free substep -->
+- [ ] New/changed classes, functions, and methods carry docstrings (see
+      `coding-standards/README.md`).
 - [ ] Any architecture decision this substep changed is reflected in the docs (Version Log
-      bumped) or recorded in an ADR.
+      bumped) or recorded in an ADR — and any new component, repo, or domain term is reflected
+      in the relevant doc (overview / `repos.yml` / glossary).
 
 ## Next
 When this substep is done, update its status in the STEP PLAN, then tell the user the next


### PR DESCRIPTION
## Summary

A review of the Throughstone method surfaced two gaps — code comments weren't mentioned anywhere, and the doc read/update loop was uneven. This closes those and the adjacent documentation gaps that fell out of the discussion. **Process/template changes only — no version bump** (method stays `0.1 (beta)`).

## What changed

**Code comments**
- Docstrings required on every class, method, and function — policy stated once in `coding-standards/README.md`, with the idiomatic form + enforcing lint added per language (Python/TS/Go/Rust/Dart).
- ~1 comment / 10 lines as a *readability suggestion* (not a gate); explain the *why*, cut narration (`// increment i`), keep docstrings true to actual behavior.
- Enforced the same way tests are: a STEP ground rule (`step-plan.md`) + a substep definition-of-done checkbox (`substep-prompt.md`) + an AGENTS.md ground rule.

**Doc read/update loop**
- "Read these first" now starts at the main docs and follows the indexes rather than trying to read everything.
- The doc-update trigger now fires on *new* code (new component/repo, new API endpoint, README/setup changes, new glossary term), not only when a decision is overturned.

**API contracts, README & docstring freshness**
- An API boundary's spec (OpenAPI/GraphQL/protobuf) is now a versioned artifact decided in session 1.3 and the contract of record in repo READMEs.
- `check-in.md` gained a freshness sweep: repo READMEs (build/run/test still work), API-spec-vs-served-endpoints drift, and docstring accuracy.

**Per-repo identity docs**
- Each repo's README "what it is" (role one-liner + Overview) is now non-droppable and a scaffolding deliverable; added an optional per-repo `ARCHITECTURE.md` convention for repos with real internal complexity.
- `registries/repos.yml` is now framed as the *index to the repo READMEs*, and "read a repo's README before working in it" is wired into AGENTS.md and the substep "Read these first" — mirroring the architecture-docs read pattern.

## Files
15 files under `Code/{{PROJECT}}-docs/` (METHOD, AGENTS, coding-standards x6, repos.yml, check-in, planning-session, repo-readme, step-plan, substep-prompt, session 03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
