### PR TITLE
Calibrate prompts to user experience level

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -99,6 +99,10 @@ or find any *other* file at the workspace root, **ask whether it belongs in a re
 durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
 
 ## Ground rules
+- **Calibrate to the user's experience level.** Before asking user-facing questions or
+  explaining a decision, read `Code/{{PROJECT}}-docs/overview.md` and use the recorded
+  **Your experience level** value as the communication baseline. Keep `overview.md` as the
+  single source of truth; don't duplicate the value into STEP plans or prompts.
 - During the architecture STEP, produce **Markdown docs + ADRs only — no code**.
 - Significant decisions become **ADRs** (`Code/{{PROJECT}}-docs/templates/adr.md`); never
   rewrite an accepted ADR's decision — supersede it or append an amendment.

--- a/Code/{{PROJECT}}-docs/templates/step-plan.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan.md
@@ -15,6 +15,8 @@
 ## Decisions already locked
 <!-- Decisions from prior STEPs/ADRs that this STEP must respect. Reference by ADR number
      or architecture doc. Carrying these forward keeps a shared mental model. -->
+- `overview.md` — read **Your experience level** before user-facing questions or
+  explanations; keep that file as the single source of truth for the value.
 - ADR-XXXX — …
 - architecture/NN-… — …
 
@@ -50,6 +52,9 @@
 ## Ground rules
 <!-- The working agreement for this STEP. e.g. "no code in this STEP", commit discipline,
      what 'done' means for a substep, review gates. -->
+- **Calibrate communication from `overview.md`.** Substep prompts should read the recorded
+  **Your experience level** and adjust explanations/questions accordingly; don't copy the
+  value into this PLAN.
 - **Tests ship with the code.** Every substep that writes or changes code also writes the
   tests for it and runs the relevant tests before it's done (see
   `templates/substep-prompt.md`). Override per substep only with a stated reason.

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt.md
@@ -15,6 +15,8 @@
 ## Read these first
 <!-- Start from the main docs this substep depends on, then follow the indexes to find
      anything else relevant — don't try to read everything. The indexes point the way:
+       - overview.md                — project brief + user's experience level; calibrate
+                                      user-facing explanations/questions to it
        - architecture/README.md     — the architecture docs (what the system is)
        - adr/README.md              — the decision records (why it's that way)
        - coding-standards/README.md — the per-language standards
@@ -24,6 +26,7 @@
      changes an API surface (an endpoint, a request/response shape), include
      coding-standards/api.md so the house style — timestamps, pagination, errors, versioning —
      stays consistent across endpoints. -->
+- overview.md
 - architecture/NN-…
 - ADR-XXXX-…
 - coding-standards/…  (include coding-standards/api.md for API-touching substeps)


### PR DESCRIPTION
## Summary
- Keep overview.md as the single source of truth for the user's experience level
- Remind agents in AGENTS.md to read that value before user-facing questions/explanations
- Add overview.md to step/substep prompt guidance so fresh-context implementation work calibrates correctly

## Tests
- Not run; docs-only change