### PR TITLE
Make architecture-session system flexible to added sessions

### DIFF
--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -134,6 +134,40 @@ change in that doc's Version Log** (and a new ADR if the decision is significant
 ADR is superseded, not edited). Re-running is the normal way the living docs stay true as
 the project learns; it's not a sign something went wrong the first time.
 
+### Adding a session
+The session set is yours to extend — and the two kinds differ sharply in cost.
+
+**A conditional session is zero-touch to the rest of the method.** Conditionals are lettered
+substeps (`1.6c`, `1.7b`) and never renumber the standard sessions. To add one:
+1. Write `templates/architecture-sessions/conditional-<topic>.md` — copy an existing conditional
+   for the shape (the two-numbers header note, a `Reads` line, the calibrate-to-experience note,
+   the decisions, Output, Next).
+2. Give its output doc the **next free number above the core block** (the conditional headers and
+   §8 explain why), and slot its substep as a letter suffix wherever it belongs.
+3. List it in §4's conditional paragraph and the `AGENTS.md` conditional set so it's invocable by
+   name, and record it in the STEP-1 PLAN's *Conditional sessions considered* table.
+
+`status.sh`, the glossary (1.12), and the cross-cutting review (1.13) all pick it up with no
+further edits.
+
+**A standard (numbered) session costs a renumber, because the cross-cutting review is always
+last.** A new standard session inserts *before* the review, which shifts the review — and
+anything after the insertion point — up by one. To add one:
+1. Write `templates/architecture-sessions/NN-<topic>.md`; its doc number is the next in the core
+   block. Append it right before the review to minimize the shift.
+2. Renumber the review (and any shifted sessions): rename the file
+   (`13-cross-cutting-review.md` → `14-…`) and update every literal reference to the old number —
+   all findable with `grep -rn '1\.13'`: the registry (§4 table, the §10 resolver,
+   `templates/step-index-seed.md`), the doc index (`architecture/README.md`), and the prose
+   pointers (`step-plan.md`, `planning-session.md`, `BOOTSTRAP-PROMPT.md`, `01-system-overview.md`,
+   the glossary's *Next*, the review file's own header, and each conditional's closing line).
+3. Add its row to the §4 table and `templates/step-index-seed.md`.
+
+`status.sh` needs no change — it locates the review by its label, not its number.
+
+When in doubt, prefer a conditional: it carries the same interview-and-document machinery without
+the renumber.
+
 ### Calibrating to the user's experience level
 The kickoff (`BOOTSTRAP-PROMPT.md`, Stage 0) asks the user how much experience they have
 building a project like this and records it in `overview.md`: **Level 1** (no coding

--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -120,10 +120,13 @@ all_done=0; [ "$nonfinal" -eq 0 ] && [ "$n_steps" -gt 0 ] && all_done=1
 where=""; next=""
 if [ -n "$lowsub" ]; then                                   # §10.1 / §10.2
   where="Architecture (STEP-1) in progress — ${done_sub}/${total_sub} substeps complete."
-  if [ "$lowsub" = "1.13" ]; then
-    next="run session 1.13 — the cross-cutting review."
-  elif [[ "$lowsub" =~ [a-z]$ ]]; then
+  # Identify the cross-cutting review by its Session-column label, not a hardcoded number —
+  # adding a standard session shifts the review off 1.13. Check the lettered-conditional case
+  # first so a conditional is never mistaken for the review.
+  if [[ "$lowsub" =~ [a-z]$ ]]; then
     next="run the conditional session for substep ${lowsub} — \"${lowsub_se}\"; invoke it BY NAME (e.g. \"run the identity-auth session\"), not by number."
+  elif printf '%s' "$lowsub_se" | grep -qiE 'cross.?cutting|review'; then
+    next="run session ${lowsub} — the cross-cutting review."
   else
     next="run session ${lowsub}  (${lowsub_se})."
   fi

--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -125,7 +125,7 @@ if [ -n "$lowsub" ]; then                                   # §10.1 / §10.2
   # first so a conditional is never mistaken for the review.
   if [[ "$lowsub" =~ [a-z]$ ]]; then
     next="run the conditional session for substep ${lowsub} — \"${lowsub_se}\"; invoke it BY NAME (e.g. \"run the identity-auth session\"), not by number."
-  elif printf '%s' "$lowsub_se" | grep -qiE 'cross.?cutting|review'; then
+  elif printf '%s' "$lowsub_se" | grep -qiE 'cross.?cutting'; then
     next="run session ${lowsub} — the cross-cutting review."
   else
     next="run session ${lowsub}  (${lowsub_se})."

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
@@ -2,7 +2,9 @@
 
 > **How to run:** Tell your agent *"run session 1.5"*. It interviews you one decision at a
 > time, then writes `architecture/05-scaling-performance.md` and updates `prompts/STEP-index.md`.
-> Reads `overview.md` and `architecture/02-*` (phasing), `03-*`, `04-*` first.
+> Reads `overview.md` and `architecture/02-*` (phasing), `03-*`, `04-*` first — plus any
+> conditional-session doc relevant to scale (e.g. native-app for offline/sync load, identity-auth,
+> or one added later), if it's been written.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
 
 ## About {{PROJECT}}

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
@@ -2,7 +2,9 @@
 
 > **How to run:** Tell your agent *"run session 1.7"*. It interviews you one decision at a
 > time, then writes `architecture/07-ui-design-system.md` and updates `prompts/STEP-index.md`.
-> Reads `overview.md` and `architecture/03-*` (for the client-surfaces answer) first.
+> Reads `overview.md` and `architecture/03-*` (for the client-surfaces answer) first — plus any
+> conditional-session doc that shapes the UI (e.g. identity-auth for login/account/consent screens,
+> or one added later), if it's been written.
 >
 > **No UI?** If session 1.3 said this is API-only / a CLI with no styled UI, skip this
 > session — note "N/A, no UI" in the index and move on.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
@@ -2,7 +2,10 @@
 
 > **How to run:** Tell your agent *"run session 1.8"*. It interviews you one decision at a
 > time, then writes `architecture/08-infrastructure-deployment.md` and updates
-> `prompts/STEP-index.md`. Reads `overview.md` and `architecture/03-*`, `05-*`, `06-*` first.
+> `prompts/STEP-index.md`. Reads `overview.md` and `architecture/03-*`, `05-*`, `06-*` first — plus
+> any conditional-session doc with infra implications (e.g. privacy-compliance for data residency/
+> retention, identity-auth for secrets & session stores, native-app for build/distribution & push,
+> or one added later), if it's been written.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
 
 ## About {{PROJECT}}

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
@@ -2,7 +2,9 @@
 
 > **How to run:** Tell your agent *"run session 1.10"*. It interviews you one decision at a
 > time, then writes `architecture/10-observability.md` and updates `prompts/STEP-index.md`.
-> Reads `overview.md` and `architecture/03-*`, `05-*` first.
+> Reads `overview.md` and `architecture/03-*`, `05-*` first — plus any conditional-session doc that
+> affects what you log/alert on (e.g. identity-auth for auth-event audit logging, privacy-compliance
+> for PII-in-logs and log retention, or one added later), if it's been written.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
 
 ## About {{PROJECT}}

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -2,7 +2,10 @@
 
 > **How to run:** Tell your agent *"run session 1.11"*. It interviews you one decision at a
 > time, then writes `architecture/11-test-strategy.md` and updates `prompts/STEP-index.md`.
-> Reads `overview.md` and `architecture/03-*`, `04-*`, `09-*` first.
+> Reads `overview.md` and `architecture/03-*`, `04-*`, `09-*` first — plus any conditional-session
+> doc that adds test surface (e.g. identity-auth for authn/authz flows, privacy-compliance for
+> data-handling/retention, native-app for device/platform testing, or one added later), if it's
+> been written.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
 
 ## About {{PROJECT}}

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-glossary.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-glossary.md
@@ -21,6 +21,15 @@ language the same way. It's short, but it prevents a lot of drift.
 ## How this session works
 - This is more harvesting than interviewing: **read the architecture docs written so far**
   and pull out the terms that need definition, then confirm/refine each with the user.
+- **Sweep *every* file in `architecture/`, whatever its number — don't stop at this session's
+  own number.** New sessions get added over time, both standard and conditional, and their
+  docs are numbered as they're slotted in; conditional-session docs in particular land *after*
+  the standard range, so a sweep that assumes a fixed upper bound will miss them. Glob the
+  directory, not a numbered range. Conditional docs tend to carry the most specialized
+  vocabulary — for the conditionals that ship today, e.g. *JWT / refresh token / scope*
+  (identity-auth), *data subject / DPA / sub-processor / retention window* (privacy-compliance),
+  *deep link / push token / platform entitlement* (native-app) — but treat that as illustrative:
+  scan whatever docs exist for new domain terms and acronyms, including any added later.
 - Flag **ambiguous or overloaded words** — terms used loosely that need a single agreed
   meaning (e.g. "user" vs. "account" vs. "member"; "job" vs. "task").
 - Keep definitions tight and align entity names with the data model (1.4).

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
@@ -6,10 +6,12 @@
 > *"run the identity-auth session."* It writes `architecture/NN-identity-auth.md` (number
 > assigned in the index) and updates `prompts/STEP-index.md`.
 > **Two separate numbers:** the *substep* number (e.g. `1.6a`) marks its place in STEP-1; the
-> *doc file* number (`NN`) is the first number **after the reserved core range `01–12`** —
-> i.e. `13`, then `14` for a second conditional — **not** the lowest unused number. (This
-> session may run early, e.g. at `1.6a`, before the later core docs `07–12` exist; still take
-> `13+`, so a core session can later claim its own `07`, `08`, … without a clash.) The substep
+> *doc file* number (`NN`) is the next free number **above the reserved core-doc block** — the
+> standard sessions reserve a contiguous block at the front (today `01–12`; the current core set
+> is the session table in `METHOD.md` §4), and each conditional takes the next number above that
+> block (today `13`, then `14`, …) — **not** the lowest unused number. (This session may run
+> early, e.g. at `1.6a`, before the later core docs exist; still take the first number above the
+> core block, so a not-yet-run core session keeps its own reserved slot without a clash.) The substep
 > number and the doc number don't have to match.
 > Reads `overview.md` and `architecture/03-*`, `04-*`, `06-*` first.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-native-app.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-native-app.md
@@ -6,10 +6,12 @@
 > `architecture/NN-native-app-architecture.md` (number assigned in the index) and updates
 > `prompts/STEP-index.md`.
 > **Two separate numbers:** the *substep* number (e.g. `1.7a`) marks its place in STEP-1; the
-> *doc file* number (`NN`) is the first number **after the reserved core range `01–12`** —
-> i.e. `13`, then `14` for a second conditional — **not** the lowest unused number. (This
-> session may run before the later core docs `08–12` exist; still take `13+`, so a core
-> session can later claim its own `08`, `09`, … without a clash.) The substep number and the
+> *doc file* number (`NN`) is the next free number **above the reserved core-doc block** — the
+> standard sessions reserve a contiguous block at the front (today `01–12`; the current core set
+> is the session table in `METHOD.md` §4), and each conditional takes the next number above that
+> block (today `13`, then `14`, …) — **not** the lowest unused number. (This session may run
+> before the later core docs exist; still take the first number above the core block, so a
+> not-yet-run core session keeps its own reserved slot without a clash.) The substep number and the
 > doc number don't have to match.
 > Reads `overview.md` and `architecture/03-*` (surfaces), `04-*`, `06-*`, `07-*` first.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
@@ -8,11 +8,13 @@
 > *"run the privacy-compliance session"*). It writes `architecture/NN-privacy-compliance.md`
 > (number assigned in the index) and updates `prompts/STEP-index.md`.
 > **Two separate numbers:** the *substep* number (e.g. `1.6b`) marks its place in STEP-1; the
-> *doc file* number (`NN`) is the first number **after the reserved core range `01–12`** —
-> i.e. `13`, or the next free conditional number if another conditional already took `13`/`14`
-> — **not** the lowest unused number. (This session may run early, before the later core docs
-> `07–12` exist; still take `13+`, so a core session can later claim its own `07`, `08`, …
-> without a clash.) The substep number and the doc number don't have to match.
+> *doc file* number (`NN`) is the next free number **above the reserved core-doc block** — the
+> standard sessions reserve a contiguous block at the front (today `01–12`; the current core set
+> is the session table in `METHOD.md` §4), and each conditional takes the next number above that
+> block (today `13`, then `14`, … — or the next free one if another conditional already claimed
+> it) — **not** the lowest unused number. (This session may run early, before the later core docs
+> exist; still take the first number above the core block, so a not-yet-run core session keeps
+> its own reserved slot without a clash.) The substep number and the doc number don't have to match.
 > Reads `overview.md` and `architecture/04-*` (data model) and `06-*` (security) first.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
 


### PR DESCRIPTION
## Summary

Makes the architecture-session system **flexible to future session additions** (standard or conditional), and documents how to add one. Grew out of a review observation that several pieces hard-coded the *current* session set in ways that would silently rot when a session is added.

All changes are to the methodology/template content (Markdown) plus one read-only script (`status.sh`); no generated-project code is affected.

## What changed

1. **Glossary (1.12) sweeps the whole `architecture/` directory** instead of an implicit `01–12` range — so it harvests terms from conditional docs (numbered 13+), which carry the most specialized vocabulary (auth, privacy, native-app).

2. **Session-numbering assumptions no longer hard-code the current set:**
   - The 3 conditional sessions state their doc-numbering as a *rule* ("next free number above the reserved core-doc block") pointing to `METHOD §4` as the authority, with `01–12`/`13` marked "today" rather than fixed.
   - `status.sh` detects the cross-cutting review by its **Session-column label** (`cross-cutting`), not the literal `1.13` — so adding a standard session (which shifts the review off 1.13) no longer mislabels the new session or loses the review. Tightened to `cross-cutting` (not bare `review`) so a future "Security review"-style session isn't hijacked.

3. **Dependency-bearing sessions read relevant conditional docs when present.** Previously only the glossary and cross-cutting review read the whole hub; every other session read a fixed list of core docs by number and could never pick up a conditional. Added a "…plus any relevant conditional-session doc, if it's been written (or one added later)" clause to **1.5, 1.7, 1.8, 1.10, 1.11**, each tailored to its area (e.g. infra ← privacy data-residency; test ← authn/authz flows).

4. **`METHOD §4` "Adding a session" recipe** — documents conditional (zero-touch) vs. standard (costs a review renumber) additions, with the exact wire-in / renumber touch-points and the `grep -rn '1\.13'` command to find them.

## Verification

`status.sh` was exercised against a synthetic workspace across 6 scenarios: review at 1.13; a new standard session at 1.13 with the review shifted to 1.14 (not mislabeled); open at the shifted review; a decoy "Security review" (not hijacked); a new conditional `1.6c` (routed by-name); and a plain numbered session. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
