### PR TITLE
Fix bootstrap review follow-ups

### DIFF
--- a/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
+++ b/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
@@ -1,4 +1,4 @@
-# Method integrity check — runs the Throughstone "doctor" (scripts/check.sh) on every push
+# Method integrity check — runs the Throughstone "doctor" on every push
 # and pull request, so structural drift fails the build instead of slipping through review:
 # duplicate STEP/ADR numbers, invalid statuses, architecture docs missing Version/Status/
 # Version-Log, and an ADR registry that disagrees with the files on disk.
@@ -10,8 +10,8 @@
 # whole workspace is checked out (locally, and during the periodic check-in).
 #
 # Mono-repo-for-now project? The workspace root is the single repo, so copy this file to the
-# ROOT `.github/workflows/` (a workflow nested under Code/<project>-docs/ won't trigger there) —
-# then check.sh sees prompts/ too and the STEP-index checks run as well. See templates/ci/README.md.
+# ROOT `.github/workflows/` (a workflow nested under Code/<project>-docs/ won't trigger there).
+# The run step below auto-detects the doctor path in either layout. See templates/ci/README.md.
 
 name: method-check
 
@@ -24,5 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run scripts/check.sh (project integrity)
-        run: bash scripts/check.sh
+      - name: Run method doctor (project integrity)
+        shell: bash
+        run: |
+          if [ -f scripts/check.sh ]; then
+            doctor=scripts/check.sh
+          else
+            shopt -s nullglob
+            candidates=(Code/*-docs/scripts/check.sh)
+            doctor="${candidates[0]:-}"
+          fi
+          if [ -z "${doctor:-}" ]; then
+            echo "No Throughstone check.sh found." >&2
+            exit 1
+          fi
+          bash "$doctor"

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
@@ -94,9 +94,10 @@ already marked skipped/N/A):
 - **1.12 Glossary** — pinning down the precise meaning of key terms
 - **1.13 Cross-cutting review** — a final pass checking it all hangs together
 
-Mention that two **conditional** sessions slot in by name when they apply — **identity & auth**
-(if there are user accounts / access control) and **native app** (if there's a mobile or
-desktop app). The roadmap session (1.2) and the index confirm which sessions are in play.
+Mention that **conditional** sessions slot in by name when they apply — **identity & auth**
+(if there are user accounts / access control), **privacy/compliance** (if there's personal or
+regulated data), and **native app** (if there's a mobile or desktop app). The roadmap session
+(1.2) and the index confirm which sessions are in play.
 
 Then point them at the next action — normally **1.2 (Phasing & roadmap)**. Tell the user to
 **start a fresh chat** and run it (*"run session 1.2"*); if the index shows a different next

--- a/Code/{{PROJECT}}-docs/templates/ci/README.md
+++ b/Code/{{PROJECT}}-docs/templates/ci/README.md
@@ -6,7 +6,7 @@ checks and the test gate the architecture's test-strategy session calls for (`ar
 
 ## 1. Method integrity — `method-check.yml`  *(ships live; no template step)*
 
-Runs the project "doctor" (`scripts/check.sh`): duplicate STEP/ADR numbers, invalid statuses,
+Runs the project "doctor" (`scripts/check.sh` in the docs hub): duplicate STEP/ADR numbers, invalid statuses,
 architecture-doc frontmatter, ADR registry vs. files on disk, root hygiene. It is **already
 installed** in the docs hub at `Code/{{PROJECT}}-docs/.github/workflows/method-check.yml`, so in a
 **multi-repo** project (the hub is its own repo) it's active the moment you push the hub — nothing
@@ -17,7 +17,8 @@ to place.
   when the whole workspace is checked out (locally and at each check-in).
 - **Mono-repo-for-now:** the workspace root is the single repo, and a workflow nested under
   `Code/<project>-docs/` does **not** trigger there — **copy** `method-check.yml` to the **root**
-  `.github/workflows/`. Then `check.sh` sees `prompts/` too, so the STEP-index checks run as well.
+  `.github/workflows/`. The workflow auto-detects `Code/<project>-docs/scripts/check.sh`;
+  from the root, that script sees `prompts/` too, so the STEP-index checks run as well.
 
 ## 2. Code-repo tests — `code-repo-ci.yml`  *(template; stamp per repo)*
 
@@ -31,6 +32,6 @@ none. Replace the `Configure me` step (which `exit 1`s) with your real setup + t
 ## Keeping it honest
 
 CI enforces what the method otherwise trusts to discipline. Pair it with the local tools:
-`scripts/status.sh` (where am I / what's next) and `scripts/check.sh` (the same checks CI runs, on
-your machine before you push). The periodic check-in (`runbooks/check-in.md`) already runs
-`check.sh` as its mechanical first pass.
+`scripts/status.sh` (where am I / what's next) and `scripts/check.sh` in the docs hub (the same
+checks CI runs, on your machine before you push). The periodic check-in (`runbooks/check-in.md`)
+already runs `check.sh` as its mechanical first pass.

--- a/init.sh
+++ b/init.sh
@@ -374,10 +374,50 @@ init_repo() { # dir
     && git branch -M main; )   # pin trunk to main (collaboration.md assumes a 'main' trunk)
   echo "  git repo: $1"
 }
-make_remote() { # dir reponame
+record_registry_remote() { # repo-name remote-url
+  local repo="$1" remote="$2" reg="$DOCS/registries/repos.yml"
+  [ -f "$reg" ] || return 0
+  REPO="$repo" REMOTE="$remote" perl -0pi -e '
+    my $remote = $ENV{REMOTE};
+    my $qremote = $remote;
+    $qremote =~ s/\\/\\\\/g;
+    $qremote =~ s/"/\\"/g;
+    s{(^[ \t]*-[ \t]*name:[ \t]*"\Q$ENV{REPO}\E"[^\n]*\n(?:(?!^[ \t]*-[ \t]*name:).)*?^[ \t]*remote:[^\n]*\n)}
+     {
+       my $block = $1;
+       $block =~ s{^[ \t]*remote:[^\n]*\n}{    remote: "$qremote"\n}m;
+       $block;
+     }ems
+    or
+    s{(^[ \t]*-[ \t]*name:[ \t]*"\Q$ENV{REPO}\E"[^\n]*\n(?:(?!^[ \t]*-[ \t]*name:).)*?^[ \t]*type:[^\n]*\n)}
+     {$1 . qq{    remote: "$qremote"\n}}ems;
+  ' "$reg"
+}
+commit_registry_remotes() {
+  local reg="$DOCS/registries/repos.yml"
   [ "$MK_REMOTES" = "1" ] || return 0
-  ( cd "$1" && gh repo create "$OWNER/$2" --private --source=. --remote=origin --push >/dev/null \
-    && echo "  remote: $OWNER/$2" ) || echo "  (skipped remote for $2)"
+  [ "$LAYOUT" = "1" ] || return 0
+  [ -f "$reg" ] || return 0
+  if git -C "$DOCS" diff --quiet -- registries/repos.yml; then
+    return 0
+  fi
+  ( cd "$DOCS" && git add registries/repos.yml && git commit -qm "Record bootstrap remotes" )
+  echo "  registry: recorded bootstrap remotes"
+  if git -C "$DOCS" remote get-url origin >/dev/null 2>&1; then
+    ( cd "$DOCS" && git push -q origin main && echo "  registry: pushed remote updates" ) \
+      || echo "  (could not push registry remote updates; push ${DOCS} manually later)"
+  fi
+}
+make_remote() { # dir reponame
+  MADE_REMOTE_URL=""
+  [ "$MK_REMOTES" = "1" ] || return 0
+  if ( cd "$1" && gh repo create "$OWNER/$2" --private --source=. --remote=origin --push >/dev/null ); then
+    MADE_REMOTE_URL="$(git -C "$1" remote get-url origin 2>/dev/null || true)"
+    echo "  remote: $OWNER/$2"
+    return 0
+  fi
+  echo "  (skipped remote for $2)"
+  return 1
 }
 reuse_root_origin() { # dir
   [ -n "$ROOT_ORIGIN" ] || return 1
@@ -399,8 +439,13 @@ else
   if [ -n "$ROOT_ORIGIN" ] && [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ]; then
     echo "  note: existing root origin is not reused in multi-repo mode; use --remotes=yes or add remotes to the docs/prompts repos later."
   fi
-  init_repo "$DOCS";     make_remote "$DOCS" "${SLUG}-docs"
-  init_repo "prompts";   make_remote "prompts" "${SLUG}-prompts"
+  init_repo "$DOCS"
+  make_remote "$DOCS" "${SLUG}-docs" \
+    && [ -n "$MADE_REMOTE_URL" ] && record_registry_remote "${SLUG}-docs" "$MADE_REMOTE_URL"
+  init_repo "prompts"
+  make_remote "prompts" "${SLUG}-prompts" \
+    && [ -n "$MADE_REMOTE_URL" ] && record_registry_remote "prompts" "$MADE_REMOTE_URL"
+  commit_registry_remotes
 fi
 
 # --- 7. Done ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Record successful bootstrap remotes in registries/repos.yml so setup-workspace can clone sibling repos.
- Make the method-check workflow locate check.sh in both multi-repo and mono-repo layouts.
- Include privacy/compliance in Session 1.1's conditional-session summary.

## Verification
- bash -n init.sh
- shellcheck init.sh
- git diff --check
- Exercised --remotes=yes with a fake gh remote and verified setup-workspace cloned prompts from repos.yml
- Verified method-check run block from docs-hub and generated mono-repo roots