### PR TITLE
Fix bootstrap setup review issues

### DIFF
--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -42,6 +42,16 @@ fi
 # Locate each table's columns from its header, then emit pipe-delimited records.
 parsed="$(awk -F'|' '
   function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+  {
+    if (in_comment) {
+      if ($0 ~ /-->/) in_comment = 0
+      next
+    }
+    if ($0 ~ /<!--/) {
+      if ($0 !~ /-->/) in_comment = 1
+      next
+    }
+  }
   /^[[:space:]]*\|/ {
     isstep = 0; issub = 0
     for (i = 1; i <= NF; i++) {

--- a/README.md
+++ b/README.md
@@ -97,16 +97,19 @@ things keep them approachable whatever your background:
 1. **Get the files into a folder named for your project.** The folder you download into
    **becomes your project's workspace root** — `init.sh` never renames it — so give it the
    name you want the project to have (e.g. `acme` or `MyCoolMobileApp`, not `Throughstone`). Two ways:
-   - **GitHub "Use this template" ▸ Create a new repository** (recommended — clean copy, no
-     template history). Name the new repo for your project, then clone it into a folder of
+   - **Clone this repo directly** into a project-named folder (e.g. `acme`):
+     ```bash
+     git clone https://github.com/mherschberg/Throughstone.git acme
+     cd acme
+     ```
+   - **Or use GitHub "Use this template" ▸ Create a new repository.** This is mainly useful
+     if you're choosing **mono-repo for now**; `init.sh` will reuse that repo's `origin`.
+     In the default **multi-repo** setup, the root is only a workspace shell, so the template
+     repo is just a download vehicle — use `--remotes=yes` or add remotes later for the docs
+     and prompts repos. Name the new repo for your project, then clone it into a folder of
      that name (e.g. `acme`):
      ```bash
      git clone <your-new-repo-url> acme
-     cd acme
-     ```
-   - **Or clone this repo directly** into a project-named folder (e.g. `acme`):
-     ```bash
-     git clone https://github.com/mherschberg/Throughstone.git acme
      cd acme
      ```
    Everything from here runs *inside* this folder. After setup it holds your repo(s); the

--- a/brand/site/index.html
+++ b/brand/site/index.html
@@ -179,9 +179,9 @@
       <p>Run the wizard once, then hand the project to your AI agent in plain English. It drafts your architecture and then guides you through the code creation.</p>
     </div>
     <div class="codeblock">
-<span class="c"># 1 · Use this template, then clone it into a new folder named for your project</span><br>
-<span class="c">#     (your-new-repo-url is on your new repo's green "Code" button)</span><br>
-$ git <span class="p">clone</span> &lt;your-new-repo-url&gt; my-project &amp;&amp; cd my-project<br><br>
+<span class="c"># 1 · Clone this repo into a new folder named for your project</span><br>
+$ git <span class="p">clone</span> https://github.com/mherschberg/Throughstone.git my-project &amp;&amp; cd my-project<br>
+<span class="c">#     GitHub "Use this template" is mainly for mono-repo starts; see README.</span><br><br>
 <span class="c"># 2 · Run the one-time setup wizard (asks a few questions)</span><br>
 $ ./init.sh<br><br>
 <span class="c"># 3 · Start your AI agent in that folder and send it one message:</span><br>
@@ -190,7 +190,7 @@ $ ./init.sh<br><br>
 <span class="c"># records (you review), then builds in phases → steps → substeps.</span>
     </div>
     <div class="cta">
-      <a class="btn btn-primary" href="https://github.com/mherschberg/Throughstone/generate">Use this template</a>
+      <a class="btn btn-primary" href="https://github.com/mherschberg/Throughstone#quickstart">Read full Quickstart</a>
     </div>
   </div>
 </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -179,9 +179,9 @@
       <p>Run the wizard once, then hand the project to your AI agent in plain English. It drafts your architecture and then guides you through the code creation.</p>
     </div>
     <div class="codeblock">
-<span class="c"># 1 · Use this template, then clone it into a new folder named for your project</span><br>
-<span class="c">#     (your-new-repo-url is on your new repo's green "Code" button)</span><br>
-$ git <span class="p">clone</span> &lt;your-new-repo-url&gt; my-project &amp;&amp; cd my-project<br><br>
+<span class="c"># 1 · Clone this repo into a new folder named for your project</span><br>
+$ git <span class="p">clone</span> https://github.com/mherschberg/Throughstone.git my-project &amp;&amp; cd my-project<br>
+<span class="c">#     GitHub "Use this template" is mainly for mono-repo starts; see README.</span><br><br>
 <span class="c"># 2 · Run the one-time setup wizard (asks a few questions)</span><br>
 $ ./init.sh<br><br>
 <span class="c"># 3 · Start your AI agent in that folder and send it one message:</span><br>
@@ -190,7 +190,7 @@ $ ./init.sh<br><br>
 <span class="c"># records (you review), then builds in phases → steps → substeps.</span>
     </div>
     <div class="cta">
-      <a class="btn btn-primary" href="https://github.com/mherschberg/Throughstone/generate">Use this template</a>
+      <a class="btn btn-primary" href="https://github.com/mherschberg/Throughstone#quickstart">Read full Quickstart</a>
     </div>
   </div>
 </section>

--- a/init.sh
+++ b/init.sh
@@ -221,6 +221,16 @@ if [ "$COLLAB" = "2" ]; then
   fi
 fi
 
+# Remember whether this download came from an existing project repo before we detach it.
+# Mono-repo mode can reuse that origin; multi-repo mode cannot because the root stops being
+# the project repo.
+ROOT_ORIGIN="$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)"
+ROOT_ORIGIN_IS_THROUGHSTONE=0
+case "$ROOT_ORIGIN" in
+  *github.com[:/]mherschberg/Throughstone|*github.com[:/]mherschberg/Throughstone.git)
+    ROOT_ORIGIN_IS_THROUGHSTONE=1 ;;
+esac
+
 # GitHub remotes (needs gh). Default off; --remotes=yes requires gh and an owner.
 MK_REMOTES=0; OWNER=""
 if [ -n "$REMOTES_IN" ]; then
@@ -235,7 +245,13 @@ if [ -n "$REMOTES_IN" ]; then
 elif [ "$NONINTERACTIVE" != "1" ] && command -v gh >/dev/null 2>&1 && yesno "Create GitHub remotes now (via gh)?"; then
   MK_REMOTES=1
 fi
-[ "$MK_REMOTES" = "1" ] && OWNER="$(want "$OWNER_IN" 'GitHub owner/org')"
+if [ "$MK_REMOTES" = "1" ]; then
+  if [ "$LAYOUT" = "2" ] && [ -n "$ROOT_ORIGIN" ] && [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ]; then
+    OWNER=""
+  else
+    OWNER="$(want "$OWNER_IN" 'GitHub owner/org')"
+  fi
+fi
 
 # --- 2. Untether from the template origin -----------------------------------
 say "Detaching from the template's git history..."
@@ -245,12 +261,12 @@ rm -rf "$ROOT/.git"
 # stay under it — BSD-3 clause 1 requires retaining the notice — so we DON'T delete it; it's
 # relocated into the docs hub as LICENSE-THROUGHSTONE once the hub is renamed (step 3). Your own
 # code is covered by the license you choose, stamped into each repo (step 6).
-# README.md is Throughstone's own front-door (it documents init.sh and "Use this template").
-# Once you've bootstrapped it's stale and template-specific, and in multi-repo mode it would be
-# a stray file at the non-repo workspace root, against the hygiene rule (METHOD.md §7). Drop it;
-# your project's context lives in the docs hub. (Mono-repo: add a project README yourself if you
-# want one.)
-rm -f "$ROOT/README.md"
+# README.md is Throughstone's own front-door (it documents init.sh and "Use this template"),
+# and CHANGELOG.md is Throughstone's release history. Once you've bootstrapped they're stale and
+# template-specific, and in multi-repo mode they would be stray files at the non-repo workspace
+# root, against the hygiene rule (METHOD.md §7). Drop them; your project's context lives in the
+# docs hub. (Mono-repo: add project versions yourself if you want them.)
+rm -f "$ROOT/README.md" "$ROOT/CHANGELOG.md"
 # The community/health files (CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, TRADEMARK) describe the
 # Throughstone *template* itself — its contribution policy, its trademark, its security contact.
 # They must not carry into your project (e.g. they'd leak the maintainer's contact and assert
@@ -363,12 +379,26 @@ make_remote() { # dir reponame
   ( cd "$1" && gh repo create "$OWNER/$2" --private --source=. --remote=origin --push >/dev/null \
     && echo "  remote: $OWNER/$2" ) || echo "  (skipped remote for $2)"
 }
+reuse_root_origin() { # dir
+  [ -n "$ROOT_ORIGIN" ] || return 1
+  [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ] || return 1
+  ( cd "$1" && git remote add origin "$ROOT_ORIGIN" )
+  echo "  remote: reused existing origin ($ROOT_ORIGIN)"
+  if [ "$MK_REMOTES" = "1" ]; then
+    ( cd "$1" && git push -u origin main >/dev/null \
+      && echo "  pushed: $ROOT_ORIGIN" ) || echo "  (could not push existing origin; push manually later)"
+  fi
+  return 0
+}
 
 say "Initialising git..."
 if [ "$LAYOUT" = "2" ]; then
   init_repo "."
-  make_remote "." "$SLUG"
+  reuse_root_origin "." || make_remote "." "$SLUG"
 else
+  if [ -n "$ROOT_ORIGIN" ] && [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ]; then
+    echo "  note: existing root origin is not reused in multi-repo mode; use --remotes=yes or add remotes to the docs/prompts repos later."
+  fi
   init_repo "$DOCS";     make_remote "$DOCS" "${SLUG}-docs"
   init_repo "prompts";   make_remote "prompts" "${SLUG}-prompts"
 fi


### PR DESCRIPTION
## Summary
- ignore HTML-commented example rows when status.sh parses STEP-index.md
- drop Throughstone CHANGELOG.md during bootstrap so generated projects do not inherit it
- clarify GitHub template use and reuse existing non-Throughstone origin for mono-repo setup

## Verification
- bash -n init.sh
- bash -n Code/{{PROJECT}}-docs/scripts/status.sh
- temp mono bootstrap reused a user/template origin
- temp direct Throughstone clone did not keep the Throughstone origin
- temp multi bootstrap left root non-git and initialized docs/prompts repos