### PR TITLE
Document conservative scaffold update guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ guidance with a conservative update model for bootstrapped projects.
   upstream update catalog; the updater itself stays stateless.
 - **Three-way comparison rules** (`base` / `local` / `upstream`) and classifications:
   already-current, upstream-only, local-only, diverged, untracked, protected, and
-  manifest-invalid.
+  manifest-invalid, with baseline-unknown handling for projects that lack a trustworthy
+  install-time manifest.
 - **Mechanical risk signals** for updater reports, including script changes, git/remote-touching
   commands, CI changes, placeholder handling, status resolver changes, incomplete update groups,
   and dirty affected repos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). V
 refer to the **Throughstone scaffold** (the method, templates, runbooks, and tooling), not to
 any project built with it.
 
+## [1.4.0] - 2026-06-03
+
+A **scaffold-update process** release: it replaces the old "hand-copy upstream improvements"
+guidance with a conservative update model for bootstrapped projects.
+
+### Added
+- **Throughstone scaffold update guide** (`UPDATING-THROUGHSTONE.md`): an
+  advisory-first process for comparing a project to a newer Throughstone release, classifying
+  files by bucket, reporting risk/implications, and applying only reviewed scaffold/process
+  changes.
+- **Manifest + catalog model** for future updater tooling: project state would live in
+  `Code/{{PROJECT}}-docs/.throughstone/manifest.yml`; release implications would live in an
+  upstream update catalog; the updater itself stays stateless.
+- **Three-way comparison rules** (`base` / `local` / `upstream`) and classifications:
+  already-current, upstream-only, local-only, diverged, untracked, protected, and
+  manifest-invalid.
+- **Mechanical risk signals** for updater reports, including script changes, git/remote-touching
+  commands, CI changes, placeholder handling, status resolver changes, incomplete update groups,
+  and dirty affected repos.
+
+### Changed
+- `METHOD.md` is now **Method version 0.2 (beta)** and points scaffold updates to the new
+  guide instead of suggesting direct hand-copying.
+- The docs hub and template README now make clear that Throughstone improvements do not apply
+  automatically after bootstrap, project-owned state is protected, and even script updates need
+  review.
+
 ## [1.3.0] - 2026-06-01
 
 A **coding-standards** release: it reframes the shipped standards as customizable starting
@@ -140,6 +167,8 @@ software **architecture-first** with an AI coding agent.
   mono-repo-for-now layouts; license selection and stamping.
 - **Brand assets** and the throughstone.org documentation site.
 
+[1.4.0]: https://github.com/mherschberg/Throughstone/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/mherschberg/Throughstone/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mherschberg/Throughstone/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mherschberg/Throughstone/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mherschberg/Throughstone/releases/tag/v1.0.0

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -1,6 +1,6 @@
 # The Method
 
-**Method version: 0.1 (beta)** — still early; expect refinement, especially the collaboration layer.
+**Method version: 0.2 (beta)** — still early; expect refinement, especially the collaboration and scaffold-update layers.
 
 > Built with **Throughstone** — this file and the other scaffold files (`templates/`,
 > `runbooks/`, `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause; the full text is
@@ -371,10 +371,18 @@ concurrent work collision-free the day a second contributor arrives; see §7 and
 This file and the templates/runbooks beside it were **copied into your project** at
 bootstrap — they're yours to edit, and upstream improvements to the Throughstone
 template don't reach you automatically. Chasing them is rarely worth it, but if you ever want
-a later improvement: compare your **Method version** (top of this file) against the upstream
-template and hand-copy in the process changes you want, bumping the version when you do. Pull
-only *process* (this file, `templates/`, `runbooks/`) — never your own `architecture/`,
-`adr/`, `overview.md`, or `prompts/`.
+a later improvement, follow `UPDATING-THROUGHSTONE.md`: it compares the project against an
+upstream Throughstone release, reports what changed, and separates "can be applied without a
+text merge" from "safe." Pull only scaffold/process material — `METHOD.md`, `AGENTS.md`,
+`UPDATING-THROUGHSTONE.md`, `templates/`, `runbooks/`, `coding-standards/`, and `scripts/` —
+and only after review.
+Never auto-update your own `architecture/`, `adr/`, `overview.md`, `prompts/`, application
+code, or files stamped from templates into project repos.
+
+Treat scaffold updates as advisory by default. Scripts can change behavior, templates affect
+future generated work, and process docs can alter how contributors or agents operate. When an
+update touches method rules, agent context, collaboration/numbering, CI, multiple repos, or
+requires manual merge decisions, make it a tracked STEP and apply it on that STEP's branch.
 
 ## 10. What to do next (the next-action resolver)
 

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -19,6 +19,7 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 |------|------|
 | [`METHOD.md`](METHOD.md) | The method — read once before working here. |
 | [`AGENTS.md`](AGENTS.md) | Canonical agent context + the next-action resolver. |
+| [`UPDATING-THROUGHSTONE.md`](UPDATING-THROUGHSTONE.md) | How to compare and selectively adopt newer Throughstone scaffold/process changes after bootstrap. |
 | [`architecture/`](architecture/README.md) | *What* the system is — living, versioned design docs (indexed). |
 | [`adr/`](adr/README.md) | *Why* it's that way — point-in-time decision records (indexed). |
 | [`coding-standards/`](coding-standards/README.md) | Per-language engineering standards (indexed). |

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -25,8 +25,8 @@ multiple repos, turn it into a tracked STEP before applying it.
 - **Do not run surprise remote code.** Manual comparison does not require signatures or
   checksums. If future tooling executes downloaded updater code, pin the release/ref and verify
   it using the provenance mechanism that release publishes.
-- **Make rollback boring.** Apply updates only from a clean git state or on the branch required
-  by this guide, and keep the report with the change.
+- **Make rollback boring.** Apply updates only when every affected repo has a clean working
+  tree and index, use the branch required by this guide, and keep the report with the change.
 
 ## 2. File Buckets
 
@@ -54,7 +54,8 @@ catalog.
    from upstream.
 5. For each candidate change, write a short report: target release/ref, files reviewed,
    implication/risk, recommendation, and whether it needs a tracked STEP.
-6. Apply only the reviewed changes the user explicitly approves, then run `scripts/check.sh`.
+6. Apply only the reviewed changes the user explicitly approves, following the apply and STEP
+   rules in §8 and §10, then run `scripts/check.sh`.
 
 Manual mode is slower than tooling, but it is the default path until the manifest and catalog
 described below exist.
@@ -174,11 +175,17 @@ Classify the result:
 | **upstream-only** | `local == base`, upstream changed | Candidate for apply, still review risk. |
 | **local-only** | local changed, upstream unchanged | Keep local; no update needed. |
 | **diverged** | local changed and upstream changed | Manual review or merge; do not auto-apply. |
+| **baseline-unknown** | install-time baseline is missing or cannot be verified | Report only; require manual review before any baseline is adopted or update is applied. |
 | **untracked** | file is not in the manifest | Report only unless explicitly added to manifest. |
 | **protected** | file is project-owned or generated | Never auto-apply. |
 | **manifest-invalid** | checksum/path/ref is missing or inconsistent | Stop automatic actions; require manual comparison. |
 
 Use precise wording: **"unchanged locally"** is acceptable; **"safe to apply"** is not.
+For projects without a trustworthy install-time manifest, do not backfill the manifest by
+treating today's local files as the original base. Mark those files `baseline-unknown` unless
+their local content can be verified against a known installed upstream ref after bootstrap
+normalization, or unless the user explicitly adopts a reviewed file as the new managed
+baseline.
 
 ## 6. Mechanical Risk Signals
 
@@ -224,11 +231,13 @@ Mechanical signals do not replace the catalog; they catch omissions and force re
 Only apply when all of these are true:
 
 - user explicitly requested apply
-- affected repo has a clean git state, or the updater created the branch required below
+- every affected repo has a clean working tree and index before the updater creates or switches
+  branches and before it writes files
 - upstream release/ref was selected; any downloaded executable updater code was verified using
   the release's published provenance mechanism
 - file is not protected
-- file is either `upstream-only` or the user selected a manual merge result
+- file is either `upstream-only` with a verified baseline or the user selected a manual merge
+  result
 - all files in the required update group are included
 
 Branch rule:

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -1,0 +1,288 @@
+# Updating Throughstone
+
+Use this when you want to compare a bootstrapped project against a newer Throughstone
+template release and decide whether to bring over scaffold improvements.
+
+Trigger phrases:
+- "check for Throughstone updates"
+- "update the scaffold"
+- "compare this project to the latest Throughstone template"
+
+This is **scaffold/method maintenance**, not a created-project runbook. Runbooks cover the
+project you are building; this file covers the Throughstone machinery copied into that
+project. If an update changes method rules, agent behavior, collaboration rules, CI, or
+multiple repos, turn it into a tracked STEP before applying it.
+
+## 1. Principles
+
+- **Default to advisory.** The first action is always a report, not a write.
+- **Do not treat unchanged-local as safe.** It only means the file can be replaced without a
+  text merge; the behavioral risk may still be high.
+- **Project state is protected.** Never automatically update architecture docs, ADRs,
+  project overview, STEP history, application code, or stamped/generated repo files.
+- **The updater is stateless.** If updater tooling exists, project state lives in a manifest
+  in the docs hub; update logic may change upstream, but it must read state from disk.
+- **Do not run surprise remote code.** Manual comparison does not require signatures or
+  checksums. If future tooling executes downloaded updater code, pin the release/ref and verify
+  it using the provenance mechanism that release publishes.
+- **Make rollback boring.** Apply updates only from a clean git state or on the branch required
+  by this guide, and keep the report with the change.
+
+## 2. File Buckets
+
+| Bucket | Examples | Update policy |
+|--------|----------|---------------|
+| **Tools / scripts** | `scripts/status.sh`, `scripts/check.sh`, `scripts/setup-workspace.sh` | Review required. May be replaced when local still matches the installed baseline, but still report behavioral implications. |
+| **Process docs** | `METHOD.md`, `AGENTS.md`, `UPDATING-THROUGHSTONE.md`, `runbooks/*.md`, `coding-standards/*.md` | Review required. Changes may alter how contributors or agents work. Apply as a coherent group when files reference each other. |
+| **Templates for future use** | `templates/*.md`, `templates/architecture-sessions/*.md`, `templates/ci/*.yml` | Future-only by default. Updating them affects newly generated docs/sessions/repos; it does not rewrite existing generated outputs. |
+| **Stamped/generated files** | repo `README.md`, copied CI workflows, `.env.example`, STEP plans | Project-owned after creation. Never auto-update; provide advisory diffs only if explicitly requested. |
+| **Project state** | `overview.md`, `architecture/`, `adr/`, `prompts/`, application code repos | Never auto-update from upstream Throughstone. Changes happen through the normal method: sessions, ADRs, STEPs, and check-ins. |
+
+## 3. Manual Mode
+
+This guide works today even without updater tooling, a project manifest, or an upstream update
+catalog.
+
+1. Pick the target Throughstone release or commit from
+   `https://github.com/mherschberg/Throughstone`.
+2. Read the target release notes / `CHANGELOG.md` and identify the scaffold/process changes
+   you may want.
+3. Compare only scaffold/process material: `METHOD.md`, `AGENTS.md`,
+   `UPDATING-THROUGHSTONE.md`, `templates/`, `runbooks/`, `coding-standards/`, and
+   `scripts/`.
+4. Treat the file buckets in §2 as the authority. Never manually copy protected project state
+   from upstream.
+5. For each candidate change, write a short report: target release/ref, files reviewed,
+   implication/risk, recommendation, and whether it needs a tracked STEP.
+6. Apply only the reviewed changes the user explicitly approves, then run `scripts/check.sh`.
+
+Manual mode is slower than tooling, but it is the default path until the manifest and catalog
+described below exist.
+
+## 4. Future Tooling Artifacts
+
+A future updater should read two kinds of metadata.
+
+### Project Manifest
+
+The manifest lives in the docs hub at `Code/{{PROJECT}}-docs/.throughstone/manifest.yml`
+when viewed from the workspace root. Within the docs hub, that same path is
+`.throughstone/manifest.yml`.
+
+The default upstream source is `https://github.com/mherschberg/Throughstone`. If a project
+intentionally tracks a fork or private mirror instead, record that source in the manifest so
+future checks compare against the right upstream.
+
+```yaml
+# .throughstone/manifest.yml
+throughstone:
+  installed_version: "0.1.0"
+  installed_ref: "abc1234"
+  source: "https://github.com/mherschberg/Throughstone"
+
+files:
+  - local_path: "METHOD.md"
+    upstream_area: "docs-hub"
+    upstream_path: "METHOD.md"
+    kind: "process"
+    policy: "review"
+    installed_sha256: "..."
+
+  - local_path: "scripts/status.sh"
+    upstream_area: "docs-hub"
+    upstream_path: "scripts/status.sh"
+    kind: "script"
+    policy: "review"
+    installed_sha256: "..."
+
+  - local_path: "templates/substep-prompt.md"
+    upstream_area: "docs-hub"
+    upstream_path: "templates/substep-prompt.md"
+    kind: "template"
+    policy: "future-only"
+    installed_sha256: "..."
+```
+
+Manifest field meanings:
+
+- `local_path` is relative to the initialized docs hub. For example,
+  `Code/acme-docs/scripts/status.sh` on disk is recorded as `scripts/status.sh`.
+- `upstream_area` names the logical scaffold area in the Throughstone source. For now, this
+  guide only defines `docs-hub`, which maps to upstream `Code/{{PROJECT}}-docs/`.
+- `upstream_path` is relative to `upstream_area`. For example, `upstream_area: "docs-hub"` plus
+  `upstream_path: "scripts/status.sh"` maps to upstream
+  `Code/{{PROJECT}}-docs/scripts/status.sh`.
+- Future tooling combines `source`, `installed_ref`, `upstream_area`, and `upstream_path` to
+  find the upstream file, and combines the initialized docs hub path with `local_path` to find
+  the local file.
+
+Keep upstream identifiers placeholder-free. Do not store the initialized project slug in an
+upstream path, and do not depend on the Throughstone project-placeholder token surviving
+bootstrap; `init.sh` intentionally replaces it in file contents.
+
+The manifest is advisory state, not magic truth. If it is missing, stale, or inconsistent,
+the updater must say so and fall back to a manual comparison.
+
+### Upstream Update Catalog
+
+Once updater tooling exists, each Throughstone release should ship an update catalog:
+
+```yaml
+version: "0.2.0"
+changes:
+  - area: "docs-hub"
+    path: "scripts/setup-workspace.sh"
+    group: "workspace-setup"
+    kind: "script"
+    risk: "medium"
+    summary: "Improves repo registry parsing when only some repos have remotes."
+    implications:
+      - "Changes clone behavior for multi-repo workspaces."
+      - "Does not modify project docs or application code."
+    recommendation: "Review, then apply if setup-workspace.sh was not customized."
+
+  - area: "docs-hub"
+    path: "templates/planning-session.md"
+    group: "planning-flow"
+    kind: "template"
+    risk: "low"
+    summary: "Adds stronger CI scaffolding guidance."
+    implications:
+      - "Affects future planning sessions only."
+      - "Does not update existing STEP plans."
+    recommendation: "Update for future use."
+```
+
+Catalog entries must name implications plainly. The updater should also compute mechanical
+risk signals instead of relying only on maintainer-written summaries.
+
+## 5. Compare Model
+
+For every scaffold-managed file, compare three versions:
+
+| Version | Meaning |
+|---------|---------|
+| **base** | the file content recorded at install time, identified by `installed_sha256` |
+| **local** | the file currently in this project |
+| **upstream** | the file in the target Throughstone release |
+
+Classify the result:
+
+| Classification | Meaning | Default action |
+|----------------|---------|----------------|
+| **already-current** | `local == upstream` | Report only. |
+| **upstream-only** | `local == base`, upstream changed | Candidate for apply, still review risk. |
+| **local-only** | local changed, upstream unchanged | Keep local; no update needed. |
+| **diverged** | local changed and upstream changed | Manual review or merge; do not auto-apply. |
+| **untracked** | file is not in the manifest | Report only unless explicitly added to manifest. |
+| **protected** | file is project-owned or generated | Never auto-apply. |
+| **manifest-invalid** | checksum/path/ref is missing or inconsistent | Stop automatic actions; require manual comparison. |
+
+Use precise wording: **"unchanged locally"** is acceptable; **"safe to apply"** is not.
+
+## 6. Mechanical Risk Signals
+
+The updater should flag at least these signals:
+
+- executable bit changed
+- shell script changed
+- file contains or changes `git`, `gh`, `ssh`, `curl`, `wget`, `rm`, `mv`, `cp`, `chmod`,
+  `chown`, `sudo`, `aws`, `kubectl`, or remote URLs
+- status resolver or agent context changed (`status.sh`, `AGENTS.md`, `METHOD.md`)
+- collaboration or numbering rules changed
+- CI workflow changed
+- file deletion or rename
+- placeholder handling changed (the Throughstone project-placeholder token, generated project
+  slug, repo paths)
+- update group is incomplete
+- affected repo has uncommitted changes
+
+Mechanical signals do not replace the catalog; they catch omissions and force review.
+
+## 7. Future Tooling Check Flow
+
+1. Confirm the docs hub and workspace layout.
+2. Read `Code/{{PROJECT}}-docs/.throughstone/manifest.yml` (or
+   `.throughstone/manifest.yml` from inside the docs hub). If absent, use manual mode (§3)
+   instead.
+3. Fetch or locate the target Throughstone release metadata. If the process executes
+   downloaded updater code, pin the release/ref and verify it using the release's published
+   provenance mechanism before execution.
+4. Read the upstream update catalog.
+5. Build the three-way comparison for every manifest file.
+6. Group related changes. If a group is incomplete, mark the whole group review-required.
+7. Print a report with:
+   - classification
+   - bucket/policy
+   - risk level and mechanical risk signals
+   - human implications from the catalog
+   - whether the update is future-only, review-required, manual-merge, or protected
+8. Stop. The default tooling command must not write files.
+
+## 8. Apply Rules
+
+Only apply when all of these are true:
+
+- user explicitly requested apply
+- affected repo has a clean git state, or the updater created the branch required below
+- upstream release/ref was selected; any downloaded executable updater code was verified using
+  the release's published provenance mechanism
+- file is not protected
+- file is either `upstream-only` or the user selected a manual merge result
+- all files in the required update group are included
+
+Branch rule:
+
+- If the update meets the STEP threshold in §10, reserve a STEP and use the normal
+  `step-NNNN-short-name` branch.
+- If the update does not meet that threshold, use a dedicated scaffold-update branch so the
+  change is still reviewable and easy to roll back.
+
+This guide describes the process whether it is done manually or by future updater tooling.
+Throughstone does **not** currently ship a `throughstone-update.sh` script. If/when one is
+added, use command names that make the risk model clear, for example:
+
+```bash
+./throughstone-update.sh check
+./throughstone-update.sh diff
+./throughstone-update.sh apply --unchanged-local-only
+./throughstone-update.sh apply METHOD.md scripts/status.sh
+```
+
+Avoid names like `--safe` or `--clean-only`; they imply more certainty than the updater has.
+
+After apply:
+
+1. Recompute and write manifest checksums for updated scaffold files.
+2. Run the docs hub checks (`scripts/check.sh`).
+3. Preserve the update report in the branch or commit message.
+4. Tell the user what changed, what was skipped, and which manual review items remain.
+
+## 9. Future Root Updater Shape
+
+A future root updater may be tiny and replaceable:
+
+1. locate the docs hub
+2. read the manifest path
+3. pin the requested upstream release/ref and verify executable updater code using the
+   release's published provenance mechanism
+4. run the verified updater from a temporary location
+5. pass only project root, docs hub path, manifest path, and requested command
+
+It must not store project state outside the manifest. If the root updater itself changes,
+that update is reported and applied like any other script update.
+
+## 10. When To Make It A STEP
+
+Make a tracked STEP when the update:
+
+- changes `METHOD.md`, `AGENTS.md`, `status.sh`, collaboration rules, or STEP/ADR numbering
+- touches more than one repo
+- changes CI behavior
+- requires manual merge decisions
+- changes how future architecture sessions or planning sessions behave
+- would affect an active team
+
+The STEP's PLAN can be thin: point to this guide, list the update groups under review, and
+define done as "report reviewed, selected updates applied, checks passed, manifest refreshed,
+and skipped/protected files recorded."

--- a/Code/{{PROJECT}}-docs/runbooks/README.md
+++ b/Code/{{PROJECT}}-docs/runbooks/README.md
@@ -2,8 +2,9 @@
 
 Repeatable procedures for the recurring, higher-stakes moments that fall *outside* normal
 STEP work — checking the project's health, shipping a release, responding to an incident,
-vetting a dependency, and collaborating without collisions. Each runbook is the durable
-"how we do this" for one such moment, so the procedure doesn't get improvised under pressure.
+vetting a dependency, rotating secrets, and collaborating without collisions. Each runbook is
+the durable "how we do this" for one such moment, so the procedure doesn't get improvised
+under pressure.
 
 ## Two kinds of runbook
 The method (`../METHOD.md`) draws a line that matters for how you *invoke* each one:
@@ -14,8 +15,9 @@ The method (`../METHOD.md`) draws a line that matters for how you *invoke* each 
   The **check-in** is one; the **incident** follow-up (Parts 2–4) becomes one.
 - **Operational procedure** — *not* a STEP. You run it in the moment by telling the agent the
   trigger phrase below, and it follows the file. The **release**, **dependency** vetting/audit,
-  **secrets rotation**, and the **incident** Part-1 response are these. **Collaboration** is neither — it's reference
-  you read once when a second contributor joins.
+  **secrets rotation**, and the **incident** Part-1 response are these. **Collaboration** is
+  neither — it's reference you read once when a second contributor joins. Throughstone
+  scaffold/method updates live separately at `../UPDATING-THROUGHSTONE.md`.
 
 The shipped runbooks are **defaults you customize** — they deliberately leave CI/CD, release
 versioning, and ecosystem-specific commands to your team's tooling. The *discipline* is the

--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ your-project/                    ← workspace shell (per-machine, not a repo)
 **Start with [`Code/{{PROJECT}}-docs/METHOD.md`](Code/{{PROJECT}}-docs/METHOD.md)** to
 understand how the project is organized.
 
+## Updating after setup
+
+Throughstone is copied into your project at bootstrap; later template improvements do not
+apply automatically. That is intentional: your architecture docs, ADRs, prompts, generated
+repo files, and application code become project-owned state.
+
+If you want to compare a bootstrapped project against a newer Throughstone release, use the
+scaffold update guide in the docs hub:
+[`Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md`](Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md).
+It defines a conservative process: report first, protect project-owned files, review even
+script updates, and apply only verified scaffold/process changes. If updater tooling is added
+later, its project state belongs in `Code/{{PROJECT}}-docs/.throughstone/manifest.yml`.
+
 ## Works with any agent
 
 The methodology, prompts, and templates are plain Markdown + a Bash wizard — nothing is


### PR DESCRIPTION
## Summary
- Add UPDATING-THROUGHSTONE.md as a docs-hub guide for comparing bootstrapped projects against newer scaffold releases.
- Replace the old hand-copy guidance in METHOD.md with an advisory-first process that protects project-owned state.
- Wire the new guide into the docs hub README, root README, and changelog while keeping runbooks focused on created-project operations.

## Process details
- Defines update buckets for scripts, process docs, future-use templates, stamped/generated files, and protected project state.
- Adds a manual mode that works today without updater tooling, a manifest, or an upstream update catalog.
- Defines future updater artifacts separately: Code/{{PROJECT}}-docs/.throughstone/manifest.yml, placeholder-free upstream identifiers, and an upstream update catalog once tooling exists.
- Specifies three-way base/local/upstream comparison states, mechanical risk signals, clean-state/branch apply rules, and when scaffold updates should become a tracked STEP.
- Clarifies that signatures/checksums are not required for manual comparison; future executable updater code should be pinned and verified using the release's published provenance mechanism.
- Clarifies that Throughstone does not currently ship a throughstone-update.sh script; command examples are only a future interface sketch.

## Validation
- Ran Code/{{PROJECT}}-docs/scripts/check.sh: RESULT OK.
- Warnings are expected for this uninitialized template instance: no prompts/STEP-index.md yet.