### PR TITLE
Add CHANGELOG.md (v1.1.0 + v1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to Throughstone are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Versions here
+refer to the **Throughstone scaffold** (the method, templates, runbooks, and tooling), not to
+any project built with it.
+
+## [1.1.0] - 2026-05-31
+
+This release **broadens the architecture sessions**, adds the **operate-time runbooks** the
+method was missing, and introduces a **mechanical tooling layer** (scripts + CI) that enforces
+rules the method previously trusted to discipline.
+
+### Broader architecture coverage
+- **Resilience & disaster recovery** is now first-class in the Infrastructure session (1.8):
+  failure modes / single points of failure, an availability target, graceful degradation, and
+  backups with RPO/RTO and restore-rehearsal.
+- **Accessibility & internationalization** in the UI session (1.7): a concrete a11y target
+  (WCAG 2.1 AA) plus a new i18n/l10n decision in the don't-foreclose spirit.
+- **New conditional session — Privacy, compliance & data governance** for projects handling
+  personal/regulated data (applicable regimes, data inventory, lawful basis/consent,
+  retention/deletion, data-subject rights, residency & sub-processors).
+
+### Stronger process discipline
+- **Explicit conditional-session selection:** the kickoff now records a *Conditional sessions
+  considered* table (Include / N-A + reason), so a skipped conditional is a deliberate, recorded
+  choice — never a silent omission.
+- **Milestone doc review:** at each phase/release the agent proactively raises release notes and
+  end-user docs.
+- **Documentation discipline** strengthened across the method; **testing guidance** sharpened
+  (~80% coverage suggestion, per-step/substep test defaults).
+
+### New operate-time runbooks
+- **Release / Deploy / Rollback** — a rollback plan before you deploy, reversible migrations,
+  staging-first, a post-deploy watch window.
+- **Incident Response & Postmortem** — stabilize, then open an Incident STEP (RCA → find similar
+  → fix & harden).
+- **Dependencies & Supply Chain** — vet before adding (license / provenance / pin) and audit on
+  the check-in cadence (vuln scan, lockfile hygiene, SBOM).
+
+### Mechanical tooling (new)
+- **`scripts/check.sh` — the "doctor":** flags *and suggests a fix for* duplicate STEP/ADR
+  numbers, invalid statuses, missing architecture-doc frontmatter, and ADR registry/disk drift.
+  Read-only; runnable in CI.
+- **`scripts/status.sh` — next-action resolver:** prints "where you are · next action · check-in
+  cadence" straight from disk; a resuming agent now runs it as its first action.
+- **GitHub Actions CI starter:** a live method-integrity workflow (runs `check.sh`) plus a
+  per-repo test-gate template.
+
+### Other
+- Maintainer contact moved to **hershey@throughstone.org**.
+- A thin pointer **README at the docs-hub root**.
+
+## [1.0.0] - 2026-05-31
+
+Initial public release of the Throughstone scaffold — a starting structure for building
+software **architecture-first** with an AI coding agent.
+
+### Added
+- **The method** (`METHOD.md`): the Phase → STEP → substep structure, architecture-first STEP-1
+  (design docs + ADRs, no code), the two durable doc genres (architecture docs + ADRs),
+  doc versioning, and the disk-derived next-action resolver.
+- **Architecture sessions:** 13 core sessions (system overview through cross-cutting review)
+  plus 2 conditional sessions (native app, identity & auth).
+- **Runbooks:** the periodic check-in and multi-developer/agent collaboration.
+- **Templates:** architecture docs, ADRs, STEP plans, substep prompts, repo READMEs, per-language
+  coding standards, and the kickoff bootstrap.
+- **Setup tooling:** the `init.sh` wizard and `setup-workspace.sh`; multi-repo and
+  mono-repo-for-now layouts; license selection and stamping.
+- **Brand assets** and the throughstone.org documentation site.
+
+[1.1.0]: https://github.com/mherschberg/Throughstone/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/mherschberg/Throughstone/releases/tag/v1.0.0


### PR DESCRIPTION
Adds a CHANGELOG.md (Keep a Changelog format) ahead of tagging **v1.1.0**.

- **v1.1.0** — the approved release notes: broader architecture sessions (resilience/DR, a11y/i18n, privacy conditional), the operate-time runbooks (release/deploy, incident, dependency), and the mechanical tooling layer (check.sh, status.sh, CI starter).
- **v1.0.0** — a brief record of the initial public release of the scaffold.

After this merges I will: annotated-tag the merge commit `v1.1.0`, push the tag, and cut a GitHub Release mirroring the v1.1.0 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)