### PR TITLE
Broaden architecture sessions + add operate-time runbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # Maintainer-only notes (handoffs, design memos) — not part of the published template.
 .dev/
+# Local maintainer scratch list of outstanding improvements — not part of the published template.
+TODO.md
 
 # Brand-asset exploration scratch (Python venv, downloaded fonts, draft comps).
 # The finished assets live in brand/logo, brand/social, brand/site, brand/BRAND.md.

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -59,7 +59,8 @@ short command and expects the first question back, not a confirmation prompt.
 
 **Conditional sessions** are invoked **by name**, not by number: *"run the identity-auth
 session"* → `conditional-identity-auth.md`; *"run the native-app session"* →
-`conditional-native-app.md`. They're slotted into STEP-1 under a lettered substep (e.g.
+`conditional-native-app.md`; *"run the privacy session"* → `conditional-privacy-compliance.md`.
+They're slotted into STEP-1 under a lettered substep (e.g.
 `1.6a`, `1.7a`), so if the index's next open substep has a letter suffix, run the matching
 `conditional-*.md` by topic rather than looking for a `NN-*.md` file for that number.
 

--- a/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
@@ -66,11 +66,15 @@ scope** before continuing.
 
 ### Stage 2 — STEP-1 PLAN  ▸ checkpoint
 STEP-1 is **architecture-first: design docs + ADRs, no code.** Decide which architecture
-sessions apply (see the core set in `METHOD.md` §4). Use the platform question to decide
-whether the **Native app** session is needed, whether **Identity/auth** applies, and — if the
-project handles personal or regulated data (PII, health/financial/children's data, or a regime
-like GDPR/HIPAA/PCI) — slot in the **Privacy/compliance** session. Drop sessions that clearly
-don't fit; note why. Write
+sessions apply (see the core set in `METHOD.md` §4). For the **conditional** sessions, make an
+*explicit* call on **each one** — never leave a conditional simply unconsidered: fill in the
+**Conditional sessions considered** table in the PLAN, marking every conditional **Include**
+(→ the substep it becomes, e.g. `1.6a`) or **N/A** (with a one-line reason). Decide each from
+its trigger: the platform question (1.3) for **Native app**; the auth posture for
+**Identity/auth**; and personal or regulated data (PII, health/financial/children's, or a
+regime like GDPR/HIPAA/PCI) for **Privacy/compliance**. A skipped conditional must leave a
+recorded reason, so a future reader sees a decision rather than an accident. Also drop any
+*core* session that clearly doesn't fit, noting why. Write
 `Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md` (from
 `Code/{{PROJECT}}-docs/templates/step-plan.md`) listing the chosen sessions as substeps,
 the locked decisions, and the definition of done. **Wait for confirmation.**

--- a/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
@@ -67,8 +67,10 @@ scope** before continuing.
 ### Stage 2 — STEP-1 PLAN  ▸ checkpoint
 STEP-1 is **architecture-first: design docs + ADRs, no code.** Decide which architecture
 sessions apply (see the core set in `METHOD.md` §4). Use the platform question to decide
-whether the **Native app** session is needed, and whether **Identity/auth** applies. Drop
-sessions that clearly don't fit; note why. Write
+whether the **Native app** session is needed, whether **Identity/auth** applies, and — if the
+project handles personal or regulated data (PII, health/financial/children's data, or a regime
+like GDPR/HIPAA/PCI) — slot in the **Privacy/compliance** session. Drop sessions that clearly
+don't fit; note why. Write
 `Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md` (from
 `Code/{{PROJECT}}-docs/templates/step-plan.md`) listing the chosen sessions as substeps,
 the locked decisions, and the definition of done. **Wait for confirmation.**

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -100,7 +100,12 @@ set lives in `templates/architecture-sessions/`.
 
 **Conditional sessions** (included only when relevant, auto-selected by the 1.3 platform
 question or by need): **Native app architecture** (mobile/desktop), **Identity & auth**,
-**Privacy, compliance & data governance** (personal or regulated data).
+**Privacy, compliance & data governance** (personal or regulated data). Each is an **explicit
+include-or-skip decision at kickoff** — the STEP-1 PLAN records a *Conditional sessions
+considered* table marking every one Include (→ substep) or N/A (with a reason), so a skip is a
+recorded choice rather than a silent omission. (A need can also emerge *later* — a project adds
+login or starts collecting regulated data — in which case slot the conditional in then, the
+same way: add its substep/STEP and run it by name.)
 
 ### Running a session  *(Layer 1 — works in any agent)*
 

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -99,7 +99,8 @@ set lives in `templates/architecture-sessions/`.
 | 1.13 | Cross-cutting review | review doc |
 
 **Conditional sessions** (included only when relevant, auto-selected by the 1.3 platform
-question or by need): **Native app architecture** (mobile/desktop), **Identity & auth**.
+question or by need): **Native app architecture** (mobile/desktop), **Identity & auth**,
+**Privacy, compliance & data governance** (personal or regulated data).
 
 ### Running a session  *(Layer 1 — works in any agent)*
 
@@ -343,7 +344,8 @@ Resolve the next action top-down against the index — the first rule that match
    *"run session N.M"* in a fresh chat. Skip any substep marked `N/A`. A substep with a
    **letter suffix** (e.g. `1.6a`, `1.7a`) is a **conditional session** the kickoff slotted
    in — invoke it **by name** (*"run the identity-auth session"* / *"run the native-app
-   session"*), since its template file is named by topic, not by number (see §4).
+   session"* / *"run the privacy session"*), since its template file is named by topic, not by
+   number (see §4).
 2. **All STEP-1 substeps done but 1.13 not?** → *"run session 1.13"* (cross-cutting review).
 3. **1.13 done and STEP-1 complete, but only the STEP-1 row exists?** → *"run the planning
    session"* — it outlines the Phase-1 implementation STEPs (§2).

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -71,8 +71,10 @@ Everything lives in the docs hub: `Code/{{PROJECT}}-docs/`.
 Other folders in the hub: `coding-standards/` (per-language; defaults ship for common
 languages, and session 1.11 reconciles them to the stack you pick — review what's there,
 add what's missing, prune the rest), `runbooks/` (repeatable procedures — ships with
-`check-in.md`, `collaboration.md`, and `release-deploy.md` (an optional, customizable
-deploy/rollback checklist); add your own operational ones), `registries/`
+`check-in.md`, `collaboration.md`, `release-deploy.md` (an optional, customizable
+deploy/rollback checklist), and `incident-postmortem.md` (respond to a production incident,
+then spin up an Incident STEP to RCA → find similar → fix); add your own operational ones),
+`registries/`
 (e.g. `repos.yml`, the repo inventory for multi-repo projects).
 
 ## 4. Architecture sessions

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -71,7 +71,8 @@ Everything lives in the docs hub: `Code/{{PROJECT}}-docs/`.
 Other folders in the hub: `coding-standards/` (per-language; defaults ship for common
 languages, and session 1.11 reconciles them to the stack you pick — review what's there,
 add what's missing, prune the rest), `runbooks/` (repeatable procedures — ships with
-`check-in.md` and `collaboration.md`; add your own operational ones), `registries/`
+`check-in.md`, `collaboration.md`, and `release-deploy.md` (an optional, customizable
+deploy/rollback checklist); add your own operational ones), `registries/`
 (e.g. `repos.yml`, the repo inventory for multi-repo projects).
 
 ## 4. Architecture sessions

--- a/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
+++ b/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
@@ -1,0 +1,76 @@
+# Runbook — Incident Response & Postmortem
+
+> **How to run:** Two modes, run in sequence.
+> - **An incident is happening right now** → this is an **operational procedure**: tell your
+>   agent *"run the incident runbook"* and follow **Part 1** to stabilize and capture the facts.
+> - **Then the durable follow-up is a STEP** (like the check-in): Part 1 ends by reserving an
+>   **Incident STEP** whose three substeps — RCA, find-similar, fix — *are* **Parts 2–4 below**.
+>   Its PLAN is thin and points here; you don't author substep prompts for it (the same special
+>   case as the check-in STEP — see `prompts/README.md`). Record the substeps' status in the
+>   index/PLAN like any other STEP.
+>
+> An "incident" is any unplanned production failure or near-miss worth not repeating — an
+> outage, data loss/corruption, a security event, a bad deploy. Small ones get a light touch;
+> the structure scales down.
+
+## Why this runbook exists
+When something breaks in production, two different jobs get confused under pressure and one
+always loses. The first is **stop the bleeding** — restore service now. The second is **make
+sure it can't happen again** — and *that's* the one that quietly gets skipped once the fire's
+out and everyone's relieved. This runbook separates them: Part 1 handles the emergency; Parts
+2–4 become a tracked STEP so the real fix can't evaporate. It is **blameless** — the goal is
+the cause in the *system*, never who typed the command.
+
+## Part 1 — Respond & capture  *(operational — do this now)*
+1. **Stabilize first.** Restore service before you investigate — most often by rolling back the
+   last release (`runbooks/release-deploy.md`, Part 4), failing over, or disabling the bad path
+   (a feature flag). Mitigation beats diagnosis while users are affected.
+2. **Confirm recovery.** Verify the critical paths work again and the alerts that fired have
+   cleared (`architecture/10-observability.md`).
+3. **Capture the facts while fresh** — a rough **timeline** (when it started, when it was
+   noticed, what you did, when it resolved), the **symptom and blast radius** (who/what was
+   affected, any data touched), and the alerts/logs that caught it (or *should* have). Don't
+   diagnose yet — just record. This is the raw material for the RCA.
+4. **Open the Incident STEP.** Reserve a STEP number and branch per the recipe
+   (`prompts/README.md`); its substeps are Parts 2–4. Park the captured timeline in the STEP
+   folder. Then hand off to that STEP — the emergency is over; the rest is deliberate work.
+
+> **Security incidents** that exposed data or credentials also start a **breach-notification**
+> clock from your privacy/security work (`architecture/06-security-threat-model.md`, and the
+> privacy-compliance doc if you have one). That obligation is not optional and runs independently
+> of this runbook — handle it in parallel with Part 1.
+
+## Part 2 — Root-cause analysis (RCA)  *(substep N.1)*
+Get past the symptom to the **cause in the system**. Ask *why* repeatedly (5 Whys) until you
+reach something you can actually change — usually not "the code had a bug" but the missing test,
+the missing guardrail, the missing alert, or the design assumption that didn't hold. Name the
+**contributing factors**, not a single culprit. Write a short **postmortem** into the Incident
+STEP folder: the timeline (from Part 1), the root cause, contributing factors, and what made it
+easier or harder to detect and recover. If the RCA overturns a recorded decision, write an
+**ADR** (`templates/adr.md`); if it shows a doc was wrong, that's a fix for Part 4.
+
+## Part 3 — Find similar issues  *(substep N.2)*
+The bug you saw is an *instance of a class*. Before fixing, **hunt the class**: search the
+codebase for the same pattern elsewhere — the same unchecked input, the same missing timeout,
+the same migration shape, the same assumption — across **all repos**, not just the file that
+broke. List every sibling you find. This is the step that turns one fix into "this whole
+category can't bite us again," and it's the one most often skipped. Record what you searched for
+and what you found — including "searched X, found none," which is a real result, not a blank.
+
+## Part 4 — Fix & harden  *(substep N.3)*
+Fix the root cause **and** every sibling found in Part 3, in this STEP. Then close the loop so
+the *next* one is caught sooner and cheaper:
+- **A regression test** that fails on the original bug and passes after the fix.
+- **Detection** — if nothing alerted (or it alerted too late), add or tune the signal
+  (`architecture/10-observability.md`) so this class trips an alarm next time.
+- **Docs / runbooks** — fix any doc the RCA found wrong (bump its Version Log); if the response
+  itself was clumsy, improve the relevant runbook so the next responder has it easier.
+- Anything too large to fix safely here becomes its own **follow-up STEP**, listed for the index.
+
+## Output
+- A **postmortem** in the Incident STEP folder: timeline, root cause, contributing factors, the
+  similar issues found (Part 3), and the fixes/hardening applied (Part 4).
+- Any **ADRs** for decisions the RCA changed; any **doc fixes** (Version Logs bumped); any
+  **follow-up STEPs** filed in `prompts/STEP-index.md`.
+- Mark the Incident STEP's substeps and the STEP **Done**; note anything to watch at the next
+  **check-in** (`runbooks/check-in.md`).

--- a/Code/{{PROJECT}}-docs/runbooks/release-deploy.md
+++ b/Code/{{PROJECT}}-docs/runbooks/release-deploy.md
@@ -1,0 +1,75 @@
+# Runbook — Release, Deploy & Rollback
+
+> **How to run:** This is an **operational procedure, not a STEP** (unlike the check-in). Run
+> it whenever you ship a version to an environment — tell your agent *"run the release"* (or
+> *"deploy the release"* / *"roll back the last release"*) and it follows this file.
+>
+> **Optional and yours to customize.** The method deliberately leaves CI/CD and release
+> versioning to your team's existing tooling (see `collaboration.md`, *"Standard practice, not
+> the method's job"*). This runbook is a **default checklist** for when you don't have a
+> release process yet — and a home to write yours down when you do. Fill in your project's
+> actual commands and environments; the *discipline* below — a rollback plan **before** you
+> deploy, reversible migrations, a watch window — is the part worth keeping whatever your
+> pipeline. The mechanism it executes was designed in
+> `architecture/08-infrastructure-deployment.md` (deploy pipeline + rollback) and
+> `architecture/09-environments.md`; point at those for the specifics.
+
+## Why this runbook exists
+A deploy is the riskiest routine thing a project does — it's where a green test suite still
+meets production reality. The failure mode usually isn't the deploy itself; it's having **no
+planned way back** when something goes wrong, so a five-minute blip becomes an outage while
+someone improvises a fix under pressure. This runbook makes a release boring: decide how you'd
+undo it *before* you do it, ship to a safe place first, watch, and have one clear lever to pull
+if it goes bad.
+
+## Part 1 — Before you deploy (pre-flight)
+- [ ] **The change is merged and reviewed**, and the **full test suite is green** — not just the
+      area you touched.
+- [ ] **Version stamped.** Tag / bump the version per your scheme so what's running is identifiable.
+- [ ] **Release notes drafted.** At a milestone or any release the method asks you to write them
+      (`METHOD.md` §5, *Milestone doc review*) — draft them now, while the changes are fresh.
+- [ ] **Migrations are safe to undo.** If this release changes the database schema, confirm the
+      migration is **reversible or forward-compatible** (prefer expand/contract: add the new
+      shape, deploy, backfill, switch, drop the old in a *later* release). A deploy you can roll
+      back sitting on a schema you can't is a trap — write down the down-path explicitly.
+- [ ] **Config & secrets for the target environment are in place** — from the secrets manager,
+      not a checked-in file (see `architecture/06-security-threat-model.md` and `08`).
+- [ ] **Rollback plan confirmed.** Write down, now, exactly how you'd undo this release (Part 4)
+      and what would make you do it. If you can't state it, you're not ready to deploy.
+
+## Part 2 — Deploy
+- [ ] **Ship to staging / pre-prod first** (`architecture/09-environments.md`) and **smoke-test**
+      the critical paths there before production. Skip only if the project has no such
+      environment — and say so.
+- [ ] **Deploy to production** via the pipeline from `architecture/08`. Where the infra supports
+      it, prefer a strategy that makes rollback cheap (blue-green / rolling / canary /
+      feature-flagged).
+- [ ] **Record it** — what version went out, to which environment, when, and by whom. It's the
+      start of an audit trail the next check-in and any incident review will want.
+
+## Part 3 — Verify (don't walk away)
+- [ ] **Smoke-test the critical user paths** in production.
+- [ ] **Watch observability** (`architecture/10-observability.md`) for a defined window — error
+      rates, latency, and the alerts you set up — before calling it done. A deploy isn't "done"
+      at deploy; it's done once it's stayed healthy for a bit.
+- [ ] **Health / uptime checks green.**
+
+## Part 4 — Rollback (when verify fails)
+- **Trigger.** Roll back when a pre-defined criterion hits — a failed smoke test, an error/latency
+  spike, a breached SLO. Decide *fast*: rolling back and investigating later beats debugging in
+  production while users are affected.
+- **Mechanism.** Execute the down-path you wrote in Part 1 — redeploy the previous version,
+  switch the blue-green pointer, turn the feature flag off, or revert and redeploy.
+- **The migration caveat (the dangerous case).** If the release ran an *irreversible* schema or
+  data migration, rolling back the code isn't enough and may corrupt data. Here a **forward fix**
+  (roll forward with a patch) is often safer than a rollback — decide deliberately. This is
+  exactly why Part 1 insists migrations be reversible or forward-compatible.
+- **After a rollback.** Capture what happened — symptom, trigger, what you did — for a brief
+  write-up. (If/when an incident-postmortem runbook exists, that's its input; until then, a few
+  lines in the release record.) File a STEP for the real fix.
+
+## After the release
+- Confirm the released version is **tagged / recorded**.
+- **Prompt the user about release notes and user-facing docs** if not already done — neither is
+  produced by normal STEP work (`METHOD.md` §5, *Milestone doc review*).
+- Note anything that should feed the next **check-in** (`runbooks/check-in.md`).

--- a/Code/{{PROJECT}}-docs/runbooks/release-deploy.md
+++ b/Code/{{PROJECT}}-docs/runbooks/release-deploy.md
@@ -64,9 +64,10 @@ if it goes bad.
   data migration, rolling back the code isn't enough and may corrupt data. Here a **forward fix**
   (roll forward with a patch) is often safer than a rollback — decide deliberately. This is
   exactly why Part 1 insists migrations be reversible or forward-compatible.
-- **After a rollback.** Capture what happened — symptom, trigger, what you did — for a brief
-  write-up. (If/when an incident-postmortem runbook exists, that's its input; until then, a few
-  lines in the release record.) File a STEP for the real fix.
+- **After a rollback.** A rollback means something broke in production — that's an **incident**.
+  Capture what happened — symptom, trigger, what you did — and hand off to
+  `runbooks/incident-postmortem.md`, which turns it into a tracked STEP (RCA → find similar →
+  fix) so the real fix can't evaporate once service is restored.
 
 ## After the release
 - Confirm the released version is **tagged / recorded**.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
@@ -38,7 +38,8 @@ now prevents painful migrations and compliance surprises later.
    whether IDs are exposed publicly.
 5. **Sensitive data / PII.** What personal or sensitive data is collected, and a rough
    classification (public / internal / confidential / regulated). Feeds the security
-   session (1.6).
+   session (1.6) — and, if any of it is regulated, the conditional Privacy/compliance session
+   (which sharpens retention/deletion below into legal obligations).
 6. **Retention & deletion.** How long each data class is kept, and how deletion works
    (including user-requested deletion / "right to be forgotten" if relevant).
 7. **Consistency & evolution.** Where you need strong consistency vs. where eventual is

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
@@ -29,7 +29,10 @@ oversight.
 
 ## Decisions to make (in order)
 1. **Assets.** What's worth protecting? (Credentials/keys, personal data, money/payments,
-   proprietary data, availability itself.) List them — everything else hangs off this.
+   proprietary data, availability itself.) List them — everything else hangs off this. (If
+   **personal/regulated data** is among them, this session covers keeping attackers *out* of
+   it; handling it *lawfully* — regimes, consent, retention, deletion rights — is the
+   conditional Privacy/compliance session. Flag that it applies.)
 2. **Trust boundaries.** Where does data cross a line of trust? (Internet → your service;
    user → admin; your service → third party; service → service.) Each boundary is where
    threats live.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
@@ -18,8 +18,9 @@ this one if the project has no UI.)
 
 ## Why this session matters
 A design system decided up front keeps the product visually consistent and saves you from
-re-litigating colors and components on every screen. It's also where two things developers
-skip get handled: **accessibility** and (for apps) **platform conventions**. The
+re-litigating colors and components on every screen. It's also where things developers
+routinely skip get handled: **accessibility**, **internationalization**, and (for apps)
+**platform conventions** — each far cheaper designed in now than bolted on later. The
 foundations — color, type, spacing — are shared across web and mobile; platform-specific
 patterns branch from there.
 
@@ -28,7 +29,7 @@ patterns branch from there.
   HTML page (or component sketch) with realistic {{PROJECT}} content so choices are visual,
   not hex codes in text. **Wait** for the answer.
 - Reuse the client-surfaces answer from 1.3 to decide which platform branches apply.
-- Recommend sensible defaults; flag accessibility implications.
+- Recommend sensible defaults; flag accessibility and localization implications.
 
 ## Decisions to make (in order)
 
@@ -51,12 +52,26 @@ patterns branch from there.
 9. **Iconography.** Icon set/library.
 10. **Responsive / device strategy.** Web: breakpoints, mobile-web behavior. Native:
     device sizes, safe areas, orientation.
-11. **Accessibility.** Contrast targets, focus states, keyboard nav, touch-target sizes,
-    screen-reader support (ARIA / VoiceOver / TalkBack). Not optional.
-12. **Motion & transitions**; **data visualization** (if charts).
-13. **Implementation approach.** CSS framework / component library (web) or native toolkit;
+11. **Accessibility.** Pick a target to design against — **WCAG 2.1 AA** is the common
+    default (and a legal requirement in many jurisdictions). Concretely: color-contrast
+    ratios, visible focus states, full keyboard navigation, adequate touch-target sizes, alt
+    text for meaningful images, labeled form fields, and screen-reader support (semantic
+    HTML / ARIA / VoiceOver / TalkBack). Honor a reduced-motion preference (ties to decision
+    13). Not optional — and far cheaper designed in now than retrofitted.
+12. **Internationalization & localization.** Two separate questions. *Internationalization
+    (i18n)* is whether the UI is **built to be translatable at all**: user-facing text pulled
+    into a strings layer instead of hardcoded, layouts that tolerate longer translated text,
+    locale-aware dates/numbers/currency, and — if you might ever need Arabic/Hebrew —
+    right-to-left support. *Localization (l10n)* is **which languages/locales you actually
+    ship** now. The trap is foreclosure: shipping English-only is fine, but *hardcoding*
+    English everywhere is the expensive mistake — retrofitting i18n later means touching every
+    screen. MVP default: ship one locale, but route user-facing text through a strings layer
+    from day one so adding a language later is a translation job, not a rewrite. Decide RTL
+    in or out deliberately.
+13. **Motion & transitions**; **data visualization** (if charts).
+14. **Implementation approach.** CSS framework / component library (web) or native toolkit;
     how tokens are defined (e.g. CSS custom properties).
-14. **Platform conventions** (if mobile/desktop). Respect iOS HIG / Android Material /
+15. **Platform conventions** (if mobile/desktop). Respect iOS HIG / Android Material /
     desktop OS conventions where they differ from web.
 
 ## Output
@@ -64,7 +79,7 @@ Write `architecture/07-ui-design-system.md` (use `templates/architecture-doc.md`
 - **Design principles**
 - **Tokens** — color, typography, spacing, shape (exact values; CSS custom properties)
 - **Components** — specs with variants
-- **Navigation, theme, icons, responsive/device, accessibility, motion, data-viz**
+- **Navigation, theme, icons, responsive/device, accessibility, internationalization, motion, data-viz**
 - **Implementation stack** and any **platform-specific** notes
 
 Fill the **Decision Summary**, record **Open Questions**, start the **Version Log**. Update

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
@@ -9,14 +9,18 @@
 {{PROJECT_DESCRIPTION}}
 
 ## What this session does
-With the architecture, scale, and security decided, we'll settle where the system runs and
-how your code gets there, so deploys are repeatable and recoverable instead of hand-assembled.
+With the architecture, scale, and security decided, we'll settle where the system runs, how
+your code gets there, and how it survives the failures it will eventually hit — so deploys
+are repeatable and recoverable instead of hand-assembled and fragile.
 
 ## Why this session matters
 "It runs on my laptop" is not a deployment. Without a deliberate plan, infrastructure
 becomes a pile of hand-configured boxes no one can reproduce. Deciding **where it runs, how
-it gets there, and how it's provisioned** now keeps deploys boring and recoverable — and
-keeps cloud lock-in a choice rather than an accident.
+it gets there, how it's provisioned, and how it recovers when something breaks** now keeps
+deploys boring and recoverable — and keeps cloud lock-in a choice rather than an accident.
+The failure half matters as much as the deploy half: every system eventually loses a
+process, a machine, or a dependency it doesn't control, and "we never thought about it" is
+how a small outage becomes permanent data loss.
 
 ## How this session works
 - One decision at a time; **wait** for answers.
@@ -39,9 +43,21 @@ keeps cloud lock-in a choice rather than an accident.
    surfaces.
 6. **Secrets in production.** Where prod secrets live (a secret manager) and how services
    get them. (Consistent with 1.6.)
-7. **Backups & disaster recovery.** What's backed up, how often, and a rough RTO/RPO (how
-   much downtime / data loss is tolerable). Even "daily DB snapshot, restore tested" counts.
-8. **Cost & cloud coupling.** Rough cost shape and what drives it as you scale; how coupled
+7. **Failure modes & resilience.** Walk what happens when a piece dies — a single process,
+   the machine or availability zone it runs on, or a dependency you don't control (the
+   database, a third-party API). Name the **single points of failure** (this is the
+   *availability* angle; 1.5 named them for *load*) and pick an **availability target**: is a
+   few hours of downtime fine, or must this stay up? For an MVP, a single region with a fast
+   redeploy is often the right call — the point is to choose it knowingly, not by default.
+   Where it's cheap, prefer **graceful degradation** (read-only mode, a cached response, a
+   clear "try again shortly") over a hard crash when a dependency is unavailable.
+8. **Backups & disaster recovery.** What's backed up, how often, and how long backups are
+   retained; then the two numbers that define recovery — **RPO** (how much *data loss* is
+   tolerable: minutes? a day?) and **RTO** (how long to get back *up*). The catch: **a backup
+   you have never restored is not a backup** — decide how and how often a restore is actually
+   rehearsed. Even "daily DB snapshot, restore rehearsed once, ~1-day RPO / few-hour RTO"
+   counts. Note who does what when it's genuinely down (the bones of a DR runbook).
+9. **Cost & cloud coupling.** Rough cost shape and what drives it as you scale; how coupled
    you are to one provider and what would be painful to move.
 
 ## Output
@@ -51,12 +67,13 @@ Body:
 - **Deploy pipeline** — build → deploy → rollback
 - **Infrastructure as code** approach
 - **Networking, TLS, secrets**
-- **Backups & DR** — what, cadence, RTO/RPO
+- **Resilience** — single points of failure, availability target, failover & degraded-mode behavior
+- **Backups & DR** — what, cadence, retention, restore-test plan, RPO/RTO, recovery responsibilities
 - **Cost & cloud-coupling** notes
 
 Fill the **Decision Summary**, record **Open Questions**, start the **Version Log**. Capture
-provider/lock-in decisions as ADRs if significant. Update `prompts/STEP-index.md`: mark 1.8
-done.
+provider/lock-in and availability/RPO-RTO decisions as ADRs if significant. Update
+`prompts/STEP-index.md`: mark 1.8 done.
 
 ## Next
 Once 1.8 is marked done, the next action is the lowest open STEP-1 substep — normally **1.9 (Environments)**. Tell the user to **start a fresh chat** and run it (*"run session 1.9"*); if the index shows a different next open substep (sessions can be skipped or added), run that instead. See the next-action resolver in `METHOD.md` §10.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
@@ -36,7 +36,8 @@ how a small outage becomes permanent data loss.
    scaling needs from 1.5.
 3. **Build & deploy pipeline.** How code becomes a running version: CI builds, artifacts,
    and how a deploy is triggered (and rolled back). Manual is OK for an MVP if it's written
-   down and repeatable.
+   down and repeatable — the optional `runbooks/release-deploy.md` checklist is where that
+   procedure lives operationally; this decision designs what it executes.
 4. **Infrastructure as code.** Terraform / Pulumi / provider tooling / none. How infra is
    provisioned reproducibly — even a single script beats clicking in a console.
 5. **Networking & TLS.** Load balancer / ingress, DNS, TLS certificates, public vs. private

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/13-cross-cutting-review.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/13-cross-cutting-review.md
@@ -27,9 +27,10 @@ between "we have a pile of docs" and "we have a coherent architecture."
 
 ## What to check
 1. **Consistency.** Do the docs agree? Common conflicts: the data model vs. the API/flows
-   in the architecture overview; scaling assumptions vs. the chosen infrastructure;
-   security boundaries vs. the actual component boundaries; terms used differently than the
-   glossary defines them.
+   in the architecture overview; scaling assumptions vs. the chosen infrastructure; the
+   backup/RPO and availability target (1.8) vs. the data the model (1.4) says you can't
+   afford to lose; security boundaries vs. the actual component boundaries; terms used
+   differently than the glossary defines them.
 2. **Completeness.** Is anything referenced but never specified? Any area that should have
    been covered for *this* project but wasn't? Any **Open Questions** still unresolved that
    would block implementation?

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
@@ -1,0 +1,88 @@
+# {{PROJECT}} — Privacy, Compliance & Data Governance (Conditional Session)
+
+> **Conditional.** Include this if the project handles **personal or regulated data** — any
+> meaningful PII, or special-category data (health, financial, biometric, children's), or
+> falls under a compliance regime (GDPR/UK-GDPR, CCPA/CPRA, HIPAA, PCI-DSS, COPPA, SOC 2,
+> sector rules). The kickoff slots it in as a substep (e.g. `1.6b`, after the security
+> session) and the index records its number. Run it by name: *"run the privacy session"* (or
+> *"run the privacy-compliance session"*). It writes `architecture/NN-privacy-compliance.md`
+> (number assigned in the index) and updates `prompts/STEP-index.md`.
+> **Two separate numbers:** the *substep* number (e.g. `1.6b`) marks its place in STEP-1; the
+> *doc file* number (`NN`) is the first number **after the reserved core range `01–12`** —
+> i.e. `13`, or the next free conditional number if another conditional already took `13`/`14`
+> — **not** the lowest unused number. (This session may run early, before the later core docs
+> `07–12` exist; still take `13+`, so a core session can later claim its own `07`, `08`, …
+> without a clash.) The substep number and the doc number don't have to match.
+> Reads `overview.md` and `architecture/04-*` (data model) and `06-*` (security) first.
+> **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
+
+## About {{PROJECT}}
+{{PROJECT_DESCRIPTION}}
+
+## What this session does
+Building on the data model and threat model, we'll decide how {{PROJECT}} handles **personal
+and regulated data lawfully and responsibly** — which rules apply, what data you hold and
+why, how long you keep it, and how you'll honor the rights people have over their own data.
+
+## Why this session matters
+The security session (1.6) asks "how do we keep attackers *out*?" This one asks a different
+question: "are we handling people's data *lawfully and responsibly*?" — and that's where the
+fines, the lawsuits, and the trust damage come from. The common mistake is treating privacy
+as a checkbox bolted on before launch; in reality it's an *architecture* decision, because
+"collect everything, keep it forever, figure out deletion later" bakes in obligations you
+then can't meet. Deciding the regimes, the data you hold, retention, and how you'll satisfy
+deletion/export requests **now** keeps compliance a design property rather than an emergency.
+
+## How this session works
+- One decision at a time; **wait** for answers.
+- Recommend the **least data, least retention, clearest purpose** option that meets the need,
+  and flag what each choice obligates you to.
+- Keep it consistent with the data model (1.4) and threat model (1.6); flag where a choice
+  ties to infrastructure/residency (1.8).
+- This is **not legal advice** — it produces an engineering record of intent and surfaces
+  where a lawyer or DPO should confirm. Say so when a question turns on a legal judgment.
+
+## Decisions to make (in order)
+1. **Applicable regimes.** Given your users, your data, and where they are, which laws and
+   standards apply — GDPR/UK-GDPR, CCPA/CPRA, HIPAA, PCI-DSS, COPPA (children), SOC 2, sector
+   rules? Name them, or consciously record "none apply, and why." Everything below follows
+   from this. (When it turns on a legal judgment, flag it for a lawyer rather than guessing.)
+2. **Personal-data inventory.** What categories of personal data you collect, where each
+   lives, and how sensitive it is (ordinary PII vs. special-category: health, financial,
+   biometric, children's). This is the privacy lens on the data model (1.4) — you can't
+   govern what you haven't named. A simple table is the deliverable.
+3. **Lawful basis & consent.** For each category, *why* you're permitted to process it
+   (consent, contract, legitimate interest, legal obligation…), and — where it's consent —
+   how consent is captured, recorded, and **withdrawn** (cookie/tracking consent included).
+4. **Data minimization & purpose limitation.** Collect only what you need; use it only for
+   what you told people. Walk the inventory and challenge each field: do you actually need it,
+   and for what stated purpose? Dropping a field now is the cheapest control there is.
+5. **Retention & deletion.** How long each category is kept, and how it's actually deleted
+   when the period ends and on account closure (including backups and downstream copies).
+   This sharpens the retention answer from 1.4 with the legal *must-delete* angle.
+6. **Data-subject rights.** How you'll satisfy access, export/portability, correction, and
+   deletion ("right to be forgotten") requests — as an *operational process*, not a promise.
+   Manual is fine for an MVP **if it's written down** and someone owns it.
+7. **Data residency & sub-processors.** Where data physically lives (residency/sovereignty
+   constraints) and which third parties (analytics, hosting, payment, email, AI APIs) receive
+   personal data — your sub-processors — plus a transfer mechanism if data crosses borders.
+   Ties to infrastructure (1.8).
+8. **Governance & accountability.** Who owns privacy, where the record-of-processing / data
+   map lives and stays current, your **breach-notification** obligations (who you must notify
+   and how fast), and the plan for a public **privacy policy** (and a DPA where required).
+   Lightweight for an MVP — but assigned to a name, not left ownerless.
+
+## Output
+Write `architecture/NN-privacy-compliance.md` (use `templates/architecture-doc.md`; NN per
+the index). Body covers each area above — lead with the **applicable-regimes** decision and
+the **personal-data inventory** table, since the rest follows from them. Fill the **Decision
+Summary**, record **Open Questions** (flag any awaiting legal/DPO confirmation), start the
+**Version Log**. Capture significant choices as **ADRs** — applicable regimes, data
+residency, retention periods, and any consent/sub-processor decision that consumers depend on.
+Cross-check retention against the data model (1.4) and residency against infrastructure (1.8),
+and note any updates those docs need. Update `prompts/STEP-index.md`: mark this substep done.
+
+## Next
+Once this substep is marked done, the next action is the lowest open STEP-1 substep in the index — its position depends on where this conditional was slotted. Tell the user to **start a fresh chat** and run it. When all STEP-1 substeps and the 1.13 review are done, the next action is *"run the planning session."* See the next-action resolver in `METHOD.md` §10.
+
+**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/step-plan.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan.md
@@ -32,6 +32,18 @@
      (N.1) and full test run (N.2) defined in runbooks/check-in.md; this PLAN just points
      there. -->
 
+## Conditional sessions considered  <!-- STEP-1 (architecture) only; delete this section for other STEPs -->
+<!-- Every conditional session is an EXPLICIT decision, never a silent omission: mark each
+     one Include (with the substep it became) or N/A (with a one-line reason). A skipped
+     conditional must leave a recorded reason here so a future reader sees a decision, not an
+     accident. See METHOD.md §4 and the conditional-*.md session files. -->
+
+| Conditional session | Decision | Substep / reason |
+|---------------------|----------|------------------|
+| Native app (mobile / desktop) | Include / N/A | {{e.g. 1.7a, or "N/A — web-only per 1.3"}} |
+| Identity & auth | Include / N/A | {{e.g. 1.6a, or "N/A — no accounts/login"}} |
+| Privacy, compliance & data governance | Include / N/A | {{e.g. 1.6b, or "N/A — no personal/regulated data"}} |
+
 ## Open questions
 <!-- Things still undecided at the start of this STEP. Mark Q1, Q2, … with owner. -->
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -83,7 +83,10 @@ long since the last (see `METHOD.md` §5).
    `Code/{{PROJECT}}-docs/templates/architecture-sessions/` — you don't author those from
    scratch. For a **Check-in STEP**, you don't author prompts either — its two substeps are
    the doc-drift reconciliation and full test run defined in
-   `Code/{{PROJECT}}-docs/runbooks/check-in.md`; the PLAN just points there.)*
+   `Code/{{PROJECT}}-docs/runbooks/check-in.md`; the PLAN just points there. An **Incident
+   STEP** is the same kind of thin STEP — its three substeps (RCA → find similar → fix) are
+   defined in `Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md`, opened by that runbook
+   when responding to a production incident.)*
 5. **Update `prompts/STEP-index.md`**: set the STEP's status and list its substeps.
 6. **On completion:** run the STEP's review — your team's standard **PR / code review** (the
    method doesn't redefine it), plus the doc-drift check — then **gather the STEP's files


### PR DESCRIPTION
## Summary

Closes architecture-session and operate-time coverage gaps surfaced in a method review. Two themes: **broaden the architecture sessions** (resilience/DR, a11y/i18n, privacy) and **add the operate-time runbooks the method was missing** (release/deploy, incident/postmortem) — plus a discipline fix so conditional sessions can't be silently skipped.

> **Merge intent:** non-squash — each commit is self-contained and worth keeping in history. Six commits, reviewable in order.

## Commits

1. **Expand infra session (1.8) with resilience & disaster recovery** — split the thin one-line "Backups & DR" decision into *Failure modes & resilience* (SPOFs from the availability angle, availability target, graceful degradation) and *Backups & DR* (retention, RPO/RTO, restore-rehearsal, recovery ownership); flag availability/RPO-RTO as ADR-worthy; add a 1.13 cross-check against the data model.
2. **Add i18n and strengthen accessibility in UI session (1.7)** — new *Internationalization & localization* decision in the don't-foreclose spirit (i18n vs. l10n, strings layer, RTL); flesh out the thin accessibility decision (WCAG 2.1 AA, alt text, form labels, reduced-motion).
3. **Add Privacy/compliance/data-governance conditional session** — new `conditional-privacy-compliance.md` (run by name) for projects handling personal/regulated data; complements the security session (lawful handling vs. keeping attackers out); explicitly not legal advice; wired into METHOD §4/§10, AGENTS, BOOTSTRAP, with cross-links from 1.4 and 1.6.
4. **Make conditional-session selection an explicit, recorded decision** — required *Conditional sessions considered* table in the STEP-1 PLAN (Include → substep / N/A → reason), so a skip is a recorded choice rather than a silent omission. Also gitignores a local maintainer `TODO.md`.
5. **Add Release / Deploy / Rollback operational runbook** — first operate-time runbook; an optional, customizable checklist (respects collaboration.md leaving CI/CD to the team's tooling) opinionated about discipline: rollback plan before deploy, reversible/forward-compatible migrations, staging-first, watch window, decisive rollback.
6. **Add Incident Response & Postmortem runbook** — Part 1 stabilizes a production failure and opens an *Incident STEP* (thin, like the check-in) whose substeps are RCA → find-similar → fix-and-harden. Resolves the forward-reference left in the release runbook; documented in the prompts authoring recipe.

## Notes for the reviewer

- **Scope:** docs/methodology + templates only — no code. All paths use the `{{PROJECT}}` placeholder per the template convention.
- **Branch name** (`infra-resilience-dr`) is narrower than the final scope — it grew into a broader session/runbook coverage PR.
- The three operate-time runbooks now form a loop: **release-deploy** ships → **incident-postmortem** catches/corrects → **check-in** reconciles.
- **Deferred** (parked in the gitignored `TODO.md`, not in this PR): a conditional re-check in the periodic check-in, and a mechanical `doctor`/validation script. METHOD §4 was deliberately written *not* to promise the check-in re-check until that runbook change lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
