### PR TITLE
docs: broaden all-languages doc rule to fields/properties

### DIFF
--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -22,7 +22,8 @@ standard so the codebase stays consistent regardless of who (or which agent) wri
 ## Documentation & comments  (all languages)
 A project-wide rule; each language file shows the idiomatic *form* and the lint that
 enforces it.
-- **Docstrings are required on every class, method, and function** — public *and* private.
+- **Docstrings are required on every class, method, and function** — and on fields/properties
+  where the language documents them (e.g. Java fields, C# properties) — public *and* private.
   Say what it does, its parameters and return, and anything non-obvious about its contract.
   Describe what the code **actually does**, not what you set out to write — a docstring that
   drifts from the behavior misleads worse than silence. This is a gate: code without them


### PR DESCRIPTION
## Summary

Follow-up to the coding-standards expansion (#15). The canonical **Documentation & comments (all languages)** rule in `coding-standards/README.md` named only class/method/function, but `java.md` and `csharp.md` already require doc comments on fields/properties.

Broadens the README rule to include fields/properties **where the language documents them** (e.g. Java fields, C# properties), so the single source of truth matches Java/C# and the other five languages inherit it gracefully without over-requiring docs on constructs they don't have.

Resolves the one cross-language inconsistency surfaced while reviewing how the documentation rule propagates across the standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
