### PR TITLE
docs: runbook/registry indexes, secrets-rotation runbook, conditional-session naming, jargon glosses

### DIFF
--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -104,7 +104,10 @@ set lives in `templates/architecture-sessions/`.
 
 **Conditional sessions** (included only when relevant, auto-selected by the 1.3 platform
 question or by need): **Native app architecture** (mobile/desktop), **Identity & auth**,
-**Privacy, compliance & data governance** (personal or regulated data). Each is an **explicit
+**Privacy, compliance & data governance** (personal or regulated data). Run each **by name**,
+not by number — *"run the identity-auth session"* → `conditional-identity-auth.md` (likewise
+`conditional-native-app.md` and `conditional-privacy-compliance.md`) — slotted under a lettered
+substep (e.g. `1.6a`, after the related core session). Each is an **explicit
 include-or-skip decision at kickoff** — the STEP-1 PLAN records a *Conditional sessions
 considered* table marking every one Include (→ substep) or N/A (with a reason), so a skip is a
 recorded choice rather than a silent omission. (A need can also emerge *later* — a project adds

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -22,8 +22,8 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 | [`architecture/`](architecture/README.md) | *What* the system is — living, versioned design docs (indexed). |
 | [`adr/`](adr/README.md) | *Why* it's that way — point-in-time decision records (indexed). |
 | [`coding-standards/`](coding-standards/README.md) | Per-language engineering standards (indexed). |
-| [`runbooks/`](runbooks/) | Repeatable procedures — check-in, collaboration. |
-| [`registries/`](registries/) | Inventories — `repos.yml`, the map of the project's repos. |
+| [`runbooks/`](runbooks/README.md) | Repeatable procedures — check-in, release, incident, dependencies, collaboration (indexed). |
+| [`registries/`](registries/README.md) | Machine-readable inventories — `repos.yml`, the map of the project's repos (indexed). |
 | [`templates/`](templates/) | The session, STEP, and doc templates the method runs from. |
 | [`scripts/`](scripts/) | Setup helpers — e.g. `setup-workspace.sh`. |
 

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -22,7 +22,7 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 | [`architecture/`](architecture/README.md) | *What* the system is — living, versioned design docs (indexed). |
 | [`adr/`](adr/README.md) | *Why* it's that way — point-in-time decision records (indexed). |
 | [`coding-standards/`](coding-standards/README.md) | Per-language engineering standards (indexed). |
-| [`runbooks/`](runbooks/README.md) | Repeatable procedures — check-in, release, incident, dependencies, collaboration (indexed). |
+| [`runbooks/`](runbooks/README.md) | Repeatable procedures — check-in, release, incident, dependencies, secrets, collaboration (indexed). |
 | [`registries/`](registries/README.md) | Machine-readable inventories — `repos.yml`, the map of the project's repos (indexed). |
 | [`templates/`](templates/) | The session, STEP, and doc templates the method runs from. |
 | [`scripts/`](scripts/) | Setup helpers — e.g. `setup-workspace.sh`. |

--- a/Code/{{PROJECT}}-docs/registries/README.md
+++ b/Code/{{PROJECT}}-docs/registries/README.md
@@ -1,0 +1,15 @@
+# Registries
+
+Machine-readable **inventories of the project's state** — structured data, not prose. Unlike
+the other doc folders (whose README *is* the index), a registry's index is the data file
+itself, because tooling and CI parse it. Keep each file the **source of truth**; describe the
+*why/when* here and the *schema* in the file's own header — don't duplicate one in the other.
+
+## Files
+
+| File | What | Consumed by |
+|------|------|-------------|
+| [`repos.yml`](repos.yml) | The repo inventory — which repos exist, what each is, and where its docs live. See its header and `METHOD.md` §7. | `scripts/setup-workspace.sh` (clones from `remote:`); `runbooks/collaboration.md` (STEP-number reservation); CI. |
+
+New registries (e.g. an owners or services map) get a row here and their own self-documenting
+header.

--- a/Code/{{PROJECT}}-docs/runbooks/README.md
+++ b/Code/{{PROJECT}}-docs/runbooks/README.md
@@ -1,0 +1,32 @@
+# Runbooks
+
+Repeatable procedures for the recurring, higher-stakes moments that fall *outside* normal
+STEP work — checking the project's health, shipping a release, responding to an incident,
+vetting a dependency, and collaborating without collisions. Each runbook is the durable
+"how we do this" for one such moment, so the procedure doesn't get improvised under pressure.
+
+## Two kinds of runbook
+The method (`../METHOD.md`) draws a line that matters for how you *invoke* each one:
+
+- **STEP-shaped** — runs as a tracked STEP with substeps that record status in the
+  `STEP-index.md`/PLAN. Its PLAN is thin and points at the runbook; you don't author substep
+  prompts for it (the same special case as the architecture STEP — see `../prompts/README.md`).
+  The **check-in** is one; the **incident** follow-up (Parts 2–4) becomes one.
+- **Operational procedure** — *not* a STEP. You run it in the moment by telling the agent the
+  trigger phrase below, and it follows the file. The **release**, **dependency** vetting/audit,
+  and the **incident** Part-1 response are these. **Collaboration** is neither — it's reference
+  you read once when a second contributor joins.
+
+The shipped runbooks are **defaults you customize** — they deliberately leave CI/CD, release
+versioning, and ecosystem-specific commands to your team's tooling. The *discipline* is the
+durable part; fill in your project's specifics.
+
+## Index
+
+| Runbook | Purpose (one line) | When it fires | Governed by |
+|---------|--------------------|---------------|-------------|
+| [`check-in.md`](check-in.md) | Doc-drift reconciliation (both directions) + a full test run — the periodic "is the project still healthy?" gate. | A **STEP**, roughly every 10–20 STEPs; *"run the check-in."* | `METHOD.md` §5 (*Check-in STEPs*); `AGENTS.md` |
+| [`release-deploy.md`](release-deploy.md) | Ship a version safely: rollback plan **before** deploy, reversible migrations, a watch window, one clear lever back. | Operational; whenever you ship/roll back — *"run the release."* | `architecture/08-infrastructure-deployment.md`, `09-environments.md` |
+| [`incident-postmortem.md`](incident-postmortem.md) | Stabilize a production failure (Part 1), then a blameless RCA → find-similar → fix as a follow-up STEP (Parts 2–4). | Operational on an incident — *"run the incident runbook"*; follow-up is a **STEP**. | `release-deploy.md` (rollback); `METHOD.md` §5 (STEP shape) |
+| [`dependency-supply-chain.md`](dependency-supply-chain.md) | Vet a dependency **before** adding it (Part 1); audit installed deps on a cadence (Parts 2–3). | Operational; before `install`/`add` — *"vet this dependency"*; audit rides the check-in or a new advisory. | `architecture/06-security-threat-model.md` |
+| [`collaboration.md`](collaboration.md) | How more than one contributor — human or agent — works without colliding: STEP/ADR numbering, branch-per-STEP, shared-file edits. | Reference; read it when a second contributor joins (solo, mostly a no-op). | `METHOD.md` §6, §8; `AGENTS.md` (team conventions) |

--- a/Code/{{PROJECT}}-docs/runbooks/README.md
+++ b/Code/{{PROJECT}}-docs/runbooks/README.md
@@ -14,7 +14,7 @@ The method (`../METHOD.md`) draws a line that matters for how you *invoke* each 
   The **check-in** is one; the **incident** follow-up (Parts 2–4) becomes one.
 - **Operational procedure** — *not* a STEP. You run it in the moment by telling the agent the
   trigger phrase below, and it follows the file. The **release**, **dependency** vetting/audit,
-  and the **incident** Part-1 response are these. **Collaboration** is neither — it's reference
+  **secrets rotation**, and the **incident** Part-1 response are these. **Collaboration** is neither — it's reference
   you read once when a second contributor joins.
 
 The shipped runbooks are **defaults you customize** — they deliberately leave CI/CD, release
@@ -29,4 +29,5 @@ durable part; fill in your project's specifics.
 | [`release-deploy.md`](release-deploy.md) | Ship a version safely: rollback plan **before** deploy, reversible migrations, a watch window, one clear lever back. | Operational; whenever you ship/roll back — *"run the release."* | `architecture/08-infrastructure-deployment.md`, `09-environments.md` |
 | [`incident-postmortem.md`](incident-postmortem.md) | Stabilize a production failure (Part 1), then a blameless RCA → find-similar → fix as a follow-up STEP (Parts 2–4). | Operational on an incident — *"run the incident runbook"*; follow-up is a **STEP**. | `release-deploy.md` (rollback); `METHOD.md` §5 (STEP shape) |
 | [`dependency-supply-chain.md`](dependency-supply-chain.md) | Vet a dependency **before** adding it (Part 1); audit installed deps on a cadence (Parts 2–3). | Operational; before `install`/`add` — *"vet this dependency"*; audit rides the check-in or a new advisory. | `architecture/06-security-threat-model.md` |
+| [`secrets-rotation.md`](secrets-rotation.md) | Rotate secrets with no downtime on a cadence (Part 1); revoke-first emergency response to a suspected leak (Part 2). | Operational; on a cadence — *"rotate the secrets"*; on exposure — *"we may have leaked a secret."* | `architecture/06-security-threat-model.md` §5 |
 | [`collaboration.md`](collaboration.md) | How more than one contributor — human or agent — works without colliding: STEP/ADR numbering, branch-per-STEP, shared-file edits. | Reference; read it when a second contributor joins (solo, mostly a no-op). | `METHOD.md` §6, §8; `AGENTS.md` (team conventions) |

--- a/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
+++ b/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
@@ -38,7 +38,8 @@ the cause in the *system*, never who typed the command.
 > **Security incidents** that exposed data or credentials also start a **breach-notification**
 > clock from your privacy/security work (`architecture/06-security-threat-model.md`, and the
 > privacy-compliance doc if you have one). That obligation is not optional and runs independently
-> of this runbook — handle it in parallel with Part 1.
+> of this runbook — handle it in parallel with Part 1. If a **credential** was exposed, revoke and
+> rotate it now per `runbooks/secrets-rotation.md` (Part 2) as part of stabilizing.
 
 ## Part 2 — Root-cause analysis (RCA)  *(substep N.1)*
 Get past the symptom to the **cause in the system**. Ask *why* repeatedly (5 Whys) until you

--- a/Code/{{PROJECT}}-docs/runbooks/release-deploy.md
+++ b/Code/{{PROJECT}}-docs/runbooks/release-deploy.md
@@ -33,7 +33,9 @@ if it goes bad.
       shape, deploy, backfill, switch, drop the old in a *later* release). A deploy you can roll
       back sitting on a schema you can't is a trap — write down the down-path explicitly.
 - [ ] **Config & secrets for the target environment are in place** — from the secrets manager,
-      not a checked-in file (see `architecture/06-security-threat-model.md` and `08`).
+      not a checked-in file (see `architecture/06-security-threat-model.md` and `08`). Rotating a
+      credential rather than just consuming one? That's its own procedure —
+      `runbooks/secrets-rotation.md`.
 - [ ] **Rollback plan confirmed.** Write down, now, exactly how you'd undo this release (Part 4)
       and what would make you do it. If you can't state it, you're not ready to deploy.
 

--- a/Code/{{PROJECT}}-docs/runbooks/secrets-rotation.md
+++ b/Code/{{PROJECT}}-docs/runbooks/secrets-rotation.md
@@ -1,0 +1,79 @@
+# Runbook — Secrets Rotation
+
+> **How to run:** This is an **operational procedure, not a STEP** (like the release runbook),
+> with two modes:
+> - **Scheduled rotation** → run the checklist (**Part 1**) on a cadence: it rides naturally on
+>   the **check-in** (`runbooks/check-in.md`, every ~10–20 STEPs), and on each secret's own
+>   expiry/rotation interval. Tell your agent *"rotate the secrets."*
+> - **Suspected leak / exposure** → an exposed credential is an emergency: run **Part 2** *now*.
+>   Tell your agent *"we may have leaked a secret"* (or *"rotate this credential"*).
+>
+> **Optional and yours to customize.** Like the release and dependency runbooks, this leaves the
+> specific tooling to your stack (Vault, AWS/GCP Secrets Manager, Doppler, SOPS, `age`,
+> cloud-native KMS, your CI's secret store…). The *discipline* below — know what you hold, rotate
+> on a cadence with no downtime, revoke first on exposure — is the durable part; fill in your
+> project's actual commands and stores. It operationalizes the **secrets & data protection**
+> posture set in `architecture/06-security-threat-model.md` (§5).
+
+## Why this runbook exists
+Secrets are time-bombs: every API key, TLS cert, signing key, and database credential is a
+live grant that someone, someday, will copy into a log, paste into a ticket, bake into an
+image, or leave in a repo. Long-lived, never-rotated credentials are one of the most common
+ways a small mistake becomes a breach — the exposure and the discovery can be months apart, and
+a key that never changes is a key that's still valid years after it leaked. Rotation is the
+discipline that bounds that blast radius: it makes "this secret might be compromised" a routine,
+low-drama operation instead of a crisis, and it proves you can actually replace a credential
+*before* the day you must.
+
+## Part 1 — Scheduled rotation (on a cadence)
+- [ ] **Know what you hold.** Keep an inventory of the project's secrets — what each is, **who
+      owns it**, where it lives, and its rotation interval. Secrets live in a real secrets
+      manager, **never in code or the repo** (the threat model's §5 rule; local dev uses a
+      gitignored `.env` / `.secrets/`, committing only `.env.example`). You can't rotate what you
+      can't list.
+- [ ] **Set a cadence per secret class.** Rotate on an interval matched to risk — short-lived
+      tokens often (or make them auto-expiring), long-lived API keys and DB credentials on a
+      defined schedule, certificates before expiry. Prefer mechanisms that **rotate themselves**
+      (short-TTL/dynamic credentials, auto-renewed certs) over a calendar reminder a human owns.
+- [ ] **Rotate with no downtime — overlap, don't cut over.** The safe shape is **two valid
+      secrets at once**: issue the new one, deploy it to every consumer, verify everything works
+      on the new value, *then* revoke the old. A hard swap — kill the old key before the new one
+      is everywhere — is a self-inflicted outage. (Same expand/contract instinct as a reversible
+      migration in `release-deploy.md`.)
+- [ ] **Update every consumer, in every environment.** Find *all* the places that hold the
+      secret — services, CI/CD, infra-as-code, backups, partner integrations — and update them
+      per environment (`architecture/09-environments.md`). A missed consumer is exactly what
+      breaks at revoke time.
+- [ ] **Verify, then revoke the old.** Confirm the critical paths work on the new secret, then
+      **revoke/delete the old value** so a leaked copy is now worthless. A rotation that leaves
+      the old key valid hasn't actually reduced risk.
+- [ ] **Update the docs/inventory.** Record what was rotated and when, and bump any expiry the
+      inventory tracks — so the next rotation (and the next check-in) starts from the truth.
+
+## Part 2 — Suspected leak or exposure  *(emergency — do this now)*
+A secret in a log, a screenshot, a public repo, a former contributor's laptop, or a breached
+third party is **assumed compromised** — treat possible exposure as exposure.
+1. **Revoke first.** Invalidate the exposed credential *before* you investigate — the opposite
+   order from a scheduled rotation. A still-valid leaked key is an open door; close it, then ask
+   how it got open. If revoking outright would cause an outage, issue the replacement and cut
+   consumers over as fast as Part 1 allows, but treat the old one as burning.
+2. **Rotate the replacement** through the Part 1 steps (issue → distribute → verify), then ensure
+   the compromised value is fully dead everywhere.
+3. **Assess the blast radius.** What could the holder of that secret reach, and for how long was
+   it exposed? Check access logs for use you didn't make. If the secret guards anything sensitive
+   or there's any sign of misuse, **this is an incident** → switch to
+   `runbooks/incident-postmortem.md` (Part 1 to stabilize; the RCA → find-similar → fix STEP to
+   make sure the *class* of leak — e.g. secrets in logs — can't recur).
+4. **Purge the source.** Scrub the exposure where you can (rotate, don't just delete: a secret
+   committed to git history or shipped in an image is already harvested — assume it's public and
+   rely on the revoke, not the deletion).
+
+## Output / record
+Most of this is action, not documents — but leave a trail:
+- **Rotation log** — what was rotated and when — in the inventory and noted for the next
+  **check-in** (`runbooks/check-in.md`).
+- **A leak becomes an incident record** via `runbooks/incident-postmortem.md`, with a
+  *find-similar* pass for the same exposure class elsewhere.
+- **Standing policies as ADRs** — e.g. "rotate production credentials every N days," "no
+  long-lived keys where dynamic credentials are available," "secrets only from the manager" — so
+  the rule outlives the person who set it.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
@@ -37,7 +37,12 @@ UI session (1.7) and the conditional Native-app session apply.
    (independent scaling, separate teams, isolation). Flag what the choice forecloses.
 4. **Boundaries & contracts.** For each boundary between components: what crosses it (an
    API call? an event/queue? a shared DB — usually avoid), sync vs async, who owns the data
-   on each side. For any boundary that's an **API**, decide that its contract is a
+   on each side. *(Plain terms: a boundary is an **API** when the handoff crosses a network —
+   one service calling another, or an outside client calling yours — not a plain in-process
+   function call within one program. Its **contract** is the agreed shape of that call, written
+   as a machine-readable file — **OpenAPI** for REST/HTTP, a **GraphQL** schema, or
+   **protobuf**/gRPC — so both sides build against one spec instead of guessing from prose.)*
+   For any boundary that's an **API**, decide that its contract is a
    **versioned artifact** — an OpenAPI / GraphQL schema / protobuf file in the owning repo,
    not just prose — since it's what other components build against and the thing most likely
    to break them when it drifts.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
@@ -48,7 +48,9 @@ oversight.
    certs/keystores); the repo commits only a `.env.example` listing the required keys with
    placeholder values — see `templates/env-example.txt` for the full convention. The
    `.gitignore` stamped by `init.sh` already excludes these — confirm production secrets come
-   from a real secrets manager, not a checked-in file.
+   from a real secrets manager, not a checked-in file. (The rotation posture you set here is
+   operationalized in `runbooks/secrets-rotation.md` — rotating on a cadence and responding to a
+   suspected leak.)
 6. **Common web risks.** Posture on input validation, injection, XSS/CSRF, rate limiting,
    dependency vulnerabilities. What's handled by the framework vs. needs attention? (The
    dependency/supply-chain posture you set here is operationalized in

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
@@ -56,8 +56,9 @@ how a small outage becomes permanent data loss.
    Where it's cheap, prefer **graceful degradation** (read-only mode, a cached response, a
    clear "try again shortly") over a hard crash when a dependency is unavailable.
 8. **Backups & disaster recovery.** What's backed up, how often, and how long backups are
-   retained; then the two numbers that define recovery — **RPO** (how much *data loss* is
-   tolerable: minutes? a day?) and **RTO** (how long to get back *up*). The catch: **a backup
+   retained; then the two numbers that define recovery — **RPO** (*recovery point* — how much
+   *data loss* is tolerable: minutes? a day?) and **RTO** (*recovery time* — how long to get
+   back *up*). The catch: **a backup
    you have never restored is not a backup** — decide how and how often a restore is actually
    rehearsed. Even "daily DB snapshot, restore rehearsed once, ~1-day RPO / few-hour RTO"
    counts. Note who does what when it's genuinely down (the bones of a DR runbook).

--- a/Code/{{PROJECT}}-docs/templates/step-index-seed.md
+++ b/Code/{{PROJECT}}-docs/templates/step-index-seed.md
@@ -58,8 +58,15 @@ worked, and completed.
 | 1.12 | Glossary | Planned | `architecture/12-…` |
 | 1.13 | Cross-cutting review | Planned | review doc |
 
-<!-- Conditional sessions (add rows if they apply): Native app architecture (mobile/desktop);
-     Identity & auth. The 1.3 platform question decides whether the app session is needed. -->
+<!-- Conditional sessions: include-or-skip per the kickoff "Conditional sessions considered"
+     table — add a row only when one is included. Slot it under a LETTERED substep after the
+     related core session, and run it BY NAME, not number (e.g. "run the identity-auth session"
+     → conditional-identity-auth.md; likewise conditional-native-app.md,
+     conditional-privacy-compliance.md). The output doc takes the next number above the core
+     set (13+). Example row shape (a real row starts at the left margin):
+       | 1.6a | Identity & auth | Planned | architecture/13-identity-auth.md |
+     The 1.3 platform question decides whether the native-app session is needed; identity-auth
+     and privacy-compliance are included by need. -->
 
 ## How to add a STEP
 See `prompts/README.md` for the authoring recipe.


### PR DESCRIPTION
Four docs-hygiene items from `TODO.md` (the *consistency & docs hygiene* and *operational runbooks* groups). All docs-only — no code, no template logic.

## Commits

1. **`runbooks/` + `registries/` README indexes** — every other durable folder ships a README that states conventions and indexes the folder; these two were the exceptions.
   - `runbooks/README.md`: indexes all five runbooks (one-line purpose, when each fires + trigger phrase, governing METHOD/AGENTS/architecture section); splits STEP-shaped vs operational procedures.
   - `registries/README.md`: thin landing page framing registries as machine-readable state, handing off to `repos.yml`'s own header for the schema (no duplication).
   - Parent `README.md` rows now point at both indexes.

2. **`secrets-rotation` runbook** — `release-deploy.md` assumed secrets exist but nothing covered rotating them. New operational runbook (Part 1 scheduled, no-downtime overlap; Part 2 revoke-first leak response → hands off to incident). Operationalizes `06-security-threat-model.md` §5, mirroring how `dependency-supply-chain` operationalizes §6. Cross-linked from the runbooks index, release pre-flight, incident runbook, threat-model §5, and the docs-hub README.

3. **Show conditional-session naming** — AGENTS.md already mapped `"run the identity-auth session"` → `conditional-identity-auth.md`, but METHOD §4 and `step-index-seed.md` described it without showing it. Added the inline file mapping to METHOD §4 and a copyable lettered-row example to the seed (`| 1.6a | Identity & auth | Planned | architecture/13-identity-auth.md |`, kept inside the comment so it isn't a live row).

4. **Plain-language glosses (sessions 03, 08)** — 03 decision 4 named OpenAPI/GraphQL/protobuf with no gloss of when a boundary is even an API; added a plain-terms aside. 08 decision 8's RPO/RTO already had a gloss — just spelled out the acronyms.

## Notes for review
- Two TODO items were **partly stale** and I trimmed scope accordingly (surfaced in the relevant commit bodies): the AGENTS→file mapping already existed (item 3), and 08's RPO/RTO already had a plain gloss (item 4).
- The branch name reflects the first item only; it grew into four related docs-hygiene fixes.

Closes the `runbooks/README.md`, secrets-rotation, conditional-session-naming, and plain-language-sidebar items in `TODO.md` (to be ticked on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
