### PR TITLE
Supply-chain runbook + mechanical tooling layer (doctor, status, CI)

### DIFF
--- a/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
+++ b/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
@@ -1,0 +1,28 @@
+# Method integrity check — runs the Throughstone "doctor" (scripts/check.sh) on every push
+# and pull request, so structural drift fails the build instead of slipping through review:
+# duplicate STEP/ADR numbers, invalid statuses, architecture docs missing Version/Status/
+# Version-Log, and an ADR registry that disagrees with the files on disk.
+#
+# This file ships LIVE in the docs-hub repo — it is active from day one in a multi-repo project
+# (the hub is its own repo, so this sits at that repo's .github/workflows/). In the hub it
+# validates the hub's own content (ADRs + architecture docs); the STEP-index lives in the
+# sibling `prompts/` repo, so those checks skip here with a note and run in full whenever the
+# whole workspace is checked out (locally, and during the periodic check-in).
+#
+# Mono-repo-for-now project? The workspace root is the single repo, so copy this file to the
+# ROOT `.github/workflows/` (a workflow nested under Code/<project>-docs/ won't trigger there) —
+# then check.sh sees prompts/ too and the STEP-index checks run as well. See templates/ci/README.md.
+
+name: method-check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run scripts/check.sh (project integrity)
+        run: bash scripts/check.sh

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -119,7 +119,8 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
 - **Always say what's next.** End every session/STEP by updating the index, then tell the
   user the next action and to **start a fresh chat** for it. Answer *"what do I do next?"* by
   reading `prompts/STEP-index.md` per the **next-action resolver** (`METHOD.md` §10) — from
-  disk, never from memory.
+  disk, never from memory. `Code/{{PROJECT}}-docs/scripts/status.sh` runs that resolver
+  mechanically (where you are · next action · check-in cadence) for a quick read.
 - One decision/question cluster at a time. Recommend defaults; flag what they foreclose.
 
 ## Working alongside others (humans or other agents)

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -25,8 +25,13 @@ line). It has one of two values:
   *What is {{PROJECT}}* below). The user should not have to pre-write `overview.md` or paste a
   kickoff command. The bootstrap flips the marker to `kickoff-complete` when it finishes.
 - **`kickoff-complete` → Resume mode.** Kickoff already happened. **Do not re-run kickoff.**
-  Pick up the next action via the next-action resolver (`METHOD.md` §10): read
-  `prompts/STEP-index.md` and tell the user what's next.
+  Pick up the next action via the next-action resolver (`METHOD.md` §10): **run
+  `Code/{{PROJECT}}-docs/scripts/status.sh`** — it resolves §10 mechanically from disk and
+  prints where you are, the next action, and the check-in cadence. Read
+  `prompts/STEP-index.md` to confirm (and for the sub-STEP detail the script doesn't carry —
+  the in-flight PLAN in `Upcoming Prompts/`), then tell the user what's next. If the script
+  isn't available (older project, no shell), fall back to reading the index and applying §10
+  yourself.
 
 (If the marker is missing entirely — an older project predating it — fall back to inferring:
 treat it as resume unless `prompts/STEP-index.md` is still the bare `init.sh` seed.)
@@ -118,9 +123,9 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
 - Keep **`prompts/STEP-index.md`** current — it's the source of truth for status.
 - **Always say what's next.** End every session/STEP by updating the index, then tell the
   user the next action and to **start a fresh chat** for it. Answer *"what do I do next?"* by
-  reading `prompts/STEP-index.md` per the **next-action resolver** (`METHOD.md` §10) — from
-  disk, never from memory. `Code/{{PROJECT}}-docs/scripts/status.sh` runs that resolver
-  mechanically (where you are · next action · check-in cadence) for a quick read.
+  running `Code/{{PROJECT}}-docs/scripts/status.sh` — it runs the **next-action resolver**
+  (`METHOD.md` §10) mechanically from disk (where you are · next action · check-in cadence) —
+  then confirming against `prompts/STEP-index.md`. From disk, never from memory.
 - One decision/question cluster at a time. Recommend defaults; flag what they foreclose.
 
 ## Working alongside others (humans or other agents)

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -348,8 +348,9 @@ to start a fresh chat for it — clearing context between units is the norm, sin
 lives in files (§4, §5).
 
 > **Shortcut:** `scripts/status.sh` runs this resolver mechanically — it prints where you
-> are, the next action, and the check-in cadence straight from the index. Use it as a quick
-> read; the rules below remain authoritative when a case is ambiguous.
+> are, the next action, and the check-in cadence straight from the index. It's the mechanism a
+> resuming agent runs first (see `AGENTS.md`, "First action"); the rules below remain
+> authoritative when a case is ambiguous or the script isn't available.
 
 Resolve the next action top-down against the index — the first rule that matches wins:
 

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -72,9 +72,10 @@ Other folders in the hub: `coding-standards/` (per-language; defaults ship for c
 languages, and session 1.11 reconciles them to the stack you pick — review what's there,
 add what's missing, prune the rest), `runbooks/` (repeatable procedures — ships with
 `check-in.md`, `collaboration.md`, `release-deploy.md` (an optional, customizable
-deploy/rollback checklist), and `incident-postmortem.md` (respond to a production incident,
-then spin up an Incident STEP to RCA → find similar → fix); add your own operational ones),
-`registries/`
+deploy/rollback checklist), `incident-postmortem.md` (respond to a production incident, then
+spin up an Incident STEP to RCA → find similar → fix), and `dependency-supply-chain.md` (vet a
+new dependency; audit dependencies for vulns/licenses on a cadence); add your own operational
+ones), `registries/`
 (e.g. `repos.yml`, the repo inventory for multi-repo projects).
 
 ## 4. Architecture sessions

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -347,6 +347,10 @@ granularity). Every session and STEP also **ends by stating the next action** an
 to start a fresh chat for it — clearing context between units is the norm, since the state
 lives in files (§4, §5).
 
+> **Shortcut:** `scripts/status.sh` runs this resolver mechanically — it prints where you
+> are, the next action, and the check-in cadence straight from the index. Use it as a quick
+> read; the rules below remain authoritative when a case is ambiguous.
+
 Resolve the next action top-down against the index — the first rule that matches wins:
 
 1. **STEP-1 has a `Planned` / `In progress` substep?** → run the lowest-numbered open one:

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -27,6 +27,13 @@ This is a **review + verification** STEP, not feature work. It writes no applica
 it fixes docs, files bugs, and proves the tests pass.
 
 ## Part 1 — Doc drift (check **both** directions)  *(substep N.1)*
+
+> **Start with the mechanical pass.** Run `scripts/check.sh` first — in seconds it catches the
+> *structural* drift this part otherwise checks by hand: duplicate STEP/ADR numbers, invalid
+> statuses, architecture docs missing `Version`/`Status`/Version-Log, and an ADR registry that
+> disagrees with the files on disk. Fix anything it flags, then do the judgment-based review
+> below (which a script can't: does the doc still describe what the system actually *does*?).
+
 For each `architecture/NN-*.md`, compare the doc against the system as it actually is now —
 in both directions, because they catch different problems:
 

--- a/Code/{{PROJECT}}-docs/runbooks/dependency-supply-chain.md
+++ b/Code/{{PROJECT}}-docs/runbooks/dependency-supply-chain.md
@@ -1,0 +1,76 @@
+# Runbook — Dependencies & Supply Chain
+
+> **How to run:** This is an **operational procedure, not a STEP** (like the release runbook),
+> with two modes:
+> - **Adding a dependency** → run the vetting checklist (**Part 1**) *before* you
+>   `npm install` / `pip install` / `go get` / `cargo add` — tell your agent *"vet this
+>   dependency."*
+> - **Periodic audit** → run **Parts 2–3** on a cadence: it rides naturally on the **check-in**
+>   (`runbooks/check-in.md`, every ~10–20 STEPs), and you also run it whenever a vulnerability
+>   advisory lands for something you use.
+>
+> **Optional and yours to customize.** Like the release runbook, this leaves the specific tools
+> to your stack (`npm audit`, `pip-audit`, `cargo audit`, `govulncheck`, Dependabot/Renovate,
+> a license scanner…). The *discipline* below — vet before you add, pin, audit on a cadence — is
+> the durable part; fill in your ecosystem's commands. It operationalizes the dependency-risk
+> posture set in `architecture/06-security-threat-model.md`.
+
+## Why this runbook exists
+Most of a modern application is code you didn't write — your dependencies, and *their*
+dependencies, several layers deep. That's the dominant way trouble enters a project that's
+otherwise careful: a compromised or abandoned package, a known CVE you never patched, a
+typosquatted name, a copyleft license that quietly contaminates a proprietary product.
+"It installed and it worked" is not vetting. This runbook makes adding and maintaining
+dependencies a deliberate choice rather than a reflex, because every dependency is a permanent
+liability you're taking on — and the cheapest one is the one you don't add.
+
+## Part 1 — Before you add a dependency (vetting)
+- [ ] **Do you actually need it?** Is this genuine leverage, or a few lines you could write and
+      own? Weigh the permanent cost — supply-chain surface, updates, license, breakage risk —
+      against what it saves. The cheapest dependency is no dependency.
+- [ ] **Is it healthy?** Actively maintained (recent releases/commits), genuinely used (not
+      single-maintainer abandonware), and reasonably responsive on issues/security. A popular,
+      maintained package is a smaller risk than a clever neglected one.
+- [ ] **License compatibility.** Check the package's license — and its transitive licenses —
+      against the license your project ships under (the one `init.sh` stamped). Copyleft
+      (GPL/AGPL) inside a proprietary product, or an incompatible mix, is a real legal problem;
+      catch it *before* the dependency is load-bearing.
+- [ ] **Security & provenance.** Any known CVEs? Is this the **canonical** package from the
+      official registry/org, spelled exactly right? Typosquatted and confusable names are a
+      common attack — a momentary misread installs hostile code.
+- [ ] **Transitive weight.** What does it drag in? A small direct dependency with a huge
+      transitive tree expands your attack surface far more than its own size suggests.
+- [ ] **Pin it.** Add it with a version constraint and **commit the lockfile**, so builds are
+      reproducible and an upstream change can't silently alter what you ship.
+
+## Part 2 — Periodic audit (on the check-in cadence)
+- [ ] **Scan for known vulnerabilities.** Run your ecosystem's audit across **all repos**.
+      Triage the findings: patch the exploitable ones now; for any you consciously defer, record
+      an **accepted-risk** note with the trigger to revisit — the same discipline as a deferred
+      threat in `architecture/06-security-threat-model.md` (a standing policy → an ADR; a
+      one-off → a line in the check-in record).
+- [ ] **Update cadence.** Apply **security patches promptly**; take feature/major upgrades
+      *deliberately* (read the changelog, expect breaking changes, run the tests). Neither
+      extreme is safe: everything pinned years behind becomes one terrifying upgrade, but
+      auto-merging majors blind breaks things — choose, don't drift.
+- [ ] **Lockfile hygiene.** Lockfile committed and in sync with the manifest; no unexplained or
+      unexpected entries (a surprise transitive change is worth a look).
+- [ ] **Prune the unused.** Remove dependencies you no longer use — dead dependencies are pure
+      liability (attack surface + audit noise) for zero benefit.
+- [ ] **SBOM (if you keep one).** Regenerate the software bill of materials so that when the next
+      big advisory drops you can answer *"are we affected by CVE-X?"* in minutes, not days.
+
+## Part 3 — When supply chain *is* the incident
+A dependency vulnerability that's being exploited, or a malicious/compromised package found in
+your tree, is an **incident** — switch to `runbooks/incident-postmortem.md`. The *find-similar*
+substep there is exactly the right reflex: is the same bad package, or the same unpatched class,
+present in other repos or other services?
+
+## Output / record
+Most of this is action, not documents — but leave a trail:
+- **Audit result** noted in the check-in record (vulnerabilities found, patched, or deferred).
+- **Accepted-risk deferrals** with their revisit trigger (per above).
+- **Standing policies** as **ADRs** — e.g. "no AGPL dependencies," "pin exact versions,"
+  "security patches within N days" — so the rule outlives the person who set it.
+- File a **follow-up STEP** for anything too big to handle in the moment (a major framework
+  upgrade, replacing an abandoned package).

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# check.sh — a "doctor" for a Throughstone project. It runs the mechanical integrity checks
+# the method otherwise trusts prose (and the agent's memory) to enforce. Read-only: it never
+# modifies a file. Safe to run anytime — intended for the periodic check-in (runbooks/check-in.md)
+# and for CI.
+#
+# Checks:
+#   1. No duplicate STEP numbers in prompts/STEP-index.md
+#   2. No duplicate ADR numbers in adr/README.md
+#   3. STEP / substep statuses are from the allowed set
+#   4. Every architecture/NN-*.md carries Version / Status / Version Log
+#   5. The ADR registry and the ADR files on disk match (both directions)
+#   6. (multi-repo only) No stray files at the workspace root
+#
+# Usage:  from anywhere — Code/<project>-docs/scripts/check.sh
+# Exit:   non-zero if any hard check FAILs; warnings alone do not fail the run.
+
+set -uo pipefail
+
+# This script lives in <workspace>/Code/<project>-docs/scripts/ — derive the paths.
+DOCS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DOCS_DIR/../.." && pwd)"
+INDEX="$ROOT/prompts/STEP-index.md"
+ADR_INDEX="$DOCS_DIR/adr/README.md"
+ARCH_DIR="$DOCS_DIR/architecture"
+ADR_DIR="$DOCS_DIR/adr"
+
+shopt -s nullglob
+
+fails=0
+warns=0
+pass() { printf '  [PASS] %s\n' "$1"; }
+fail() { printf '  [FAIL] %s\n' "$1"; fails=$((fails + 1)); }
+warn() { printf '  [WARN] %s\n' "$1"; warns=$((warns + 1)); }
+hdr()  { printf '\n%s\n' "$1"; }
+
+# Emit a newline list as sorted, unique, non-empty lines (for comm).
+emit() { printf '%s\n' "$1" | sed '/^[[:space:]]*$/d' | sort -u; }
+
+echo "Throughstone check — $ROOT"
+
+# --- 1. Duplicate STEP numbers ------------------------------------------------
+hdr "1. Duplicate STEP numbers (prompts/STEP-index.md)"
+if [ -f "$INDEX" ]; then
+  dups="$(grep -oE '^\|[[:space:]]*STEP-[0-9]+' "$INDEX" | grep -oE 'STEP-[0-9]+' | sort | uniq -d)"
+  if [ -n "$dups" ]; then
+    fail "duplicate STEP number(s): $(echo "$dups" | tr '\n' ' ')"
+  else
+    pass "no duplicate STEP numbers"
+  fi
+else
+  warn "no prompts/STEP-index.md yet (project not initialized?) — skipping STEP checks"
+fi
+
+# --- 2. Duplicate ADR numbers -------------------------------------------------
+hdr "2. Duplicate ADR numbers (adr/README.md)"
+if [ -f "$ADR_INDEX" ]; then
+  dups="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE 'ADR-[0-9]+' | sort | uniq -d)"
+  if [ -n "$dups" ]; then
+    fail "duplicate ADR number(s): $(echo "$dups" | tr '\n' ' ')"
+  else
+    pass "no duplicate ADR numbers"
+  fi
+else
+  warn "no adr/README.md — skipping ADR-number check"
+fi
+
+# --- 3. Valid STEP / substep statuses -----------------------------------------
+hdr "3. Statuses valid (Planned · In progress · Done · Abandoned · N/A)"
+if [ -f "$INDEX" ]; then
+  # Find each table's Status column from its header row, then validate that cell in data rows.
+  bad="$(awk -F'|' '
+    function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+    {
+      if ($0 !~ /^[[:space:]]*\|/) { inrow = 0; statuscol = 0; next }   # left a table
+      ishdr = 0
+      for (i = 1; i <= NF; i++) if (trim($i) == "Status") { ishdr = 1; statuscol = i }
+      if (ishdr) { inrow = 1; next }
+      if (!inrow || statuscol == 0) next
+      sc = trim($statuscol)
+      if (sc == "" || sc ~ /^:?-+:?$/) next                            # blank or separator row
+      if (sc != "Planned" && sc != "In progress" && sc != "Done" && sc != "Abandoned" && sc != "N/A")
+        print trim($2) " -> \"" sc "\""
+    }
+  ' "$INDEX")"
+  if [ -n "$bad" ]; then
+    fail "invalid status value(s):"
+    while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$bad"
+  else
+    pass "all statuses valid"
+  fi
+else
+  warn "no prompts/STEP-index.md yet — skipping status check"
+fi
+
+# --- 4. Architecture-doc frontmatter ------------------------------------------
+hdr "4. Architecture docs carry Version / Status / Version Log"
+docs=("$ARCH_DIR"/[0-9][0-9]-*.md)
+if [ ${#docs[@]} -eq 0 ]; then
+  pass "no architecture docs yet (nothing to check)"
+else
+  missing_any=0
+  for f in "${docs[@]}"; do
+    b="$(basename "$f")"
+    missing=""
+    grep -qF '**Version:**'  "$f" || missing="$missing Version"
+    grep -qF '**Status:**'   "$f" || missing="$missing Status"
+    grep -qiF 'version log'  "$f" || missing="$missing Version-Log"
+    if [ -n "$missing" ]; then fail "$b missing:$missing"; missing_any=1; fi
+  done
+  [ "$missing_any" -eq 0 ] && pass "all ${#docs[@]} architecture doc(s) have the required fields"
+fi
+
+# --- 5. ADR registry <-> files on disk ----------------------------------------
+hdr "5. ADR registry matches ADR files on disk (both directions)"
+if [ -f "$ADR_INDEX" ]; then
+  reg_ids="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE 'ADR-[0-9]+')"
+  disk_ids=""
+  for f in "$ADR_DIR"/ADR-*.md; do disk_ids="$disk_ids$(basename "$f" | grep -oE 'ADR-[0-9]+')"$'\n'; done
+  missing_files="$(comm -23 <(emit "$reg_ids") <(emit "$disk_ids"))"   # in registry, no file
+  missing_rows="$(comm -13 <(emit "$reg_ids") <(emit "$disk_ids"))"    # file, not in registry
+  ok=1
+  [ -n "$missing_files" ] && { fail "in registry but no file: $(echo "$missing_files" | tr '\n' ' ')"; ok=0; }
+  [ -n "$missing_rows" ]  && { fail "file on disk but not in registry: $(echo "$missing_rows" | tr '\n' ' ')"; ok=0; }
+  [ "$ok" -eq 1 ] && pass "registry and files agree ($(emit "$reg_ids" | grep -c . ) ADR(s))"
+else
+  warn "no adr/README.md — skipping ADR registry/disk check"
+fi
+
+# --- 6. Workspace-root hygiene (multi-repo only) ------------------------------
+hdr "6. Workspace-root hygiene (multi-repo only)"
+if [ -e "$ROOT/.git" ]; then
+  pass "workspace root is itself a repo (mono-repo or the template) — hygiene rule relaxed; skipping"
+else
+  allow=" CLAUDE.md AGENTS.md init.sh .git .gitignore .gitattributes .DS_Store .claude Code prompts Upcoming Prompts "
+  stray=""
+  for entry in "$ROOT"/* "$ROOT"/.[!.]*; do
+    [ -e "$entry" ] || continue
+    name="$(basename "$entry")"
+    case "$allow" in *" $name "*) : ;; *) stray="$stray $name" ;; esac
+  done
+  if [ -n "$stray" ]; then
+    warn "unexpected entr(ies) at workspace root:$stray — should these be inside a repo (usually the docs hub)?"
+  else
+    pass "only the expected pointers / repos at the workspace root"
+  fi
+fi
+
+# --- Summary ------------------------------------------------------------------
+hdr "Summary"
+printf '  %d fail(s), %d warning(s)\n' "$fails" "$warns"
+if [ "$fails" -gt 0 ]; then
+  echo "  RESULT: FAIL"
+  exit 1
+fi
+echo "  RESULT: OK"
+exit 0

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -34,6 +34,9 @@ pass() { printf '  [PASS] %s\n' "$1"; }
 fail() { printf '  [FAIL] %s\n' "$1"; fails=$((fails + 1)); }
 warn() { printf '  [WARN] %s\n' "$1"; warns=$((warns + 1)); }
 hdr()  { printf '\n%s\n' "$1"; }
+# A suggested remediation under a finding. The doctor diagnoses and prescribes; it never
+# edits files — renumbering touches branch/folder names and needs human judgment.
+hint() { printf '         → fix: %s\n' "$1"; }
 
 # Emit a newline list as sorted, unique, non-empty lines (for comm).
 emit() { printf '%s\n' "$1" | sed '/^[[:space:]]*$/d' | sort -u; }
@@ -46,6 +49,12 @@ if [ -f "$INDEX" ]; then
   dups="$(grep -oE '^\|[[:space:]]*STEP-[0-9]+' "$INDEX" | grep -oE 'STEP-[0-9]+' | sort | uniq -d)"
   if [ -n "$dups" ]; then
     fail "duplicate STEP number(s): $(echo "$dups" | tr '\n' ' ')"
+    for d in $dups; do
+      lns="$(grep -nE "^\|[[:space:]]*$d([[:space:]]|\|)" "$INDEX" | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')"
+      printf '         %s appears on line(s): %s\n' "$d" "$lns"
+    done
+    maxn="$(grep -oE '^\|[[:space:]]*STEP-[0-9]+' "$INDEX" | grep -oE '[0-9]+' | sort -n | tail -1)"
+    hint "renumber the duplicate (the one reserved later) to STEP-$((maxn + 1)) — never reuse or delete a number; mark a row Abandoned if it won't be built. See runbooks/collaboration.md §2."
   else
     pass "no duplicate STEP numbers"
   fi
@@ -59,6 +68,12 @@ if [ -f "$ADR_INDEX" ]; then
   dups="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE 'ADR-[0-9]+' | sort | uniq -d)"
   if [ -n "$dups" ]; then
     fail "duplicate ADR number(s): $(echo "$dups" | tr '\n' ' ')"
+    for d in $dups; do
+      lns="$(grep -nE "^\|[[:space:]]*$d([[:space:]]|\|)" "$ADR_INDEX" | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')"
+      printf '         %s appears on line(s): %s\n' "$d" "$lns"
+    done
+    maxn="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE '[0-9]+' | sed 's/^0*//' | sort -n | tail -1)"
+    hint "renumber the later duplicate to $(printf 'ADR-%04d' "$((maxn + 1))") and rename its file to match — never reuse a number. See adr/README.md and runbooks/collaboration.md §6."
   else
     pass "no duplicate ADR numbers"
   fi
@@ -87,6 +102,7 @@ if [ -f "$INDEX" ]; then
   if [ -n "$bad" ]; then
     fail "invalid status value(s):"
     while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$bad"
+    hint "use exactly one of: Planned · In progress · Done · Abandoned (a substep may also be N/A). See METHOD.md §1."
   else
     pass "all statuses valid"
   fi
@@ -109,7 +125,11 @@ else
     grep -qiF 'version log'  "$f" || missing="$missing Version-Log"
     if [ -n "$missing" ]; then fail "$b missing:$missing"; missing_any=1; fi
   done
-  [ "$missing_any" -eq 0 ] && pass "all ${#docs[@]} architecture doc(s) have the required fields"
+  if [ "$missing_any" -eq 0 ]; then
+    pass "all ${#docs[@]} architecture doc(s) have the required fields"
+  else
+    hint "add the missing field(s) from templates/architecture-doc.md (Version / Status header, and a Version Log table). See METHOD.md §6."
+  fi
 fi
 
 # --- 5. ADR registry <-> files on disk ----------------------------------------
@@ -121,8 +141,8 @@ if [ -f "$ADR_INDEX" ]; then
   missing_files="$(comm -23 <(emit "$reg_ids") <(emit "$disk_ids"))"   # in registry, no file
   missing_rows="$(comm -13 <(emit "$reg_ids") <(emit "$disk_ids"))"    # file, not in registry
   ok=1
-  [ -n "$missing_files" ] && { fail "in registry but no file: $(echo "$missing_files" | tr '\n' ' ')"; ok=0; }
-  [ -n "$missing_rows" ]  && { fail "file on disk but not in registry: $(echo "$missing_rows" | tr '\n' ' ')"; ok=0; }
+  [ -n "$missing_files" ] && { fail "in registry but no file: $(echo "$missing_files" | tr '\n' ' ')"; ok=0; hint "create the ADR file(s) from templates/adr.md, or remove the stale registry row(s) in adr/README.md."; }
+  [ -n "$missing_rows" ]  && { fail "file on disk but not in registry: $(echo "$missing_rows" | tr '\n' ' ')"; ok=0; hint "add a registry row in adr/README.md for the file(s), or delete the file if it shouldn't exist."; }
   [ "$ok" -eq 1 ] && pass "registry and files agree ($(emit "$reg_ids" | grep -c . ) ADR(s))"
 else
   warn "no adr/README.md — skipping ADR registry/disk check"
@@ -142,6 +162,7 @@ else
   done
   if [ -n "$stray" ]; then
     warn "unexpected entr(ies) at workspace root:$stray — should these be inside a repo (usually the docs hub)?"
+    hint "move durable content into a repo (almost always Code/<project>-docs/); the root holds only per-machine pointers, the repo folders, and Upcoming Prompts/. See METHOD.md §7."
   else
     pass "only the expected pointers / repos at the workspace root"
   fi

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -150,7 +150,9 @@ fi
 
 # --- 6. Workspace-root hygiene (multi-repo only) ------------------------------
 hdr "6. Workspace-root hygiene (multi-repo only)"
-if [ -e "$ROOT/.git" ]; then
+if [ -n "${CI:-}" ]; then
+  pass "CI environment — root hygiene is a local-workspace check (a single repo is checked out here); skipping"
+elif [ -e "$ROOT/.git" ]; then
   pass "workspace root is itself a repo (mono-repo or the template) — hygiene rule relaxed; skipping"
 else
   allow=" CLAUDE.md AGENTS.md init.sh .git .gitignore .gitattributes .DS_Store .claude Code prompts Upcoming Prompts "

--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# status.sh — mechanically run the next-action resolver (METHOD.md §10) and print where the
+# project is, what to do next, and the check-in cadence. Read-only. It reads the kickoff marker
+# in overview.md and the roadmap in prompts/STEP-index.md — the same disk state the resolver
+# uses — so a fresh chat (or a new teammate) can answer "what do I do next?" without guessing.
+#
+# This is a *helper*: METHOD.md §10 remains authoritative. When the index can't determine the
+# answer, the script says so and points there.
+#
+# Usage:  from anywhere — Code/<project>-docs/scripts/status.sh
+
+set -uo pipefail
+
+DOCS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DOCS_DIR/../.." && pwd)"
+INDEX="$ROOT/prompts/STEP-index.md"
+OVERVIEW="$DOCS_DIR/overview.md"
+
+echo "Throughstone status — $ROOT"
+echo
+
+# --- Kickoff gate (AGENTS.md "First action") ----------------------------------
+if [ -f "$OVERVIEW" ] && grep -q 'PROJECT-STATUS: not-started' "$OVERVIEW"; then
+  echo "Where you are:  kickoff not started (overview.md marker: not-started)."
+  echo
+  echo "Next action:"
+  echo "  → start the kickoff — open the project and say:  \"Read AGENTS.md and follow it.\""
+  echo "    It runs BOOTSTRAP-PROMPT.md from Stage 0 (no command to paste)."
+  exit 0
+fi
+
+if [ ! -f "$INDEX" ]; then
+  echo "Where you are:  project not initialized (no prompts/STEP-index.md)."
+  echo
+  echo "Next action:"
+  echo "  → run ./init.sh, then \"Read AGENTS.md and follow it\" to begin the kickoff."
+  exit 0
+fi
+
+# --- Parse the index into STEP rows and STEP-1 substep rows --------------------
+# Locate each table's columns from its header, then emit pipe-delimited records.
+parsed="$(awk -F'|' '
+  function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+  /^[[:space:]]*\|/ {
+    isstep = 0; issub = 0
+    for (i = 1; i <= NF; i++) {
+      c = trim($i)
+      if (c == "STEP")    { isstep = 1; stepcol = i }
+      if (c == "Substep") { issub  = 1; subcol  = i }
+      if (c == "Title")   { titlecol   = i }
+      if (c == "Session") { sessioncol = i }
+      if (c == "Status")  { scol = i }
+    }
+    if (isstep) { mode = "step"; statuscol = scol; next }
+    if (issub)  { mode = "sub";  statuscol = scol; next }
+    if (mode == "" || statuscol == 0) next
+    st = trim($statuscol)
+    if (st == "" || st ~ /^:?-+:?$/) next
+    if (mode == "step") {
+      id = trim($stepcol);    if (id ~ /^STEP-[0-9]+$/)            print "STEP|" id "|" st "|" trim($titlecol)
+    } else {
+      id = trim($subcol);     if (id ~ /^[0-9]+\.[0-9]+[a-z]?$/)   print "SUB|"  id "|" st "|" trim($sessioncol)
+    }
+  }
+' "$INDEX")"
+
+# Parallel indexed arrays (bash 3.2 has no associative arrays — stock macOS must run this).
+step_id=(); step_st=(); step_ti=()
+sub_id=(); sub_st=(); sub_se=()
+while IFS='|' read -r kind id st extra; do
+  [ -z "${kind:-}" ] && continue
+  if [ "$kind" = "STEP" ]; then
+    step_id+=("$id"); step_st+=("$st"); step_ti+=("$extra")
+  elif [ "$kind" = "SUB" ]; then
+    sub_id+=("$id"); sub_st+=("$st"); sub_se+=("$extra")
+  fi
+done <<< "$parsed"
+
+# Sortable key for a substep id: 1.6a -> 100600+ord('a'); 1.13 -> 101300.
+subkey() {
+  local x="$1" maj="${1%%.*}" rest="${1#*.}" num let lo=0
+  num="${rest%%[a-z]*}"; let="${rest#"$num"}"
+  [ -n "$let" ] && lo=$(printf '%d' "'$let")
+  echo $(( maj * 100000 + num * 100 + lo ))
+}
+
+# --- STEP-1 substep state -----------------------------------------------------
+total_sub=${#sub_id[@]}; done_sub=0; lowsub=""; lowsub_se=""; lowkey=99999999
+i=0
+while [ "$i" -lt "$total_sub" ]; do
+  s="${sub_id[$i]}"
+  case "${sub_st[$i]}" in
+    Done|N/A) done_sub=$((done_sub + 1)) ;;
+    Planned|"In progress")
+      k=$(subkey "$s"); if [ "$k" -lt "$lowkey" ]; then lowkey=$k; lowsub=$s; lowsub_se="${sub_se[$i]}"; fi ;;
+  esac
+  i=$((i + 1))
+done
+
+# --- Main STEP state ----------------------------------------------------------
+maxnum=0; have_impl=0; nonfinal=0; last_ci=0; step1_st=""
+inprog=""; inprog_ti=""; inprog_n=999999
+lowplanned=""; lowplanned_ti=""; lowplanned_n=999999
+n_steps=${#step_id[@]}; i=0
+while [ "$i" -lt "$n_steps" ]; do
+  id="${step_id[$i]}"; st="${step_st[$i]}"; ti="${step_ti[$i]}"; n=${id#STEP-}
+  [ "$id" = "STEP-1" ] && step1_st="$st"
+  [ "$n" -gt "$maxnum" ] && maxnum=$n
+  [ "$n" -ge 2 ] && have_impl=1
+  if [ "$st" = "In progress" ] && [ "$n" -lt "$inprog_n" ]; then inprog_n=$n; inprog=$id; inprog_ti="$ti"; fi
+  if [ "$n" -ge 2 ] && [ "$st" = "Planned" ] && [ "$n" -lt "$lowplanned_n" ]; then lowplanned_n=$n; lowplanned=$id; lowplanned_ti="$ti"; fi
+  case "$st" in Done|Abandoned) ;; *) nonfinal=1 ;; esac
+  if printf '%s' "$ti" | grep -qiE 'check.?in'; then [ "$n" -gt "$last_ci" ] && last_ci=$n; fi
+  i=$((i + 1))
+done
+all_done=0; [ "$nonfinal" -eq 0 ] && [ "$n_steps" -gt 0 ] && all_done=1
+
+# --- Resolve (METHOD.md §10, first match wins) --------------------------------
+where=""; next=""
+if [ -n "$lowsub" ]; then                                   # §10.1 / §10.2
+  where="Architecture (STEP-1) in progress — ${done_sub}/${total_sub} substeps complete."
+  if [ "$lowsub" = "1.13" ]; then
+    next="run session 1.13 — the cross-cutting review."
+  elif [[ "$lowsub" =~ [a-z]$ ]]; then
+    next="run the conditional session for substep ${lowsub} — \"${lowsub_se}\"; invoke it BY NAME (e.g. \"run the identity-auth session\"), not by number."
+  else
+    next="run session ${lowsub}  (${lowsub_se})."
+  fi
+elif [ "$have_impl" -eq 0 ]; then                           # §10.3 (or STEP-1 not yet run)
+  if [ "$total_sub" -gt 0 ]; then
+    where="Architecture (STEP-1) complete (${done_sub}/${total_sub} substeps); implementation not yet outlined."
+    next="run the planning session — it outlines the Phase-1 implementation STEPs (templates/planning-session.md)."
+  elif [ "$step1_st" = "Done" ]; then
+    where="STEP-1 done; implementation not yet outlined."
+    next="run the planning session — it outlines the Phase-1 implementation STEPs."
+  else
+    where="Architecture (STEP-1) not yet run."
+    next="run session 1.1 — start the architecture STEP."
+  fi
+elif [ -n "$inprog" ]; then                                 # §10.5
+  where="Building — ${inprog} (${inprog_ti}) is In progress."
+  next="open ${inprog}'s PLAN in \"Upcoming Prompts/\" and run its lowest open substep (\"run substep N.M\"). When the last is done: review, archive to prompts/, mark ${inprog} Done."
+elif [ -n "$lowplanned" ]; then                             # §10.4
+  where="Building — no STEP In progress; next up is ${lowplanned} (${lowplanned_ti})."
+  next="start ${lowplanned} — confirm scope, then author its PLAN + substep prompts (prompts/README.md recipe) in a fresh chat."
+elif [ "$all_done" -eq 1 ]; then                            # §10.7
+  where="Every STEP in the index is Done."
+  next="phase looks complete — it's a milestone: prompt release notes + user-facing doc updates (METHOD §5), then open the next phase and run the planning session for it."
+else
+  where="Indeterminate from the index alone."
+  next="resolve by hand via the next-action resolver in METHOD.md §10."
+fi
+
+# --- Check-in cadence (METHOD.md §10.6) ---------------------------------------
+if [ "$last_ci" -gt 0 ]; then
+  since=$(( maxnum - last_ci ))
+  if   [ "$since" -ge 20 ]; then ci="last at STEP-${last_ci}, ${since} STEPs ago — OVERDUE (>20); insert a Check-in STEP now."
+  elif [ "$since" -ge 10 ]; then ci="last at STEP-${last_ci}, ${since} STEPs ago — DUE (you're in the 10–20 window)."
+  else ci="last at STEP-${last_ci}, ${since} STEPs ago — ~$(( 10 - since ))–$(( 20 - since )) STEPs of headroom."
+  fi
+elif [ "$maxnum" -ge 10 ]; then
+  ci="no Check-in STEP yet — consider one (${maxnum} STEPs in; cadence is ~10–20)."
+else
+  ci="no Check-in STEP yet — fine (${maxnum} STEP(s) in; first due ~STEP-10–20)."
+fi
+
+# --- Output -------------------------------------------------------------------
+echo "Where you are:"
+echo "  $where"
+echo
+echo "Next action:"
+echo "  → $next"
+echo "  (start a fresh chat for it — state lives on disk, not in this conversation.)"
+echo
+echo "Check-in cadence:"
+echo "  $ci"

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
@@ -50,7 +50,9 @@ oversight.
    `.gitignore` stamped by `init.sh` already excludes these — confirm production secrets come
    from a real secrets manager, not a checked-in file.
 6. **Common web risks.** Posture on input validation, injection, XSS/CSRF, rate limiting,
-   dependency vulnerabilities. What's handled by the framework vs. needs attention?
+   dependency vulnerabilities. What's handled by the framework vs. needs attention? (The
+   dependency/supply-chain posture you set here is operationalized in
+   `runbooks/dependency-supply-chain.md` — vetting new deps and auditing them on a cadence.)
 7. **Mitigate now vs. defer.** For each significant threat: mitigate in the MVP, or defer?
    For every deferral, record the blast radius and **what triggers revisiting** (e.g.
    "before we accept real user data / payments / go public").

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -39,7 +39,9 @@ where the pieces have to work *together*.
 5. **System / end-to-end tests.** How the whole system is tested together — important for
    multi-repo. Where do cross-repo e2e tests live (often a dedicated tests repo)?
 6. **CI gates.** What must pass before code merges and before it deploys (tests, linters,
-   type checks, build). Keep the gate fast enough that people don't route around it.
+   type checks, build). Keep the gate fast enough that people don't route around it. A starter
+   wiring this up ships in `templates/ci/` (a method-integrity workflow that runs
+   `scripts/check.sh`, plus a per-repo test workflow to fill in) — see `templates/ci/README.md`.
 7. **Performance / load testing.** Whether and when load tests run (ties to the targets in
    1.5).
 8. **Coding standards per language.** Confirm the implementation language(s) from the

--- a/Code/{{PROJECT}}-docs/templates/ci/README.md
+++ b/Code/{{PROJECT}}-docs/templates/ci/README.md
@@ -1,0 +1,36 @@
+# CI starter (GitHub Actions)
+
+Two workflows so a {{PROJECT}} project has continuous integration **from day one** — the method
+checks and the test gate the architecture's test-strategy session calls for (`architecture/11-test-strategy.md`,
+"CI gates"). They're GitHub Actions, but the *shape* (check on push/PR, fail on red) ports to any CI.
+
+## 1. Method integrity — `method-check.yml`  *(ships live; no template step)*
+
+Runs the project "doctor" (`scripts/check.sh`): duplicate STEP/ADR numbers, invalid statuses,
+architecture-doc frontmatter, ADR registry vs. files on disk, root hygiene. It is **already
+installed** in the docs hub at `Code/{{PROJECT}}-docs/.github/workflows/method-check.yml`, so in a
+**multi-repo** project (the hub is its own repo) it's active the moment you push the hub — nothing
+to place.
+
+- **Multi-repo:** active as shipped. In the hub it validates the hub's content (ADRs + architecture
+  docs); the `STEP-index` lives in the `prompts/` repo, so those checks skip here and run in full
+  when the whole workspace is checked out (locally and at each check-in).
+- **Mono-repo-for-now:** the workspace root is the single repo, and a workflow nested under
+  `Code/<project>-docs/` does **not** trigger there — **copy** `method-check.yml` to the **root**
+  `.github/workflows/`. Then `check.sh` sees `prompts/` too, so the STEP-index checks run as well.
+
+## 2. Code-repo tests — `code-repo-ci.yml`  *(template; stamp per repo)*
+
+The test gate for a code repo. When you scaffold a code repo (stamping its README from
+`templates/repo-readme.md`), also drop this into that repo's `.github/workflows/ci.yml` and fill in
+the toolchain + test command for its stack — examples for Node / Python / Go / Rust are inlined.
+
+It **fails until configured** on purpose: an unconfigured gate that silently passes is worse than
+none. Replace the `Configure me` step (which `exit 1`s) with your real setup + test command.
+
+## Keeping it honest
+
+CI enforces what the method otherwise trusts to discipline. Pair it with the local tools:
+`scripts/status.sh` (where am I / what's next) and `scripts/check.sh` (the same checks CI runs, on
+your machine before you push). The periodic check-in (`runbooks/check-in.md`) already runs
+`check.sh` as its mechanical first pass.

--- a/Code/{{PROJECT}}-docs/templates/ci/code-repo-ci.yml
+++ b/Code/{{PROJECT}}-docs/templates/ci/code-repo-ci.yml
@@ -1,0 +1,46 @@
+# Tests CI for a {{PROJECT}} code repo — runs the test suite on every push and pull request.
+# This is the merge gate from the test-strategy session (architecture/11-test-strategy.md,
+# "CI gates"): keep it fast enough that people don't route around it.
+#
+# Stamp this into each code repo's .github/workflows/ when the repo is scaffolded (alongside its
+# README from templates/repo-readme.md), then fill in the toolchain + test command for that
+# repo's stack. The job below FAILS on purpose until you do — an unconfigured gate that silently
+# passes is worse than none. Replace the final step with one of the examples (or your own).
+
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # --- Node (npm) ---
+      # - uses: actions/setup-node@v4
+      #   with: { node-version: '20', cache: 'npm' }
+      # - run: npm ci
+      # - run: npm test
+
+      # --- Python ---
+      # - uses: actions/setup-python@v5
+      #   with: { python-version: '3.12' }
+      # - run: pip install -r requirements.txt
+      # - run: pytest
+
+      # --- Go ---
+      # - uses: actions/setup-go@v5
+      #   with: { go-version: '1.22' }
+      # - run: go test ./...
+
+      # --- Rust ---
+      # - uses: dtolnay/rust-toolchain@stable
+      # - run: cargo test
+
+      - name: Configure me
+        run: |
+          echo "TODO: replace this step with this repo's setup + test command (see examples above)."
+          exit 1

--- a/Code/{{PROJECT}}-docs/templates/repo-readme.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme.md
@@ -9,6 +9,9 @@
   so the project reads uniformly. Sections that don't apply can be dropped (e.g. no
   "API / interface" for a library), but keep the order — and never drop the role one-liner
   above or the Overview below: explaining what the repo *is* is the one non-negotiable part.
+
+  Stamp the CI gate too: drop `templates/ci/code-repo-ci.yml` into this repo's
+  `.github/workflows/ci.yml` and fill in its stack's test command (see `templates/ci/README.md`).
 -->
 
 ## Overview


### PR DESCRIPTION
## Summary

Second wave of the method review (after #10). Adds supply-chain discipline and the **mechanical tooling layer** the method was missing — turning rules it previously trusted to prose into scripts and CI. Docs + scaffolding only; no application code.

> **Merge intent:** non-squash — each commit is self-contained and worth keeping. Five commits, reviewable in order.

## Commits

1. **Add Dependencies & Supply-Chain runbook** — operational runbook (not a STEP): vet a dependency before adding (need / health / license / provenance / transitive weight / pin), and audit on the check-in cadence (vuln scan + triage, update cadence, lockfile hygiene, prune, SBOM). A malicious/exploited package routes to the incident runbook. Optional/customizable, opinionated about discipline. Wired into METHOD §3 and security session 1.6.
2. **Add `scripts/check.sh` — the "doctor"** — the first *mechanical* enforcement: duplicate STEP/ADR numbers, valid statuses, architecture-doc frontmatter, ADR registry ↔ files on disk, root hygiene. Read-only; exits non-zero on hard failures (CI-able); degrades gracefully on fresh projects. Verified against a fixture tripping all six checks. Wired into the check-in runbook as its mechanical first pass.
3. **`check.sh`: suggest a fix per finding** — each `[FAIL]` now prints a `→ fix:` hint: duplicate numbers show the offending lines and the recommended next-free number (`max+1`, zero-padded for ADRs) per collaboration.md; others point at the canonical remedy. Still read-only — it prescribes, never auto-renumbers.
4. **Add `scripts/status.sh` — mechanical next-action resolver** — runs METHOD §10 from disk and prints *where you are · next action · check-in cadence*. Mirrors the rule order (kickoff gate → lowest open STEP-1 substep, naming lettered conditionals by name → planning session → in-progress substeps → start lowest Planned → phase-complete milestone). bash 3.2-compatible (stock macOS); verified across six project states.
5. **Add GitHub Actions CI starter** — `method-check.yml` ships live in the docs hub (runs `check.sh` on push/PR); `templates/ci/code-repo-ci.yml` is the per-repo test gate (stamped on scaffold, fails until configured); README covers mono vs multi placement. `check.sh` skips root-hygiene under `$CI`.

## Reviewer notes

- **Branch name** (`dependency-supply-chain-runbook`) is much narrower than the final scope — it grew into the dependency runbook **+ the full tooling layer** (doctor, status, CI). Suggest merging under this PR's broader title.
- **The tooling is the theme:** `status.sh` (where am I), `check.sh` (is it sound), CI (both, automatically) — the mechanical backstop to the prose method.
- **Scripts verified locally** on bash 3.2 against fixtures; CI workflow YAML validated; no tabs. The scripts are read-only and never renumber/auto-edit.
- **Still open** (tracked in the maintainer's gitignored `TODO.md`, not in this PR): API-contract session, AI-feature conditional, risk/tech-debt register, the conditional re-check at check-in (#2) + its semantic doctor checks, a `check.sh --fix` mode, and a DR restore-rehearsal runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
