### PR TITLE
docs: add cross-cutting API design coding standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). V
 refer to the **Throughstone scaffold** (the method, templates, runbooks, and tooling), not to
 any project built with it.
 
+## [Unreleased]
+
+### New cross-cutting coding standard
+- **API design** (`coding-standards/api.md`): an opinionated, customizable house style for
+  REST/HTTP APIs — resource naming, methods/status codes, RFC 3339 UTC timestamps, money as
+  integer minor units, RFC 9457 problem-details errors, idempotency, and rate limits. Three
+  genuine forks are flagged for per-project review (field casing snake_case vs. camelCase,
+  cursor vs. offset pagination, URI vs. header versioning), each with an ADR pointer.
+  Complements — doesn't replace — each API's versioned contract artifact from session 1.3.
+- **Wired in:** listed in `coding-standards/README.md` (intro + Files table) and the `METHOD.md`
+  hub gloss, reconciled by **session 1.11** as a cross-cutting standard (kept only when a 1.3
+  boundary is an HTTP/REST API the project exposes or consumes), and nudged in
+  `templates/substep-prompt.md` so any API-touching substep reads it.
+
 ## [1.2.0] - 2026-06-01
 
 A **discoverability & docs-hygiene** release: it indexes the runbook and registry folders, adds

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -68,9 +68,10 @@ Everything lives in the docs hub: `Code/{{PROJECT}}-docs/`.
   rejected, consequences. You don't edit an ADR's decision later; you write a new ADR that
   supersedes it, or append a dated amendment. There's an index at `adr/README.md`.
 
-Other folders in the hub: `coding-standards/` (per-language; defaults ship for common
-languages, and session 1.11 reconciles them to the stack you pick — review what's there,
-add what's missing, prune the rest), `runbooks/` (repeatable procedures — ships with
+Other folders in the hub: `coding-standards/` (per-language plus cross-cutting — `sql.md`,
+`shell.md`, `api.md`; defaults ship for common languages, and session 1.11 reconciles them to
+the stack you pick — review what's there, add what's missing, prune the rest), `runbooks/`
+(repeatable procedures — ships with
 `check-in.md`, `collaboration.md`, `release-deploy.md` (an optional, customizable
 deploy/rollback checklist), `incident-postmortem.md` (respond to a production incident, then
 spin up an Incident STEP to RCA → find similar → fix), and `dependency-supply-chain.md` (vet a

--- a/Code/{{PROJECT}}-docs/coding-standards/README.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/README.md
@@ -7,8 +7,9 @@ standard so the codebase stays consistent regardless of who (or which agent) wri
 ## How this works
 - Default standards for common languages ship with Throughstone (e.g. `python.md`,
   `typescript.md`, `go.md`, `rust.md`, `dart.md`, `java.md`, `csharp.md`), plus cross-cutting
-  `sql.md` (SQL in migrations, queries, and embedded in app code) and `shell.md` (Bash scripts —
-  CI glue, dev scripts, entrypoints). **These are starting points — review and
+  `sql.md` (SQL in migrations, queries, and embedded in app code), `shell.md` (Bash scripts —
+  CI glue, dev scripts, entrypoints), and `api.md` (the house style for REST/HTTP APIs —
+  timestamps, pagination, errors, versioning). **These are starting points — review and
   customize them** to match your team's preferences. Nothing here is fixed law; treat the
   shipped contents as a draft to edit, not a rule to obey.
 - You only need the file(s) for the language(s) you actually use. **Session 1.11
@@ -49,3 +50,4 @@ the rest, and customize the contents to match your team.
 | C# | [`csharp.md`](csharp.md) | Default — customize |
 | SQL (cross-cutting) | [`sql.md`](sql.md) | Default — customize; secondary to the language docs |
 | Shell / Bash (cross-cutting) | [`shell.md`](shell.md) | Default — customize |
+| API design (cross-cutting) | [`api.md`](api.md) | Default — customize; keep only if the project exposes/consumes an HTTP API |

--- a/Code/{{PROJECT}}-docs/coding-standards/api.md
+++ b/Code/{{PROJECT}}-docs/coding-standards/api.md
@@ -1,0 +1,98 @@
+# API design standards — {{PROJECT}}
+
+> **Starting point — review and customize.** These are sane, opinionated defaults so every API
+> looks the same from day one. Change anything that doesn't fit your team — a few choices below are
+> flagged as genuine forks to settle per project.
+>
+> **Cross-cutting, and complementary to the contract artifact.** Architecture session 1.3 already
+> decides that every API boundary's contract is a **versioned artifact** (OpenAPI / GraphQL schema /
+> protobuf). That artifact pins *one* API's shape; this file pins the **house style every API
+> follows** — timestamps, pagination, errors, naming, versioning — so endpoints stay consistent no
+> matter who (or which agent) writes them. Where a rule here conflicts with an **external** API you
+> must integrate with, the external API wins — you don't own it. Record real decisions (the chosen
+> pagination style, versioning scheme, casing) in an ADR and link it from this file.
+
+**Scope:** this standard targets **REST / HTTP+JSON** APIs — the common case. A **GraphQL** or
+**gRPC/protobuf** API has its own idioms (schema design, field deprecation, error models); keep the
+cross-cutting parts here (timestamps, money, versioning intent) and follow the relevant ecosystem
+guide for the rest.
+
+**Baseline:** adopt a published guide as the reference rather than re-deriving one — the
+[Google API Design Guide](https://cloud.google.com/apis/design) / [AIPs](https://google.aip.dev/),
+the [Microsoft REST API Guidelines](https://github.com/microsoft/api-guidelines), or the
+opinionated [Zalando RESTful API Guidelines](https://opensource.zalando.com/restful-api-guidelines/).
+Lint the OpenAPI spec with **[Spectral](https://github.com/stoplightio/spectral)** (the ShellCheck
+of API design — rulesets for naming, required descriptions, response shapes), pinned in CI so the
+standard is enforced, not just documented.
+
+## Resource naming & URLs
+- **Nouns, not verbs**; the HTTP method *is* the verb. `GET /orders/{id}`, not `GET /getOrder`.
+- **Plural collections**, lowercase, `kebab-case` for multi-word path segments:
+  `/shipping-addresses`, not `/shippingAddresses` or `/shipping_addresses`.
+- Model relationships by nesting one level — `/orders/{id}/items` — but avoid deep nesting; link by
+  ID past the first level. Keep query parameters for filtering/sorting/pagination, not for
+  identifying resources.
+
+## HTTP methods & status codes
+- Use methods for their defined semantics: **GET** (safe, read), **POST** (create / non-idempotent
+  action), **PUT** (full replace, idempotent), **PATCH** (partial update), **DELETE** (idempotent).
+- Return **meaningful status codes**, not `200` for everything: `201 Created` (+ `Location` header)
+  on create, `204 No Content` on an empty success, `400/401/403/404/409/422` for the matching client
+  error, `429` when rate-limited, `5xx` only for genuine server faults. Don't bury an error inside a
+  `200` body.
+
+## Field conventions
+- **Field casing — fork; pick one and apply it everywhere.** **Default: `snake_case`** (Google,
+  Zalando, JSON:API; also matches `sql.md`, reducing mapping friction). **Alternative: `camelCase`**
+  — switch if the API is consumed primarily by a JS/TS frontend and you'd rather not translate at the
+  boundary. Whatever you choose, it is **uniform across every endpoint**; record it in an ADR.
+- **Timestamps: always [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) / ISO 8601, in
+  UTC, `Z`-suffixed** — `2026-06-01T14:30:00Z`. Never epoch ints, never local time, never a custom
+  format. Name them with an `_at` suffix (`created_at`, `updated_at`) — or `_time` if you follow
+  Google's AIPs. Durations use ISO 8601 (`P3D`, `PT30S`).
+- **Money: integer minor units + an ISO 4217 currency code** (`{"amount": 1099, "currency":
+  "USD"}`) — never floats; binary floating point silently corrupts currency.
+- **Booleans read as predicates** (`is_active`, `has_items`). **Enums are lowercase strings**, not
+  magic numbers, so they're self-describing and extensible.
+- **Omit vs. null:** be consistent — prefer omitting absent fields, and document `null` only where it
+  carries meaning distinct from absence. Don't return a field as `null` in one response and absent in
+  another.
+
+## Pagination
+- **Fork; pick one.** **Default: cursor-based** — return an opaque `next` cursor (and `next` link);
+  the client passes it back as `?cursor=…`. Cursors are stable when rows are inserted or deleted
+  mid-scan, and they scale (no large `OFFSET`). **Alternative: offset/limit** (`?offset=&limit=`) —
+  simpler, allows jumping to an arbitrary page; switch if the dataset is small and bounded and users
+  need page numbers. Document the choice in an ADR.
+- **Always cap and default `limit`** (e.g. default 25, max 100) so a client can't request the world.
+  Convey links either via the **`Link` header** (`rel="next"`/`"prev"`, per
+  [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288)) **or** a consistent body envelope — pick one and
+  use it for every collection.
+
+## Errors
+- **Use [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457.html)** (obsoletes RFC
+  7807) with `Content-Type: application/problem+json`. The body carries `type`, `title`, `status`,
+  `detail`, `instance` — plus a stable, machine-readable `code` and per-field validation errors where
+  relevant. One error shape across the whole API.
+- **Never leak internals** — no stack traces, SQL, or internal hostnames in a response body.
+  Include a correlation/request ID the client can quote in a support ticket (ties to the
+  observability session). The status line and the `status` member agree.
+
+## Versioning
+- **Fork; pick one.** **Default: URI versioning** — a major version in the path (`/v1/…`). It's
+  explicit, cache- and log-friendly, and trivial to route. **Alternative: header versioning** (e.g.
+  `Accept: application/vnd.{{PROJECT}}.v1+json`) — keeps URLs clean and version-free; switch if you
+  prefer content negotiation and your clients/proxies handle custom Accept media types well. Record
+  the choice in an ADR.
+- **Bump the major only on breaking changes.** Additive changes (new optional field, new endpoint)
+  ship without a version bump — so clients **must ignore unknown fields**. Announce deprecations with
+  a timeline (and the `Deprecation`/`Sunset` headers where practical) before removing anything.
+
+## Idempotency, safety & limits
+- **Make unsafe retries safe.** For non-idempotent creates, accept an **`Idempotency-Key`** header
+  and de-dupe on it, so a client that retries after a timeout doesn't double-charge / double-create.
+- **Rate-limit** public surfaces and signal it: `429` plus `Retry-After`. Validate and bound every
+  input (sizes, lengths, ranges) at the edge.
+- **Security is not optional:** authenticate every non-public endpoint, authorize per resource, and
+  serve only over TLS. Depth lives in the security-threat-model session and the **security-review**
+  process — this file just sets the house style.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-test-strategy.md
@@ -58,10 +58,13 @@ where the pieces have to work *together*.
      existing standard (e.g. `coding-standards/python.md`) — same sections (naming, layout,
      error handling, logging, testing) — and fill it in with the user.
    - **Prune** the default standards for languages this project won't use.
-   - **`sql.md` and `shell.md` are cross-cutting**, not 1.3 implementation languages: keep `sql.md`
-     if the project uses a relational database, and `shell.md` if it ships shell scripts (CI glue,
-     dev scripts, entrypoints) — regardless of the language list; prune either if it doesn't apply.
-     `sql.md`'s rules are secondary to the language docs where they conflict.
+   - **`sql.md`, `shell.md`, and `api.md` are cross-cutting**, not 1.3 implementation languages:
+     keep `sql.md` if the project uses a relational database, `shell.md` if it ships shell scripts
+     (CI glue, dev scripts, entrypoints), and `api.md` if any boundary from 1.3 is an HTTP/REST API
+     it exposes or consumes — regardless of the language list; prune any that don't apply.
+     `sql.md`'s rules are secondary to the language docs where they conflict; `api.md` is the house
+     style that complements each API's versioned contract artifact (the OpenAPI/GraphQL/protobuf
+     spec from 1.3).
 
 ## Output
 Write `architecture/11-test-strategy.md` (use `templates/architecture-doc.md`). Body:

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt.md
@@ -20,10 +20,13 @@
        - coding-standards/README.md — the per-language standards
        - registries/repos.yml       — the repo inventory; each repo's own README is its "about"
      List the specific files this substep depends on below — including the README of each
-     repo this substep touches, read before you work in it. -->
+     repo this substep touches, read before you work in it. For any substep that adds or
+     changes an API surface (an endpoint, a request/response shape), include
+     coding-standards/api.md so the house style — timestamps, pagination, errors, versioning —
+     stays consistent across endpoints. -->
 - architecture/NN-…
 - ADR-XXXX-…
-- coding-standards/…
+- coding-standards/…  (include coding-standards/api.md for API-touching substeps)
 - <repo>/README.md  (for each repo this substep touches)
 
 ## Scope


### PR DESCRIPTION
## What

Adds a new cross-cutting coding standard, `coding-standards/api.md` — an opinionated,
"review & customize" house style for REST/HTTP APIs — and wires it into the method so it
surfaces at the right moments.

It fills a real gap: session 1.3 already establishes that every API boundary has a
**versioned contract artifact** (OpenAPI/GraphQL/protobuf), and `coding-standards/` covers
*how we write code* — but nothing covered *the house style every API follows*. That's the
dimension most likely to drift across endpoints written by different agents/people.

## The standard (`api.md`)

Matches the tone/density of `shell.md` / `sql.md`.

- **Settled defaults:** noun/plural resource naming, correct HTTP methods + status codes,
  RFC 3339 UTC timestamps, money as integer minor units, lowercase enums, RFC 9457
  problem-details errors, idempotency keys, rate limits, TLS/auth.
- **Three forks flagged** (Default → Alternative → switch if… → record in an ADR):
  - Field casing: **snake_case** vs camelCase
  - Pagination: **cursor** vs offset
  - Versioning: **URI `/v1`** vs header
- Scoped to REST; points GraphQL/gRPC to their own idioms. Baseline references Google AIPs /
  Microsoft / Zalando; enforce with Spectral in CI.

## Wiring (when/where it surfaces)

- **Reviewed once** by the user in **session 1.11**, gated on whether a session-1.3 boundary is
  an HTTP/REST API the project exposes or consumes (pruned otherwise).
- **Consulted repeatedly** by the coding agent: `substep-prompt.md` now nudges any API-touching
  substep to read it.
- Listed in `coding-standards/README.md` (intro + Files table) and the `METHOD.md` hub gloss
  ("per-language plus cross-cutting").
- Recorded under a new `[Unreleased]` CHANGELOG section.

## Files

- `coding-standards/api.md` (new)
- `coding-standards/README.md`, `METHOD.md`, `templates/architecture-sessions/11-test-strategy.md`,
  `templates/substep-prompt.md`, `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
