### PR TITLE
docs: expand coding standards (Java, C#, SQL, Shell + concurrency/idioms sweep)

### DIFF
--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -6,7 +6,7 @@ standard so the codebase stays consistent regardless of who (or which agent) wri
 
 ## How this works
 - Default standards for common languages ship with Throughstone (e.g. `python.md`,
-  `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`). **These are starting points — review and
+  `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`, `csharp.md`). **These are starting points — review and
   customize them** to match your team's preferences. Nothing here is fixed law; treat the
   shipped contents as a draft to edit, not a rule to obey.
 - You only need the file(s) for the language(s) you actually use. **Session 1.11
@@ -43,3 +43,4 @@ the rest, and customize the contents to match your team.
 | Rust | [`rust.md`](rust.md) | Default — customize |
 | Dart / Flutter | [`dart.md`](dart.md) | Default — customize |
 | Java | [`java.md`](java.md) | Default — customize |
+| C# | [`csharp.md`](csharp.md) | Default — customize |

--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -6,8 +6,9 @@ standard so the codebase stays consistent regardless of who (or which agent) wri
 
 ## How this works
 - Default standards for common languages ship with Throughstone (e.g. `python.md`,
-  `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`, `csharp.md`), plus a cross-cutting
-  `sql.md` for the SQL you write in migrations, queries, and embedded in app code. **These are starting points — review and
+  `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`, `csharp.md`), plus cross-cutting
+  `sql.md` (SQL in migrations, queries, and embedded in app code) and `shell.md` (Bash scripts —
+  CI glue, dev scripts, entrypoints). **These are starting points — review and
   customize them** to match your team's preferences. Nothing here is fixed law; treat the
   shipped contents as a draft to edit, not a rule to obey.
 - You only need the file(s) for the language(s) you actually use. **Session 1.11
@@ -46,3 +47,4 @@ the rest, and customize the contents to match your team.
 | Java | [`java.md`](java.md) | Default — customize |
 | C# | [`csharp.md`](csharp.md) | Default — customize |
 | SQL (cross-cutting) | [`sql.md`](sql.md) | Default — customize; secondary to the language docs |
+| Shell / Bash (cross-cutting) | [`shell.md`](shell.md) | Default — customize |

--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -6,7 +6,7 @@ standard so the codebase stays consistent regardless of who (or which agent) wri
 
 ## How this works
 - Default standards for common languages ship with Throughstone (e.g. `python.md`,
-  `typescript.md`, `go.md`, `rust.md`, `dart.md`). **These are starting points — review and
+  `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`). **These are starting points — review and
   customize them** to match your team's preferences. Nothing here is fixed law; treat the
   shipped contents as a draft to edit, not a rule to obey.
 - You only need the file(s) for the language(s) you actually use. **Session 1.11
@@ -42,3 +42,4 @@ the rest, and customize the contents to match your team.
 | Go | [`go.md`](go.md) | Default — customize |
 | Rust | [`rust.md`](rust.md) | Default — customize |
 | Dart / Flutter | [`dart.md`](dart.md) | Default — customize |
+| Java | [`java.md`](java.md) | Default — customize |

--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -6,7 +6,8 @@ standard so the codebase stays consistent regardless of who (or which agent) wri
 
 ## How this works
 - Default standards for common languages ship with Throughstone (e.g. `python.md`,
-  `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`, `csharp.md`). **These are starting points — review and
+  `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`, `csharp.md`), plus a cross-cutting
+  `sql.md` for the SQL you write in migrations, queries, and embedded in app code. **These are starting points — review and
   customize them** to match your team's preferences. Nothing here is fixed law; treat the
   shipped contents as a draft to edit, not a rule to obey.
 - You only need the file(s) for the language(s) you actually use. **Session 1.11
@@ -44,3 +45,4 @@ the rest, and customize the contents to match your team.
 | Dart / Flutter | [`dart.md`](dart.md) | Default — customize |
 | Java | [`java.md`](java.md) | Default — customize |
 | C# | [`csharp.md`](csharp.md) | Default — customize |
+| SQL (cross-cutting) | [`sql.md`](sql.md) | Default — customize; secondary to the language docs |

--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -6,8 +6,9 @@ standard so the codebase stays consistent regardless of who (or which agent) wri
 
 ## How this works
 - Default standards for common languages ship with Throughstone (e.g. `python.md`,
-  `typescript.md`, `go.md`, `rust.md`, `dart.md`). **They are starting points — overwrite or
-  replace them** to match your team's preferences.
+  `typescript.md`, `go.md`, `rust.md`, `dart.md`). **These are starting points — review and
+  customize them** to match your team's preferences. Nothing here is fixed law; treat the
+  shipped contents as a draft to edit, not a rule to obey.
 - You only need the file(s) for the language(s) you actually use. **Session 1.11
   (test strategy)** reconciles this directory to the languages chosen in 1.3: for each
   language it either has you *review* the standard that ships, or *create* a new one from an
@@ -32,12 +33,12 @@ enforces it.
 
 ## Files
 Defaults that ship with Throughstone. Keep the file(s) for the language(s) you use, prune
-the rest, and overwrite the contents to match your team.
+the rest, and customize the contents to match your team.
 
 | Language | File | Status |
 |----------|------|--------|
-| Python | [`python.md`](python.md) | Default — overwrite |
-| TypeScript | [`typescript.md`](typescript.md) | Default — overwrite |
-| Go | [`go.md`](go.md) | Default — overwrite |
-| Rust | [`rust.md`](rust.md) | Default — overwrite |
-| Dart / Flutter | [`dart.md`](dart.md) | Default — overwrite |
+| Python | [`python.md`](python.md) | Default — customize |
+| TypeScript | [`typescript.md`](typescript.md) | Default — customize |
+| Go | [`go.md`](go.md) | Default — customize |
+| Rust | [`rust.md`](rust.md) | Default — customize |
+| Dart / Flutter | [`dart.md`](dart.md) | Default — customize |

--- a/Code/{{PROJECT}}-docs/coding-standards/csharp.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/csharp.md
@@ -1,0 +1,95 @@
+# C# coding standards — {{PROJECT}}
+
+> **Starting point — review and customize.** These are sane defaults so code is consistent
+> from day one. Change anything that doesn't fit your team. If a rule here encodes a real
+> decision (a chosen framework, a logging library), record the *why* in an ADR and link it
+> from this file.
+
+**Baseline:** target a supported LTS release (.NET 8 or later). Follow Microsoft's
+[C# Coding Conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+and the [Framework Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/)
+for naming; the points below are where we're opinionated. Enforce style with an
+**`.editorconfig`** checked into the repo and **`dotnet format`**; enable the Roslyn
+**analyzers** with **nullable reference types on** (`<Nullable>enable</Nullable>`) and warnings
+treated as errors in CI so the standard is enforced, not just documented.
+
+## Naming
+- **PascalCase** for namespaces, types, interfaces, methods, properties, events, enum members,
+  constants, and public fields. **camelCase** for parameters and local variables. Interfaces
+  are prefixed **`I`** (`IEnumerable`); type parameters are prefixed **`T`** (`T`, `TKey`,
+  `TResult`).
+- **Private/internal instance fields are `_camelCase`** (leading underscore); static fields
+  `s_camelCase`, thread-static `t_camelCase`. `readonly` comes after `static`
+  (`static readonly`).
+- Two-letter acronyms are fully capitalized (`IOStream`); acronyms of three+ letters are
+  PascalCased (`HtmlParser`, not `HTMLParser`). Treat closed-form compounds as one word (`Id`,
+  `Email`, `Endpoint`). Async methods end in `Async`.
+- **Use the language keywords, not the BCL type names** — `int`/`string`/`float`, not
+  `Int32`/`String`/`Single` (including `int.Parse`). Avoid `this.` unless required to
+  disambiguate.
+
+## Documentation
+- **XML doc comments (`///`) on every type and member — public *and* private** (the project
+  rule — see [`README.md`](README.md)). This goes further than Microsoft's norm, which
+  documents only public members. Use `<summary>`, `<param>`, `<returns>`, and `<exception>`;
+  start the summary with a capital and end with a period. Enable doc-comment analyzers so gaps
+  are flagged in CI.
+- Use `//` for implementation comments, on their own line, explaining the *why*. Avoid `/* */`
+  blocks. A `// TODO:` includes a tracking link.
+
+## Project / file layout
+- **File-scoped namespaces** (`namespace Foo.Bar;`). Put **`using` directives outside** the
+  namespace declaration. **One top-level type per file**, named for the type.
+- Standard solution layout: one project per deployable/library, `src/` and `tests/` separated.
+  Organize by feature/domain rather than by technical layer once a project outgrows a handful
+  of types. Keep the public surface minimal — `internal` by default, `public` deliberately.
+
+## Language usage
+- **`var` only when the type is obvious from the right-hand side** (a `new`, an explicit cast,
+  or a literal). Spell out the type otherwise; don't rely on the method name to convey it.
+- Prefer **`record`** types for immutable data; make fields `readonly` and properties
+  `{ get; init; }` where possible. Use `required` properties over forcing initialization
+  through constructors.
+- Use **string interpolation** for short concatenation (`$"{first} {last}"`), **raw string
+  literals** (`"""…"""`) over escapes/verbatim, and **`StringBuilder`** for building strings in
+  loops. Use **collection expressions** (`int[] xs = [1, 2, 3];`) and **object initializers**.
+- Use expression-bodied members and pattern matching / switch expressions where they read more
+  clearly. Use `&&`/`||` (short-circuiting), not `&`/`|`, in conditions. Prefer LINQ for
+  collection transforms.
+
+## Error handling
+- Catch the **most specific** exception type; **never catch `Exception` (or `Catch`-all)
+  without a filter** you can actually handle. An empty `catch` needs a comment justifying it.
+- **Rethrow with bare `throw;`**, never `throw ex;` — the latter resets the stack trace. Use
+  exception filters (`catch (… ex) when (…)`) instead of catch-and-rethrow where possible.
+- Validate arguments and fail fast: `ArgumentNullException.ThrowIfNull(x)`,
+  `ArgumentException`. Don't use exceptions for ordinary control flow.
+- Use **`using` declarations** (`using var f = …;`) for anything `IDisposable` rather than
+  hand-written `try`/`finally`. Don't log *and* rethrow the same exception — pick one.
+
+## Logging
+- Log through **`Microsoft.Extensions.Logging`** (`ILogger<T>` via dependency injection) — not
+  `Console.WriteLine` or a concrete logger.
+- Use **structured message templates** with named placeholders, never string interpolation:
+  `logger.LogInformation("User {UserId} logged in", userId)` — the named values flow to the
+  logging backend as structured data. Pick levels deliberately
+  (Critical/Error/Warning/Information/Debug/Trace). **Never log secrets, credentials, or PII.**
+
+## Async & concurrency
+- Use **`async`/`await`** for I/O-bound work; return `Task`/`Task<T>` (or `ValueTask` on hot
+  paths) and suffix the method `Async`. **Never `async void`** except for event handlers.
+- **Don't block on async code** with `.Result` or `.Wait()` — it risks deadlocks. Flow a
+  **`CancellationToken`** through async call chains. In library code, use
+  `ConfigureAwait(false)`.
+- For shared mutable state prefer the concurrent collections and primitives in
+  `System.Collections.Concurrent` / `System.Threading` over hand-rolled locking; immutable data
+  is the simplest path to thread safety.
+
+## Testing
+- **xUnit** (or NUnit/MSTest) with **FluentAssertions** for readable assertions and a mocking
+  library (**Moq** or **NSubstitute**). Tests live in a parallel `tests/` project.
+- Name tests for the behavior under test, follow Arrange-Act-Assert, and keep them fast and
+  deterministic — no sleeps, no shared mutable state. Gate slow/integration tests behind a
+  trait/category so the unit suite stays quick.
+- Cover behavior and edge cases, not a coverage number — though ~80% unit-test coverage is a
+  reasonable guide to aim for, not a gate.

--- a/Code/{{PROJECT}}-docs/coding-standards/dart.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/dart.md
@@ -1,7 +1,7 @@
 # Dart / Flutter coding standards — {{PROJECT}}
 
-> **Starting point — overwrite this.** These are sane defaults so code is consistent from
-> day one. Replace anything that doesn't fit your team. If a rule here encodes a real
+> **Starting point — review and customize.** These are sane defaults so code is consistent from
+> day one. Change anything that doesn't fit your team. If a rule here encodes a real
 > decision (state management, a logging package), record the *why* in an ADR and link it
 > from this file.
 

--- a/Code/{{PROJECT}}-docs/coding-standards/go.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/go.md
@@ -1,7 +1,7 @@
 # Go coding standards — {{PROJECT}}
 
-> **Starting point — overwrite this.** These are sane defaults so code is consistent from
-> day one. Replace anything that doesn't fit your team. If a rule here encodes a real
+> **Starting point — review and customize.** These are sane defaults so code is consistent from
+> day one. Change anything that doesn't fit your team. If a rule here encodes a real
 > decision (a chosen framework, a logging library), record the *why* in an ADR and link it
 > from this file.
 

--- a/Code/{{PROJECT}}-docs/coding-standards/java.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/java.md
@@ -1,0 +1,93 @@
+# Java coding standards — {{PROJECT}}
+
+> **Starting point — review and customize.** These are sane defaults so code is consistent
+> from day one. Change anything that doesn't fit your team. If a rule here encodes a real
+> decision (a chosen framework, a logging backend), record the *why* in an ADR and link it
+> from this file.
+
+**Baseline:** target a supported LTS release (Java 21 or later). Follow the
+[Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) for layout and
+naming; the points below are where we're opinionated. Format with **`google-java-format`**
+(via the **Spotless** plugin) so formatting is never hand-maintained or argued in review.
+Analyze with **Error Prone**, **SpotBugs**, and **Checkstyle**, pinned in the build (Maven or
+Gradle) so the standard is enforced in CI, not just documented here.
+
+## Naming
+- `UpperCamelCase` for classes, interfaces, enums, and records (noun phrases).
+  `lowerCamelCase` for methods (verb phrases), fields, parameters, and locals. No underscores,
+  no Hungarian notation, no `m`/`s` prefixes.
+- `UPPER_SNAKE_CASE` only for `static final` constants whose contents are deeply immutable.
+  A mutable `static final` field is not a constant — name it like a field.
+- Packages: lowercase letters and digits, no underscores; concatenate words
+  (`com.example.deepspace`). Type parameters: a single capital letter, optionally with a
+  numeral (`E`, `T`, `T2`), or a descriptive name suffixed with `T` (`RequestT`).
+- Don't add `get`/`set` to things that aren't bean accessors; don't encode types in names.
+  Test classes end in `Test`.
+
+## Documentation
+- **Javadoc on every class, method, and field — public *and* private** (the project rule —
+  see [`README.md`](README.md)). This goes further than Google's norm, which requires Javadoc
+  only on visible members and exempts trivial getters and `@Override` methods. Begin with a
+  summary fragment (a capitalized noun/verb phrase, not "This method returns…"); block tags in
+  order `@param`, `@return`, `@throws`. Checkstyle can flag missing or malformed Javadoc.
+- Comment the *why* of non-obvious logic, not the *what*. A `TODO:` includes a tracking link.
+- Annotate with **`@Override` whenever it is legal** — the compiler then catches signature
+  drift. Use `@Deprecated` (and say what to use instead in the Javadoc) rather than deleting
+  public API silently.
+
+## Project / module layout
+- Standard Maven/Gradle layout: `src/main/java`, `src/test/java`, package = directory. **One
+  top-level class per file**, named for the class. No wildcard imports.
+- Package by feature/domain (`orders`, `billing`), not by layer (`controllers`, `services`)
+  once the project outgrows a handful of classes — it keeps related code together and limits
+  blast radius. Use the JPMS module system or package-private visibility to enforce
+  boundaries; expose the minimum surface.
+
+## Language & immutability
+- **Prefer immutability.** Make fields `final` by default; expose unmodifiable collections.
+  Use **`record`** for data carriers (`record Money(BigDecimal amount, Currency currency) {}`)
+  instead of hand-written getters/`equals`/`hashCode`.
+- Use **`Optional`** for return values that may be absent — never for fields or parameters,
+  and never call `.get()` without first checking. Return empty collections, not `null`.
+- Reach for modern constructs where they read more clearly: switch expressions, sealed
+  hierarchies, pattern matching for `instanceof`, text blocks. Use `var` for locals only when
+  the initializer makes the type obvious.
+- **Never override `Object.finalize`.** Use try-with-resources for anything `AutoCloseable`.
+
+## Error handling
+- Catch the **most specific** exception you can handle; never catch `Exception`/`Throwable`
+  broadly except at a top-level boundary. **Never swallow** — an empty `catch` needs a comment
+  justifying why doing nothing is correct.
+- When rethrowing, **preserve the cause**: `throw new OrderException("loading order " + id, e)`.
+  Don't discard the stack trace by re-wrapping without the cause.
+- Don't use exceptions for ordinary control flow. Validate arguments and fail fast
+  (`Objects.requireNonNull`, `IllegalArgumentException`). Prefer unchecked exceptions for
+  programming errors; reserve checked exceptions for recoverable conditions callers must handle.
+- Don't log *and* rethrow the same exception — pick one (usually rethrow; log once at the
+  boundary that handles it).
+
+## Logging
+- Log through the **SLF4J** facade with a Logback or Log4j 2 backend — never `System.out` or a
+  concrete logger directly. One `private static final Logger log = LoggerFactory.getLogger(...)`
+  per class.
+- Use **parameterized messages**, never string concatenation:
+  `log.info("user {} logged in", userId)` — the arguments are only formatted if the level is
+  enabled. To log an exception, pass it as the **last argument** so the stack trace is
+  captured: `log.error("failed to load order {}", id, e)`.
+- Pick levels deliberately (ERROR/WARN/INFO/DEBUG). **Never log secrets, credentials, or PII.**
+
+## Concurrency
+- Immutability is the best concurrency strategy — share immutable objects freely. For mutable
+  shared state, prefer **`java.util.concurrent`** (executors, concurrent collections, atomics)
+  over raw `Thread` and hand-rolled `synchronized`/`wait`/`notify`.
+- Document the thread-safety of any class designed for concurrent use. For I/O-bound
+  fan-out on Java 21+, virtual threads are the simple default.
+
+## Testing
+- **JUnit 5 (Jupiter)** with **AssertJ** for fluent assertions and **Mockito** for mocking.
+  Test classes named `FooTest`, alongside the standard `src/test/java` tree.
+- Name tests for the behavior under test (`rejectsExpiredToken`), follow Arrange-Act-Assert,
+  and keep them fast and deterministic — no sleeps, no shared mutable fixtures. Gate slow or
+  integration tests behind a tag/profile so the unit suite stays quick.
+- Cover behavior and edge cases, not a coverage number — though ~80% unit-test coverage is a
+  reasonable guide to aim for, not a gate.

--- a/Code/{{PROJECT}}-docs/coding-standards/python.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/python.md
@@ -1,7 +1,7 @@
 # Python coding standards — {{PROJECT}}
 
-> **Starting point — overwrite this.** These are sane defaults so code is consistent from
-> day one. Replace anything that doesn't fit your team. If a rule here encodes a real
+> **Starting point — review and customize.** These are sane defaults so code is consistent from
+> day one. Change anything that doesn't fit your team. If a rule here encodes a real
 > decision (a chosen framework, an error-handling pattern), record the *why* in an ADR and
 > link it from this file.
 

--- a/Code/{{PROJECT}}-docs/coding-standards/python.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/python.md
@@ -54,6 +54,24 @@ just documented.
   `ERROR` failures needing attention. Configure handlers/format once at the entrypoint, not
   in libraries. Never log secrets or PII.
 
+## Concurrency & async
+- Pick the model by workload: **`asyncio`** for I/O-bound work with many concurrent operations
+  (cooperative, single-threaded); **threads** (`threading` /
+  `concurrent.futures.ThreadPoolExecutor`) for I/O-bound work that calls blocking libraries —
+  both are bound by the **GIL**, so neither parallelizes CPU work. For **CPU-bound** work use
+  processes (`multiprocessing` / `ProcessPoolExecutor`).
+- In asyncio, **never block the event loop** — one slow call stalls every task. Offload blocking
+  or CPU-heavy work with `asyncio.to_thread(...)` (or `loop.run_in_executor`), and enter the loop
+  once at the top with `asyncio.run(main())`.
+- Prefer **structured concurrency**: run related tasks under `async with asyncio.TaskGroup()`
+  (3.11+) rather than bare `asyncio.gather` — a TaskGroup cancels its siblings when one fails and
+  surfaces errors as an `ExceptionGroup`. Bound waits with `async with asyncio.timeout(...)`.
+- For fire-and-forget `create_task`, **keep a strong reference** to the task — the loop holds only
+  a weak one, so it can be garbage-collected mid-flight and its exception silently dropped.
+- asyncio objects are **not thread-safe**: cross thread boundaries only via
+  `asyncio.run_coroutine_threadsafe` / `loop.call_soon_threadsafe`. Let `CancelledError` propagate
+  (it derives from `BaseException`) and do cleanup in `finally`.
+
 ## Testing
 - **pytest**. Tests in `tests/`, files `test_*.py` (or `*_test.py`), plain `assert`.
 - Arrange–Act–Assert; one behavior per test. Name tests for the behavior

--- a/Code/{{PROJECT}}-docs/coding-standards/python.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/python.md
@@ -36,6 +36,24 @@ just documented.
 - **Type hints** on all public APIs at minimum; fully typing new code is recommended (and
   is what the strict type-checker config above assumes).
 
+## Language idioms
+- **Prefer immutability and value types.** Use **`@dataclass`** for data-holding classes
+  (`frozen=True` when they shouldn't mutate) instead of hand-written
+  `__init__`/`__repr__`/`__eq__`; **never use a mutable default** (`[]`, `{}`) — use
+  `field(default_factory=list)`. Reach for `tuple`/`frozenset` when a value shouldn't change.
+- **EAFP over LBYL** — Python prefers "easier to ask forgiveness than permission": attempt the
+  operation and catch the exception rather than pre-checking with `if`. Guard-first (LBYL) code is
+  race-prone and less idiomatic. (Still validate at trust boundaries — see *Error handling*.)
+- Use **comprehensions** and **generator expressions** to transform iterables
+  (`[f(x) for x in xs if p(x)]`), and a generator (`yield`) for lazy or streamed sequences —
+  don't build a list with an explicit `for`-append loop when a comprehension reads clearly.
+- Manage resources with **context managers** (`with open(...) as f:`) rather than manual
+  open/close, and iterate with `enumerate`/`zip` rather than index arithmetic.
+- Follow the [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations) idioms: lean on
+  **truthiness** (`if not items:`, not `if len(items) == 0:`), compare to `None` with `is`/`is not`,
+  and use `isinstance(x, T)` not `type(x) == T`. Prefer **f-strings** for formatting (except in
+  logging — see *Logging*) and **`pathlib`** over `os.path` string munging.
+
 ## Error handling
 - Raise specific exceptions; define a small package-level hierarchy
   (`class {{PROJECT}}Error(Exception)`) and derive from it so callers can catch by domain.

--- a/Code/{{PROJECT}}-docs/coding-standards/rust.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/rust.md
@@ -1,7 +1,7 @@
 # Rust coding standards — {{PROJECT}}
 
-> **Starting point — overwrite this.** These are sane defaults so code is consistent from
-> day one. Replace anything that doesn't fit your team. If a rule here encodes a real
+> **Starting point — review and customize.** These are sane defaults so code is consistent from
+> day one. Change anything that doesn't fit your team. If a rule here encodes a real
 > decision (a chosen error or logging crate), record the *why* in an ADR and link it from
 > this file.
 

--- a/Code/{{PROJECT}}-docs/coding-standards/rust.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/rust.md
@@ -62,6 +62,20 @@ compiler's built-in lints enforce the case conventions (`clippy` adds more):
   `error` failures needing attention. Initialize the subscriber once in `main`. Never log
   secrets or PII.
 
+## Concurrency
+- Lean on **"fearless concurrency"**: the ownership model plus the `Send`/`Sync` marker traits
+  turn data races into compile errors rather than runtime bugs — let the type system carry the
+  guarantee.
+- **CPU-bound parallelism → threads** (`std::thread`, or `rayon` for data-parallel iterators).
+  **I/O-bound concurrency → async**. Prefer **message passing** (channels — `std::sync::mpsc` or
+  `crossbeam`) over shared state; when you must share, use `Arc<Mutex<T>>` / `Arc<RwLock<T>>`.
+- Async **futures are inert** — they do nothing until `.await`ed, and dropping one cancels it.
+  The standard library ships **no executor**, so you choose a runtime (**`tokio`** is the common
+  default). That choice is viral across the codebase — record it in an ADR.
+- **Don't block inside async tasks** — a blocking or CPU-heavy call stalls the executor. Offload
+  it to `tokio::task::spawn_blocking` or a dedicated thread. Spawned tasks must be `Send + 'static`;
+  move owned data in with `async move` and share it via `Arc`.
+
 ## Testing
 - Standard test framework: `#[cfg(test)] mod tests` with `#[test]` for **unit tests**
   alongside the code; **integration tests** in `tests/`; **doc tests** in `///` examples

--- a/Code/{{PROJECT}}-docs/coding-standards/shell.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/shell.md
@@ -20,8 +20,10 @@ control flow or real data structures, it's usually worth rewriting in Python/Go 
 read, and maintain. This is a guideline to weigh, not a hard gate.
 
 ## Preamble & strict mode
-- **Shebang:** `#!/usr/bin/env bash` (portable across systems where bash isn't in `/bin`, e.g.
-  macOS/Nix); the Google guide uses `#!/bin/bash`. Pick one and apply it everywhere.
+- **Shebang — a project decision; pick one and apply it everywhere.** `#!/usr/bin/env bash`
+  resolves bash via `PATH`, so it works where bash isn't in `/bin` (macOS/Homebrew, Nix);
+  `#!/bin/bash` is an absolute path (what the Google guide mandates) and avoids `PATH` surprises.
+  There's no universal default — settle it for the project (and record the why if it's not obvious).
 - Start scripts with **strict mode**: `set -euo pipefail` — exit on error, error on unset
   variables, and fail a pipeline if any stage fails. Be aware `set -e` has well-known edge cases,
   so still check explicitly any command whose failure you must handle. Set `IFS=$'\n\t'` when

--- a/Code/{{PROJECT}}-docs/coding-standards/shell.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/shell.md
@@ -1,0 +1,55 @@
+# Shell (Bash) coding standards — {{PROJECT}}
+
+> **Starting point — review and customize.** These are sane defaults so code is consistent from
+> day one. Change anything that doesn't fit your team.
+>
+> **Cross-cutting.** Shell scripts show up across the repo — CI glue, dev scripts, Docker
+> entrypoints — alongside whatever language a project is written in. Record real decisions (a
+> required interpreter, a target environment) in an ADR and link it from this file.
+
+**Baseline:** this standard targets **bash** — it is bash-specific, not portable POSIX `sh`.
+Reach for `sh`/`dash` only when a constraint requires it (e.g. a minimal Alpine image), and say
+so at the top of the script. Follow the
+[Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html); lint with
+**ShellCheck** and format with **shfmt**, both pinned in CI so the standard is enforced, not just
+documented.
+
+**Prefer a real language past simple scripts (recommendation).** Shell is best for small
+utilities and wrappers. When a script grows beyond ~100 lines, or needs non-straightforward
+control flow or real data structures, it's usually worth rewriting in Python/Go — easier to test,
+read, and maintain. This is a guideline to weigh, not a hard gate.
+
+## Preamble & strict mode
+- **Shebang:** `#!/usr/bin/env bash` (portable across systems where bash isn't in `/bin`, e.g.
+  macOS/Nix); the Google guide uses `#!/bin/bash`. Pick one and apply it everywhere.
+- Start scripts with **strict mode**: `set -euo pipefail` — exit on error, error on unset
+  variables, and fail a pipeline if any stage fails. Be aware `set -e` has well-known edge cases,
+  so still check explicitly any command whose failure you must handle. Set `IFS=$'\n\t'` when
+  word-splitting behavior matters.
+
+## Safety & quoting
+- **Always quote expansions** — `"${var}"`, `"$(cmd)"`, and `"$@"` (never `$*`). Unquoted
+  expansion causes word-splitting and glob bugs, the single most common shell defect; ShellCheck
+  flags them.
+- Use **arrays** for argument lists and iterate with `"${arr[@]}"`. Avoid **`eval`**. Use explicit
+  paths with globs (`./*`, not `*`), and don't parse the output of `ls`.
+
+## Naming & layout
+- `lower_snake_case` for variables and functions; `UPPER_SNAKE_CASE` for constants and exported
+  environment (`readonly MAX_RETRIES=3`). Declare function-local variables with **`local`**.
+- 2-space indentation (no tabs), lines ≤ 80 columns. Put `; then` / `; do` on the same line as
+  `if`/`for`/`while`, and `{` on the same line as the function name. Define functions near the top;
+  if a script has multiple functions, put the body in **`main()`** and call `main "$@"` at the end.
+
+## Commands & idioms
+- Prefer **`[[ … ]]`** over `[ … ]`/`test`; use `==` for string comparison and **`(( … ))`** for
+  arithmetic and numeric comparison (never `<`/`>` inside `[[ … ]]`). Use **`$(…)`**, not
+  backticks.
+- Prefer shell builtins over spawning external processes. Avoid aliases in scripts — use functions.
+
+## Error handling
+- Send **all error and diagnostic messages to STDERR** (`echo "..." >&2`); keep STDOUT for real
+  output. Return meaningful **exit codes** (`0` success, non-zero failure).
+- Use a **`trap … EXIT`** to clean up temp files and resources even on failure
+  (`trap 'rm -f "${tmpfile}"' EXIT`). Check return values — `if cmd; then …` or `$?` — and inspect
+  individual stages of a pipeline via the **`PIPESTATUS`** array.

--- a/Code/{{PROJECT}}-docs/coding-standards/sql.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/sql.md
@@ -1,0 +1,67 @@
+# SQL coding standards — {{PROJECT}}
+
+> **Starting point — review and customize.** These are sane defaults so code is consistent from
+> day one. Change anything that doesn't fit your team.
+>
+> **Secondary to the language standards.** SQL is cross-cutting — you write it in migrations, in
+> standalone queries, and embedded in application code. Where any rule here conflicts with a
+> language standard or its ORM/framework conventions (a column named to match a mapped field,
+> how a SQL string is formatted inside host code), **the language doc wins.** Record real
+> decisions (the chosen dialect, the migration tool) in an ADR and link it from this file.
+
+**Baseline:** there is no PEP 8 for SQL — adopt a community base (the
+[SQL Style Guide](https://www.sqlstyle.guide/) or the
+[dbt style guide](https://docs.getdbt.com/best-practices/how-we-style/2-how-we-style-our-sql))
+and enforce it with **`sqlfluff`** (lint + autoformat) configured to **your pinned dialect**
+(Postgres, MySQL, SQLite, …), pinned in CI so the standard is enforced, not just documented. The
+two base guides disagree on some points (keyword case, key naming) — pick one and let the
+formatter settle the rest.
+
+## Naming
+- `snake_case` for tables, columns, and all identifiers — never camelCase, `tbl_`/`sp_` prefixes,
+  or Hungarian notation. Begin with a letter; use only letters, digits, and underscores.
+- Pick **one** table-naming convention — plural (`customers`) or singular — and apply it
+  everywhere. Column names are singular. Don't use SQL reserved words as identifiers.
+- Decide a primary/foreign-key style and keep it consistent: e.g. an `id` PK with `<table>_id`
+  FKs (common in ORM-backed schemas) or a named key per the SQL Style Guide. Use meaningful
+  suffixes (`_id`, `_at`/`_date`, `_count`, `_status`).
+- Always alias with the explicit **`AS`** keyword. When the language/ORM dictates a name, defer to
+  it (see the header).
+
+## Formatting
+- **Let `sqlfluff` own formatting** — don't hand-argue it in review. Configure once and enforce:
+  keyword case (UPPERCASE per the SQL Style Guide, or lowercase per dbt — pick one), indentation,
+  and comma style (trailing is most common).
+- One column/clause per line in non-trivial queries; put each `JOIN` and its `ON` on their own
+  lines; break before `AND`/`OR`. Prefer **CTEs** over deeply nested subqueries for readability.
+
+## Query practices
+- **No `SELECT *`** in application or production queries — list columns explicitly so results stay
+  stable as the schema changes.
+- **Explicit join types** (`INNER JOIN`, `LEFT JOIN`) with `ON` predicates — never comma joins
+  (`FROM a, b WHERE …`). **Qualify columns with their table** when two or more tables are in play.
+- Filter and aggregate as early as possible, on the smallest dataset. Keep predicates **sargable**
+  — avoid wrapping an indexed column in a function. Verify non-trivial queries with `EXPLAIN`.
+
+## Safety
+- **Always use parameterized queries / prepared statements. Never build SQL by concatenating user
+  input** — this is the leading cause of SQL injection, and it's a hard rule, not a preference.
+  OWASP's primary defense is parameterization; see the **security-review** process for depth.
+- Run the application under a **least-privilege** database account, never an admin/superuser. Wrap
+  multi-statement changes that must succeed or fail together in a **transaction**, and keep
+  transactions short to limit lock contention.
+
+## Schema / DDL
+- Explicit column types; `NOT NULL` with sensible defaults wherever a value is required. **Enforce
+  integrity in the database** — primary keys, foreign keys, `UNIQUE`, and `CHECK` constraints — not
+  only in application code.
+- Index the columns you filter and join on, but add indexes deliberately (they cost on every
+  write). Store timestamps in UTC.
+
+## Migrations
+- Every schema change ships as a **versioned, code-reviewed migration** (Flyway, Liquibase,
+  Alembic, Rails, Prisma, … — choose per project and record it in an ADR). No ad-hoc changes
+  against a live database.
+- **Never edit a migration once it has been applied** anywhere shared — add a new one. Prefer
+  **backward-compatible** changes (expand/contract) so deploys don't need downtime, and make
+  migrations reversible (or document the rollback) where practical.

--- a/Code/{{PROJECT}}-docs/coding-standards/typescript.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/typescript.md
@@ -65,6 +65,21 @@ not just documented.
   failures needing attention. Configure the logger once at the entrypoint. Never log secrets
   or PII.
 
+## Async
+- JavaScript is single-threaded: `async`/`await` gives you **concurrency, not parallelism**. Keep
+  CPU-heavy work off the event loop — move it to **worker threads** (`node:worker_threads`); the
+  built-in async I/O already handles I/O-bound work efficiently.
+- Prefer `async`/`await` with `try/catch` over `.then()` chains; if you do chain, keep it flat and
+  don't nest. Run **independent** operations concurrently with **`Promise.all`** (fail-fast),
+  **`Promise.allSettled`** (want every outcome), `Promise.race`, or `Promise.any` — don't `await`
+  them one at a time in a loop.
+- **No floating promises** — every promise is `await`ed, returned, `.catch()`-ed, or `void`-ed
+  (see *Error handling*); `@typescript-eslint/no-floating-promises` and `no-misused-promises`
+  enforce it.
+- Make long-running async work **cancellable** with `AbortController` / `AbortSignal` (and
+  `AbortSignal.timeout(ms)` for deadlines), passing the `signal` to `fetch` and other
+  signal-aware APIs.
+
 ## Testing
 - **Vitest** (or Jest). Test files `*.test.ts`; one behavior per test, Arrange–Act–Assert.
 - Name tests for the behavior (`rejects an expired token`), not the function. Mock at

--- a/Code/{{PROJECT}}-docs/coding-standards/typescript.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/typescript.md
@@ -1,7 +1,7 @@
 # TypeScript coding standards — {{PROJECT}}
 
-> **Starting point — overwrite this.** These are sane defaults so code is consistent from
-> day one. Replace anything that doesn't fit your team. If a rule here encodes a real
+> **Starting point — review and customize.** These are sane defaults so code is consistent from
+> day one. Change anything that doesn't fit your team. If a rule here encodes a real
 > decision (a chosen framework, a module system), record the *why* in an ADR and link it
 > from this file.
 

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -58,9 +58,10 @@ where the pieces have to work *together*.
      existing standard (e.g. `coding-standards/python.md`) — same sections (naming, layout,
      error handling, logging, testing) — and fill it in with the user.
    - **Prune** the default standards for languages this project won't use.
-   - **`sql.md` is cross-cutting**, not a 1.3 implementation language: keep it if the project uses
-     a relational database (regardless of the language list), prune it if not. Its rules are
-     secondary to the language docs where they conflict.
+   - **`sql.md` and `shell.md` are cross-cutting**, not 1.3 implementation languages: keep `sql.md`
+     if the project uses a relational database, and `shell.md` if it ships shell scripts (CI glue,
+     dev scripts, entrypoints) — regardless of the language list; prune either if it doesn't apply.
+     `sql.md`'s rules are secondary to the language docs where they conflict.
 
 ## Output
 Write `architecture/11-test-strategy.md` (use `templates/architecture-doc.md`). Body:

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -51,7 +51,7 @@ where the pieces have to work *together*.
    high-level stack (1.3 decision 6). Then reconcile `coding-standards/` to that list, **one
    language at a time**:
    - **If a `coding-standards/<lang>.md` already ships** (e.g. `python.md`, `typescript.md`,
-     `go.md`, `rust.md`, `dart.md`, `java.md`): tell the user it exists as a *default starting point*,
+     `go.md`, `rust.md`, `dart.md`, `java.md`, `csharp.md`): tell the user it exists as a *default starting point*,
      and ask them to review it and flag anything they want changed for this project. Apply
      their edits.
    - **If there's no file for that language:** create one by copying the structure of an

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -58,6 +58,9 @@ where the pieces have to work *together*.
      existing standard (e.g. `coding-standards/python.md`) — same sections (naming, layout,
      error handling, logging, testing) — and fill it in with the user.
    - **Prune** the default standards for languages this project won't use.
+   - **`sql.md` is cross-cutting**, not a 1.3 implementation language: keep it if the project uses
+     a relational database (regardless of the language list), prune it if not. Its rules are
+     secondary to the language docs where they conflict.
 
 ## Output
 Write `architecture/11-test-strategy.md` (use `templates/architecture-doc.md`). Body:

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -51,7 +51,7 @@ where the pieces have to work *together*.
    high-level stack (1.3 decision 6). Then reconcile `coding-standards/` to that list, **one
    language at a time**:
    - **If a `coding-standards/<lang>.md` already ships** (e.g. `python.md`, `typescript.md`,
-     `go.md`, `rust.md`, `dart.md`): tell the user it exists as a *default starting point*,
+     `go.md`, `rust.md`, `dart.md`, `java.md`): tell the user it exists as a *default starting point*,
      and ask them to review it and flag anything they want changed for this project. Apply
      their edits.
    - **If there's no file for that language:** create one by copying the structure of an


### PR DESCRIPTION
## Summary

Expands and tightens the `coding-standards/` directory: two new language standards, two new cross-cutting standards, a missing-section sweep, and a wording cleanup. Every new doc is grounded in authoritative sources (linked below), not invented, and follows the existing file structure.

## Changes

**New language standards**
- **Java** (`java.md`) — grounded in the Google Java Style Guide + current practice (SLF4J, records/immutability, JUnit 5).
- **C#** (`csharp.md`) — grounded in Microsoft's C# Coding Conventions, the Framework Design Guidelines, and the dotnet/runtime style.

**New cross-cutting standards** (explicitly secondary to the language docs where they conflict)
- **SQL** (`sql.md`) — sqlstyle.guide + dbt style guide + OWASP (parameterize, never concatenate).
- **Shell / Bash** (`shell.md`) — Google Shell Style Guide + ShellCheck/shfmt; bash-only; "rewrite past ~100 lines" as a recommendation, not a gate; shebang left as an explicit project decision.

**Cross-cutting section sweep** — added a Concurrency/async section where it was missing (Python, Rust, TypeScript) to match Go/Java/C#, each grounded in that language's authoritative docs. Added a Language idioms section to Python (PEP 8, glossary EAFP/LBYL, dataclasses).

**Wording cleanup** — reframed the "overwrite this" framing in the README and all per-language headers to "review and customize," so the shipped standards don't read as immutable law.

**Registration** — new files registered in the coding-standards README (file list + table) and in the Session 1.11 reconcile step. Cross-cutting docs are noted as *not* 1.3 implementation languages (keep SQL if there's a relational DB, Shell if the project ships scripts; prune otherwise).

## Sources

- Java: [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- C#: [C# Coding Conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions), [Framework Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/), [dotnet/runtime style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md)
- SQL: [sqlstyle.guide](https://www.sqlstyle.guide/), [dbt style guide](https://docs.getdbt.com/best-practices/how-we-style/2-how-we-style-our-sql), [OWASP SQLi prevention](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
- Shell: [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html), [ShellCheck](https://github.com/koalaman/shellcheck)
- Concurrency: Python [asyncio](https://docs.python.org/3/library/asyncio-dev.html)/[concurrency](https://docs.python.org/3/library/concurrency.html) docs; Rust [Fearless Concurrency](https://doc.rust-lang.org/book/ch16-00-concurrency.html) + [async book](https://rust-lang.github.io/async-book/) + [tokio](https://tokio.rs/tokio/tutorial/spawning); TypeScript [MDN promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) + [typescript-eslint](https://typescript-eslint.io/rules/no-floating-promises/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
