### PR TITLE
Add milestone doc review (release notes + end-user docs)

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -108,6 +108,10 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
   last check-in, proactively propose inserting a **Check-in STEP** that runs
   `Code/{{PROJECT}}-docs/runbooks/check-in.md` (doc-drift reconciliation both ways + full
   test run). See `METHOD.md` §5.
+- **Flag milestone docs at a phase/release.** When a phase completes or you cut a release,
+  proactively ask the user about **release notes** and **user-facing doc updates** — neither
+  is produced by normal STEP work, and end-user docs are otherwise outside this method's scope
+  (see `METHOD.md` §5, *Milestone doc review*).
 - **Never commit secrets.** Local dev values live in a gitignored `.env` / `.secrets/`;
   commit only a `.env.example` that documents the required keys.
 - Keep **`prompts/STEP-index.md`** current — it's the source of truth for status.

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -210,6 +210,20 @@ judgment. The agent should also **proactively suggest** inserting a check-in whe
 many STEPs have passed since the last one. This is the periodic safety net; it's separate
 from the continuous rule that every substep updates the doc it changes.
 
+### Milestone doc review
+A **phase is a release-level milestone** (§1), and two kinds of documentation fall *outside*
+the per-STEP engineering discipline — they're written for people outside the build, not to
+keep the code's own docs true:
+- **Release notes** — a human-readable "what shipped" for the milestone.
+- **End-user / product docs** — user guides, help, tutorials. These are otherwise **out of
+  scope** of this method, which documents the *engineering*, not the product surface.
+
+Because nothing in normal STEP work produces them, they need a deliberate prompt: **at each
+milestone (a phase completing, or any release you cut), the agent proactively asks the user**
+whether user-facing docs need updating and whether to write release notes. The user decides
+how much to do — the method's job is to *raise it at the right moment*, not to mandate the
+output.
+
 ## 6. Versioning architecture docs
 
 Each architecture doc carries:
@@ -341,7 +355,9 @@ Resolve the next action top-down against the index — the first rule that match
    then archive it (§5) and mark it `Done`.
 6. **~10–20 STEPs since the last check-in?** → propose a **Check-in STEP** at the next
    sensible breakpoint (§5; `runbooks/check-in.md`).
-7. **The phase is complete?** → open the next phase and re-run the planning session for it.
+7. **The phase is complete?** → it's a **milestone**: first prompt the user about **release
+   notes and any user-facing doc updates** (§5, *Milestone doc review*), then open the next
+   phase and re-run the planning session for it.
 
 When the index and an in-flight PLAN disagree, the **index** is authoritative for *which
 STEP* is next; the **PLAN** owns *which substep* within it.


### PR DESCRIPTION
## Summary

Adds a **milestone doc review** to the method: release notes and end-user/product docs fall outside the per-STEP engineering discipline, so nothing in normal STEP work prompts them. This makes the agent raise them at the right moment — when a phase completes or a release is cut.

## What changed (2 files)

- **`METHOD.md` §5** — new *Milestone doc review* subsection. Establishes that **release notes** and **end-user/product docs** are written for people outside the build (end-user docs explicitly **out of scope** of the method), and that the agent **proactively asks the user at each milestone** whether to update user-facing docs and write release notes. The user decides the amount; the method just raises it.
- **`METHOD.md` §10 rule 7** — phase-complete now triggers that prompt before opening the next phase.
- **`AGENTS.md` ground rules** — an operational nudge mirroring the existing "suggest a check-in every ~10–20 STEPs" rule.

## Design notes

- Reuses the existing milestone signal (a **phase = release-level milestone**, §1) rather than inventing a new trigger.
- Deliberately stays out of the planning session, preserving its "outline buildable STEPs only" purity — the milestone prompt is an agent↔user check-in, not a STEP.
- No method version bump (stays `0.1 (beta)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
