### PR TITLE
Validate and preserve generated project licenses

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,6 @@ Closes #___
 
 ## Checklist
 - [ ] If I changed a script: `bash -n init.sh` and `bash -n "Code/{{PROJECT}}-docs/scripts/setup-workspace.sh"` pass
-- [ ] If I changed the wizard or templates: ran a throwaway `init.sh` smoke test and confirmed a clean generated project
+- [ ] If I changed the wizard or templates, I ran a throwaway `init.sh` smoke test and confirmed a clean generated project
 - [ ] Kept the `{{PROJECT}}` placeholder convention intact
 - [ ] Updated `METHOD.md` / `README.md` / `prompts/` for consistency where the change affects them

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -95,6 +95,14 @@ pointers are committed files; see `METHOD.md` §7.) The repos are siblings:
 entry points to a repo whose **README is its "about"** (what it is, how to set it up; plus an
 `ARCHITECTURE.md` if it has deep internals). **Before working in a repo, read its README
 first** — the same way you read the architecture docs before a design change.
+When creating an application-code repo, also apply the project-license posture recorded at
+bootstrap by running
+`Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <new-repo-path>`. The authoritative
+selection is in `Code/{{PROJECT}}-docs/.throughstone/project-license`; the helper validates
+that selection against the docs hub's canonical `LICENSE`, copies the project license unchanged
+for open-source projects, and creates no project `LICENSE` for proprietary projects. It also
+copies `LICENSE-THROUGHSTONE` because the standard generated repo retains Throughstone-authored
+README and CI scaffolding, and writes `LICENSING.md` to make those scopes explicit.
 `scripts/setup-workspace.sh` sets up a new developer's machine (clones the siblings, writes
 the root pointers).
 

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -5,7 +5,10 @@
 > Built with **Throughstone** — this file and the other scaffold files (`templates/`,
 > `runbooks/`, `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause; the full text is
 > retained as `LICENSE-THROUGHSTONE` in this docs hub. Your own application code is under the
-> license you chose at setup.
+> open-source license you chose at setup or remains private/proprietary. For open-source
+> projects, the docs hub's `LICENSE` is the canonical project-license file copied into each
+> application-code repo when that repo is created. The durable selection is recorded separately
+> in `.throughstone/project-license`, so a missing license file cannot silently change it.
 
 How projects built with this scaffold are structured. This is the canonical reference;
 the agent reads it to understand how to work. Read it once before you start.
@@ -315,7 +318,15 @@ register row. **Every repo carries a README explaining
 what it is** — its role and the slice of the system it owns — stamped from that template and
 filled in when the repo is scaffolded (with a matching one-line `description` in
 `registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
-its root for its internal design.
+its root for its internal design. **Every new application-code repo also inherits the
+project-license posture established by `init.sh`:** read the authoritative selection from the
+docs hub's `.throughstone/project-license`. For an open-source selection, the docs hub must have
+a matching canonical `LICENSE`, which is copied unchanged to the new repo root. For
+`Proprietary`, the new repo gets no project `LICENSE`. Do not copy `LICENSE-THROUGHSTONE` into
+application-code repos that contain no Throughstone-authored material. Repos scaffolded through
+this method do contain the Throughstone-authored README and CI starter, so
+`scripts/apply-project-license.sh` copies `LICENSE-THROUGHSTONE` and writes a visible
+`LICENSING.md` that distinguishes retained scaffold material from project-authored code.
 
 **All durable content lives in a repo** — almost always `Code/{{PROJECT}}-docs/`. The
 workspace root holds only **per-machine** files: the pointer `CLAUDE.md` / `AGENTS.md`

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -26,9 +26,14 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 | [`runbooks/`](runbooks/README.md) | Repeatable procedures — check-in, release, incident, dependencies, secrets, collaboration (indexed). |
 | [`registries/`](registries/README.md) | Machine-readable inventories — repo map (`repos.yml`) and accepted risk / tech-debt index (`risks.yml`) (indexed). |
 | [`templates/`](templates/) | The session, STEP, and doc templates the method runs from. |
-| [`scripts/`](scripts/) | Setup helpers — e.g. `setup-workspace.sh`. |
+| [`scripts/`](scripts/) | Setup helpers — workspace setup and project-license propagation. |
 
 > Built with **Throughstone**. The scaffold files (`METHOD.md`, `templates/`, `runbooks/`,
 > `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause — full text in
-> `LICENSE-THROUGHSTONE`. Your application code and project docs are yours, under the license
-> you chose at setup.
+> `LICENSE-THROUGHSTONE`. Your application code and project docs are yours, under the
+> open-source license you chose at setup or kept private/proprietary. For open-source projects,
+> this repo's `LICENSE` is the canonical project-license file copied unchanged into each
+> application-code repo when it is created. `.throughstone/project-license` records the durable
+> selection independently, and the repo-scaffolding helper validates the two before copying.
+> It also copies `LICENSE-THROUGHSTONE` for retained Throughstone-authored README and CI
+> templates and writes `LICENSING.md` so its limited scope is visible.

--- a/Code/{{PROJECT}}-docs/runbooks/dependency-supply-chain.md
+++ b/Code/{{PROJECT}}-docs/runbooks/dependency-supply-chain.md
@@ -33,7 +33,7 @@ liability you're taking on — and the cheapest one is the one you don't add.
       single-maintainer abandonware), and reasonably responsive on issues/security. A popular,
       maintained package is a smaller risk than a clever neglected one.
 - [ ] **License compatibility.** Check the package's license — and its transitive licenses —
-      against the license your project ships under (the one `init.sh` stamped). Copyleft
+      against your project's open-source license or proprietary distribution model. Copyleft
       (GPL/AGPL) inside a proprietary product, or an incompatible mix, is a real legal problem;
       catch it *before* the dependency is load-bearing.
 - [ ] **Security & provenance.** Any known CVEs? Is this the **canonical** package from the

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Apply the project-license posture selected during Throughstone bootstrap.
+
+set -euo pipefail
+
+DOCS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${1:-}"
+POLICY_FILE="$DOCS_ROOT/.throughstone/project-license"
+
+if [ -z "$TARGET" ]; then
+  echo "usage: $0 TARGET_REPO" >&2
+  exit 2
+fi
+if [ ! -d "$TARGET" ]; then
+  echo "apply-project-license.sh: target directory does not exist: $TARGET" >&2
+  exit 2
+fi
+
+verify_compatible() {
+  local source="$1" target="$2" label="$3"
+  if [ -e "$target" ] && ! cmp -s "$source" "$target"; then
+    echo "apply-project-license.sh: refusing to overwrite different $label: $target" >&2
+    return 1
+  fi
+}
+
+copy_if_missing() {
+  local source="$1" target="$2" label="$3"
+  if [ -e "$target" ]; then
+    echo "$label: $target (already current)"
+  else
+    cp "$source" "$target"
+    echo "$label: $target"
+  fi
+}
+
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "apply-project-license.sh: missing project-license posture: $POLICY_FILE" >&2
+  exit 1
+fi
+PROJECT_LICENSE_ID="$(cat "$POLICY_FILE")"
+case "$PROJECT_LICENSE_ID" in
+  MIT|BSD-3-Clause|Apache-2.0)
+    PROJECT_IS_OPEN_SOURCE=1
+    ;;
+  Proprietary)
+    PROJECT_IS_OPEN_SOURCE=0
+    ;;
+  *)
+    echo "apply-project-license.sh: invalid project-license posture in $POLICY_FILE: $PROJECT_LICENSE_ID" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "$DOCS_ROOT/LICENSE-THROUGHSTONE" ]; then
+  echo "apply-project-license.sh: missing Throughstone notice: $DOCS_ROOT/LICENSE-THROUGHSTONE" >&2
+  exit 1
+fi
+verify_compatible \
+  "$DOCS_ROOT/LICENSE-THROUGHSTONE" \
+  "$TARGET/LICENSE-THROUGHSTONE" \
+  "Throughstone license"
+
+if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ] && [ ! -f "$DOCS_ROOT/LICENSE" ]; then
+  echo "apply-project-license.sh: project posture is $PROJECT_LICENSE_ID, but the canonical license is missing: $DOCS_ROOT/LICENSE" >&2
+  exit 1
+fi
+if [ "$PROJECT_IS_OPEN_SOURCE" = "0" ] && [ -e "$DOCS_ROOT/LICENSE" ]; then
+  echo "apply-project-license.sh: project posture is Proprietary, but the docs hub has a project LICENSE: $DOCS_ROOT/LICENSE" >&2
+  exit 1
+fi
+
+LICENSING_SOURCE="$(mktemp "${TMPDIR:-/tmp}/throughstone-licensing.XXXXXX")"
+trap 'rm -f "$LICENSING_SOURCE"' EXIT
+if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ]; then
+  cat > "$LICENSING_SOURCE" <<EOF
+# Licensing
+
+Project-authored content in this repository is licensed under $PROJECT_LICENSE_ID. See
+\`LICENSE\` for the full project license.
+
+\`LICENSE-THROUGHSTONE\` applies only to retained Throughstone-authored scaffold material;
+it does not replace or alter the project license.
+EOF
+else
+  cat > "$LICENSING_SOURCE" <<'EOF'
+# Licensing
+
+Project-authored content in this repository is proprietary. No project `LICENSE` is
+provided, and the presence of `LICENSE-THROUGHSTONE` does not grant permission to copy,
+modify, or distribute the project's application code.
+
+`LICENSE-THROUGHSTONE` applies only to retained Throughstone-authored scaffold material.
+EOF
+fi
+verify_compatible "$LICENSING_SOURCE" "$TARGET/LICENSING.md" "licensing summary"
+
+if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ]; then
+  verify_compatible "$DOCS_ROOT/LICENSE" "$TARGET/LICENSE" "project license"
+elif [ -e "$TARGET/LICENSE" ]; then
+  echo "apply-project-license.sh: project is proprietary, but target already has LICENSE: $TARGET/LICENSE" >&2
+  exit 1
+fi
+
+copy_if_missing \
+  "$DOCS_ROOT/LICENSE-THROUGHSTONE" \
+  "$TARGET/LICENSE-THROUGHSTONE" \
+  "Throughstone license"
+copy_if_missing "$LICENSING_SOURCE" "$TARGET/LICENSING.md" "licensing summary"
+
+if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ]; then
+  copy_if_missing "$DOCS_ROOT/LICENSE" "$TARGET/LICENSE" "project license"
+else
+  echo "project license: proprietary (no LICENSE created)"
+fi

--- a/Code/{{PROJECT}}-docs/templates/licenses/Proprietary.txt
+++ b/Code/{{PROJECT}}-docs/templates/licenses/Proprietary.txt
@@ -1,8 +1,0 @@
-Copyright (c) {{YEAR}} {{HOLDER}}
-All rights reserved.
-
-This software and its source code are proprietary and confidential.
-
-Unauthorized copying, distribution, modification, or use of this software,
-in whole or in part, by any means or in any medium, is strictly prohibited
-without the express prior written permission of the copyright holder.

--- a/Code/{{PROJECT}}-docs/templates/licenses/README.md
+++ b/Code/{{PROJECT}}-docs/templates/licenses/README.md
@@ -1,18 +1,22 @@
 # License templates
 
-Source text for the license that `init.sh` stamps into your project repo(s). Each file uses
-two placeholders that `init.sh` fills in: `{{YEAR}}` and `{{HOLDER}}` (the copyright holder).
+Source text for the open-source license that `init.sh` stamps into your project repo(s).
+Each file uses two placeholders that `init.sh` fills in: `{{YEAR}}` and `{{HOLDER}}` (the
+copyright holder).
 
 `init.sh` first asks whether the project is **open source** or **private/proprietary**.
-Open source then picks one of the three permissive licenses; private stamps the proprietary
-notice. Either way the filled text is written to `LICENSE` in each repo.
+Open source then picks one of the three permissive licenses and writes the filled text to
+`LICENSE` in the bootstrap repos. The docs hub's copy is canonical and is copied unchanged
+into each application-code repo when that repo is created later. The selection is also recorded
+as a validated token in `.throughstone/project-license`; the propagation helper fails if an
+open-source selection's canonical `LICENSE` is missing. Private projects record `Proprietary`
+and do not get a project `LICENSE` file.
 
 | File | License | When `init.sh` uses it |
 |------|---------|------------------------|
 | `MIT.txt` | MIT | Open source → MIT. Permissive, simplest; a good default. |
 | `BSD-3-Clause.txt` | BSD 3-Clause | Open source → BSD-3. Permissive, plus a name-endorsement protection clause. |
 | `Apache-2.0.txt` | Apache License 2.0 | Open source → Apache. Permissive, with an explicit patent grant; common for larger/commercial OSS. |
-| `Proprietary.txt` | Proprietary / all rights reserved | Private/proprietary projects. An explicit "all rights reserved" notice. |
 
 To use a different license, drop its text here as `<name>.txt` (with the same placeholders)
 and add a branch in `init.sh`, or just add the `LICENSE` to your repo by hand.

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -55,7 +55,18 @@ architecture changes and the remaining STEPs need re-planning.
    named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each repo as its
    `.env.example`, and adding a **stack-appropriate `.gitignore`** to each new code repo
    (language/build artifacts — `node_modules/`, `__pycache__/`, `target/`, `dist/`, … — plus
-   the `.env` / `.secrets/` secret-file block so local secrets never get committed). **Each
+   the `.env` / `.secrets/` secret-file block so local secrets never get committed). Apply the
+   project-license posture too: run
+   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <new-repo-path>` for every new code
+   repo. It reads `.throughstone/project-license`, requires the canonical docs-hub `LICENSE`
+   for an open-source selection, and copies that file unchanged. For `Proprietary`, no project
+   `LICENSE` is created. It also copies `LICENSE-THROUGHSTONE`, because the standard repo README
+   and CI starter are retained Throughstone-authored scaffold material, and writes
+   `LICENSING.md` to make clear that notice is not the application-code license. Repository
+   visibility is separate: when adding a remote for each code repo, choose private or public
+   deliberately rather than inferring it from the license. Publishing a proprietary repo makes
+   its source visible without granting open-source reuse rights, so call that out explicitly.
+   **Each
    repo's README isn't just stamped — its role one-liner and Overview get filled in** (what
    the repo is and the slice of the system it owns), and the repo gets a row in
    `registries/repos.yml` with a one-line `description`; a repo isn't scaffolded until it can

--- a/Code/{{PROJECT}}-docs/templates/repo-readme.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme.md
@@ -13,6 +13,13 @@
   Stamp the CI gate named by the Test Strategy architecture doc too: drop
   `templates/ci/code-repo-ci.yml` into this repo's `.github/workflows/ci.yml` and fill in its
   stack's test command (see `templates/ci/README.md`).
+
+  Apply the project license established at bootstrap by running
+  `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <this-repo-path>`. It copies the
+  docs hub's canonical `LICENSE` unchanged for open-source projects. Proprietary projects
+  get no project license file. It also copies `LICENSE-THROUGHSTONE` for this retained
+  Throughstone-authored README/CI scaffolding and writes `LICENSING.md` to make the boundary
+  between the two licenses explicit.
 -->
 
 ## Overview
@@ -26,6 +33,12 @@
      `ARCHITECTURE.md` at the repo root for its internal design — the main modules, key
      flows, and *why* it's built this way (the codebase-level counterpart to the hub's
      system-wide `architecture/` docs) — and link it from here. Skip it for a simple repo. -->
+
+## Licensing
+
+See [`LICENSING.md`](LICENSING.md) for the exact scope. A root `LICENSE`, when present,
+governs project-authored content. `LICENSE-THROUGHSTONE` applies only to retained
+Throughstone-authored scaffold material and does not license the project's application code.
 
 ## Tech stack
 <!-- Language + version, framework, datastore(s), key libraries. -->

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ things keep them approachable whatever your background:
    ```
    It asks a few questions (project slug, repo layout, **license**, optional pieces), then
    detaches this download from the template's git history, renames the `{{PROJECT}}`
-   placeholder everywhere to your slug, stamps your chosen `LICENSE`, and initializes your
-   repo(s). See [`init.sh`](init.sh).
+   placeholder everywhere to your slug, stamps your chosen open-source `LICENSE` when
+   applicable, and initializes your repo(s). See [`init.sh`](init.sh).
 
    Prefer to script it? Every question has a flag — run `./init.sh --help` to see them, or
    pre-answer non-interactively, e.g.:
@@ -134,6 +134,11 @@ things keep them approachable whatever your background:
    Any flag you omit is still prompted (without `--non-interactive`); with it, a missing
    required value is an error. `init.sh` first checks that `git` and `perl` are present. When
    it finishes you can delete `init.sh` — it has done its job.
+
+   Repository visibility is separate from licensing. When creating GitHub remotes, use
+   `--visibility=private` or `--visibility=public`; the default is private. Public visibility
+   with `--license=private` publishes the source without granting open-source reuse rights, so
+   the wizard warns before creating that combination.
 
 3. **Start your AI agent in the project folder, and send it one command.** Launch your
    agent however you normally do (Claude Code, Codex, … — start it yourself; this scaffold
@@ -333,13 +338,18 @@ reports, fixes, and ideas are genuinely welcome. A few starting points:
 ## License
 
 This Throughstone template is released under the [BSD 3-Clause License](LICENSE) — use
-it freely. `init.sh` sets up **your** project's own license for the code you write: it asks
-whether your project is open source (MIT, BSD-3, or Apache-2.0) or private/proprietary (an
-"all rights reserved" notice) and stamps that into each repo. The scaffold's own files
-(`METHOD.md`, `templates/`, `runbooks/`, `scripts/`) remain under BSD-3-Clause — `init.sh`
-retains it as `LICENSE-THROUGHSTONE` in the docs hub (BSD-3 requires keeping the notice). So your
-application code is governed by the license you chose, while the project keeps a reference
-back to Throughstone.
+it freely. `init.sh` asks whether **your** project is open source (MIT, BSD-3, or Apache-2.0)
+or private/proprietary. Open-source projects get the selected project `LICENSE`; private
+projects get no project license file. The selected license in the docs hub is the source copied
+into application-code repos when they are created later. The durable selection is recorded in
+the docs hub's `.throughstone/project-license`, so deleting or losing the canonical `LICENSE`
+causes an error instead of silently changing an open-source project to proprietary.
+Throughstone-authored scaffold material remains under BSD-3-Clause, so `init.sh` retains that
+separate notice as `LICENSE-THROUGHSTONE` in each independently distributed repo that contains
+it, including the root of a mono-repo. Generated repos also include `LICENSING.md` to state that
+the Throughstone notice does not license proprietary application code. Your application code is
+therefore governed by the open-source license you chose or remains proprietary, while retained
+Throughstone material keeps its original license.
 
 > **A note on the name.** The BSD-3-Clause license covers the *code*, not the *name*.
 > "Throughstone" is a trademark of Mark A. Herschberg — you're welcome to say you *use*

--- a/init.sh
+++ b/init.sh
@@ -27,6 +27,53 @@ want() {
   ask "$prompt" "$def"
 }
 
+# normalize_license_choice INPUT — set NORMALIZED_LICENSE_CHOICE to a canonical value.
+normalize_license_choice() {
+  local input
+  input="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$input" in
+    mit|1)                       NORMALIZED_LICENSE_CHOICE=1 ;;
+    bsd|bsd-3|bsd-3-clause|2)   NORMALIZED_LICENSE_CHOICE=2 ;;
+    apache|apache-2|apache-2.0|3) NORMALIZED_LICENSE_CHOICE=3 ;;
+    proprietary|private)        NORMALIZED_LICENSE_CHOICE=private ;;
+    *)                          return 1 ;;
+  esac
+}
+
+# choose_license_interactively — prompt until the project type and license are valid.
+choose_license_interactively() {
+  local project_type license_input
+
+  while :; do
+    echo "Is this project open source or private/proprietary?"
+    echo "  1) Open source"
+    echo "  2) Private / proprietary"
+    project_type="$(ask 'Choose 1 or 2' '1')"
+    case "$project_type" in
+      1) break ;;
+      2)
+        LICENSE_CHOICE="private"
+        return 0
+        ;;
+      *) echo "  -> choose 1 for open source or 2 for private / proprietary." ;;
+    esac
+  done
+
+  while :; do
+    echo "Open-source license:"
+    echo "  1) MIT           (permissive, simplest)"
+    echo "  2) BSD-3-Clause  (permissive + name-endorsement protection)"
+    echo "  3) Apache-2.0    (permissive, with patent grant)"
+    license_input="$(ask 'Choose 1, 2, or 3' '1')"
+    if normalize_license_choice "$license_input" \
+      && [ "$NORMALIZED_LICENSE_CHOICE" != "private" ]; then
+      LICENSE_CHOICE="$NORMALIZED_LICENSE_CHOICE"
+      return 0
+    fi
+    echo "  -> choose 1/mit, 2/bsd-3, or 3/apache-2.0."
+  done
+}
+
 preflight_git_commit() {
   local tmp out status
   tmp="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-git-preflight.XXXXXX")"
@@ -78,20 +125,21 @@ Usage: ./init.sh [options]
 Options:
   --slug=SLUG            Project slug (lowercase kebab-case, e.g. acme-scheduler)
   --desc=TEXT           One-line description
-  --license=NAME        mit | bsd-3 | apache-2.0 | proprietary
-  --holder=NAME         Copyright holder (name or org)
+  --license=NAME        mit | bsd-3 | apache-2.0 | private
+  --holder=NAME         Copyright holder (required for open-source licenses)
   --layout=LAYOUT       multi | mono                    (default: multi)
   --registries=yes|no   Keep registries/ (mono-repo only; default: yes)
   --collab=MODE         solo | team                     (default: solo)
   --adr-authority=TEXT  Who accepts ADRs (team only; default: consensus of maintainers)
   --remotes=yes|no      Create GitHub remotes via gh    (default: no; needs gh)
   --owner=OWNER         GitHub owner/org (required when --remotes=yes)
+  --visibility=VALUE    private | public                (default: private)
   -y, --non-interactive Never prompt; error on any missing required value
   -h, --help            Show this help and exit
 
 Env vars (flags take precedence): INIT_SLUG, INIT_DESC, INIT_LICENSE, INIT_HOLDER,
   INIT_LAYOUT, INIT_REGISTRIES, INIT_COLLAB, INIT_ADR_AUTHORITY, INIT_REMOTES,
-  INIT_OWNER, INIT_NONINTERACTIVE.
+  INIT_OWNER, INIT_VISIBILITY, INIT_NONINTERACTIVE.
 USAGE
 }
 
@@ -101,6 +149,7 @@ LICENSE_IN="${INIT_LICENSE:-}"; HOLDER_IN="${INIT_HOLDER:-}"
 LAYOUT_IN="${INIT_LAYOUT:-}";   REGISTRIES_IN="${INIT_REGISTRIES:-}"
 COLLAB_IN="${INIT_COLLAB:-}";   ADR_AUTHORITY_IN="${INIT_ADR_AUTHORITY:-}"
 REMOTES_IN="${INIT_REMOTES:-}"; OWNER_IN="${INIT_OWNER:-}"
+VISIBILITY_IN="${INIT_VISIBILITY:-}"
 NONINTERACTIVE="${INIT_NONINTERACTIVE:-0}"
 
 while [ $# -gt 0 ]; do
@@ -125,6 +174,8 @@ while [ $# -gt 0 ]; do
     --remotes)         REMOTES_IN="${2:-}"; shift ;;
     --owner=*)         OWNER_IN="${1#*=}" ;;
     --owner)           OWNER_IN="${2:-}"; shift ;;
+    --visibility=*)    VISIBILITY_IN="${1#*=}" ;;
+    --visibility)      VISIBILITY_IN="${2:-}"; shift ;;
     -y|--yes|--non-interactive) NONINTERACTIVE=1 ;;
     -h|--help)         usage; exit 0 ;;
     *) echo "init.sh: unknown option: $1 (try './init.sh --help')" >&2; exit 2 ;;
@@ -166,31 +217,46 @@ DESC="$(want "$DESC_IN" 'One-line description')"
 # License — accept a friendly token from --license, else ask the two-part question.
 LICENSE_CHOICE=""
 if [ -n "$LICENSE_IN" ]; then
-  case "$(printf '%s' "$LICENSE_IN" | tr '[:upper:]' '[:lower:]')" in
-    mit)                        LICENSE_CHOICE=1 ;;
-    bsd|bsd-3|bsd-3-clause)     LICENSE_CHOICE=2 ;;
-    apache|apache-2|apache-2.0) LICENSE_CHOICE=3 ;;
-    proprietary|private)        LICENSE_CHOICE=proprietary ;;
-    1|2|3)                      LICENSE_CHOICE="$LICENSE_IN" ;;
-    *) echo "init.sh: invalid --license '$LICENSE_IN' (mit | bsd-3 | apache-2.0 | proprietary)." >&2; exit 2 ;;
-  esac
+  normalize_license_choice "$LICENSE_IN" \
+    || { echo "init.sh: invalid --license '$LICENSE_IN' (mit | bsd-3 | apache-2.0 | private)." >&2; exit 2; }
+  LICENSE_CHOICE="$NORMALIZED_LICENSE_CHOICE"
 elif [ "$NONINTERACTIVE" = "1" ]; then
-  echo "init.sh: --license is required in --non-interactive mode (mit | bsd-3 | apache-2.0 | proprietary)." >&2; exit 2
+  echo "init.sh: --license is required in --non-interactive mode (mit | bsd-3 | apache-2.0 | private)." >&2; exit 2
 else
-  echo "Is this project open source or private/proprietary?"
-  echo "  1) Open source"
-  echo "  2) Private / proprietary"
-  if [ "$(ask 'Choose 1 or 2' '1')" = "2" ]; then
-    LICENSE_CHOICE="proprietary"
-  else
-    echo "Open-source license:"
-    echo "  1) MIT           (permissive, simplest)"
-    echo "  2) BSD-3-Clause  (permissive + name-endorsement protection)"
-    echo "  3) Apache-2.0    (permissive, with patent grant)"
-    LICENSE_CHOICE="$(ask 'Choose 1, 2, or 3' '1')"
-  fi
+  choose_license_interactively
 fi
-HOLDER="$(want "$HOLDER_IN" 'Copyright holder (name or org)')"
+HOLDER=""
+if [ "$LICENSE_CHOICE" != "private" ]; then
+  HOLDER="$(want "$HOLDER_IN" 'Copyright holder (name or org)')"
+fi
+LICENSE_TEMPLATE_NAME=""
+PROJECT_LICENSE_ID=""
+case "$LICENSE_CHOICE" in
+  1)
+    LICENSE_TEMPLATE_NAME="MIT.txt"
+    PROJECT_LICENSE_ID="MIT"
+    ;;
+  2)
+    LICENSE_TEMPLATE_NAME="BSD-3-Clause.txt"
+    PROJECT_LICENSE_ID="BSD-3-Clause"
+    ;;
+  3)
+    LICENSE_TEMPLATE_NAME="Apache-2.0.txt"
+    PROJECT_LICENSE_ID="Apache-2.0"
+    ;;
+  private)
+    PROJECT_LICENSE_ID="Proprietary"
+    ;;
+  *)
+    echo "init.sh: internal error: unsupported license choice '$LICENSE_CHOICE'." >&2
+    exit 1
+    ;;
+esac
+if [ -n "$LICENSE_TEMPLATE_NAME" ] \
+  && [ ! -f "$ROOT/Code/{{PROJECT}}-docs/templates/licenses/$LICENSE_TEMPLATE_NAME" ]; then
+  echo "init.sh: project license template is missing: Code/{{PROJECT}}-docs/templates/licenses/$LICENSE_TEMPLATE_NAME" >&2
+  exit 1
+fi
 
 # Repo layout — multi (default) or mono.
 if [ -n "$LAYOUT_IN" ]; then
@@ -271,7 +337,9 @@ case "$ROOT_ORIGIN" in
 esac
 
 # GitHub remotes (needs gh). Default off; --remotes=yes requires gh and an owner.
-MK_REMOTES=0; OWNER=""
+# Visibility is independent of the project license: private repos may use open-source
+# licenses, and public repos still need an explicit project-license choice.
+MK_REMOTES=0; OWNER=""; REMOTE_VISIBILITY=private
 if [ -n "$REMOTES_IN" ]; then
   case "$(printf '%s' "$REMOTES_IN" | tr '[:upper:]' '[:lower:]')" in
     y|yes|true|1) MK_REMOTES=1 ;;
@@ -285,10 +353,42 @@ elif [ "$NONINTERACTIVE" != "1" ] && command -v gh >/dev/null 2>&1 && yesno "Cre
   MK_REMOTES=1
 fi
 if [ "$MK_REMOTES" = "1" ]; then
+  if [ -n "$VISIBILITY_IN" ]; then
+    case "$(printf '%s' "$VISIBILITY_IN" | tr '[:upper:]' '[:lower:]')" in
+      private|1) REMOTE_VISIBILITY=private ;;
+      public|2)  REMOTE_VISIBILITY=public ;;
+      *) echo "init.sh: invalid --visibility '$VISIBILITY_IN' (private | public)." >&2; exit 2 ;;
+    esac
+  elif [ "$NONINTERACTIVE" != "1" ]; then
+    echo "GitHub repository visibility:"
+    echo "  1) Private"
+    echo "  2) Public"
+    while :; do
+      case "$(ask 'Choose 1 or 2' '1')" in
+        1) REMOTE_VISIBILITY=private; break ;;
+        2) REMOTE_VISIBILITY=public; break ;;
+        *) echo "  -> choose 1 for private or 2 for public." ;;
+      esac
+    done
+  fi
   if [ "$LAYOUT" = "2" ] && [ -n "$ROOT_ORIGIN" ] && [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ]; then
     OWNER=""
   else
     OWNER="$(want "$OWNER_IN" 'GitHub owner/org')"
+  fi
+fi
+if [ "$MK_REMOTES" = "1" ] \
+  && [ "$REMOTE_VISIBILITY" = "public" ] \
+  && [ "$LICENSE_CHOICE" = "private" ]; then
+  cat >&2 <<'WARNING'
+WARNING: public visibility with a proprietary license publishes the source code but grants
+no open-source reuse rights. LICENSE-THROUGHSTONE covers only retained Throughstone scaffold
+material; it does not license the project's application code.
+WARNING
+  if [ "$NONINTERACTIVE" != "1" ] \
+    && ! yesno "Continue with public proprietary repositories?"; then
+    echo "init.sh: public proprietary repository creation cancelled." >&2
+    exit 2
   fi
 fi
 
@@ -298,8 +398,8 @@ rm -rf "$ROOT/.git"
 # The root LICENSE is the Throughstone scaffold's own license (BSD-3-Clause, © Mark A.
 # Herschberg). The scaffold files you keep using (METHOD.md, templates/, runbooks/, scripts/)
 # stay under it — BSD-3 clause 1 requires retaining the notice — so we DON'T delete it; it's
-# relocated into the docs hub as LICENSE-THROUGHSTONE once the hub is renamed (step 3). Your own
-# code is covered by the license you choose, stamped into each repo (step 6).
+# relocated into the docs hub as LICENSE-THROUGHSTONE once the hub is renamed (step 3).
+# Open-source projects get their selected license in each repo; private projects do not.
 # README.md is Throughstone's own front-door (it documents init.sh and "Use this template"),
 # and CHANGELOG.md is Throughstone's release history. Once you've bootstrapped they're stale and
 # template-specific, and in multi-repo mode they would be stray files at the non-repo workspace
@@ -319,9 +419,10 @@ rm -rf "$ROOT/.github"
 # .dev/ holds template-maintainer-only notes (handoffs, design memos) — not part of your
 # project; drop it so internal notes don't leak into bootstrapped repos.
 rm -rf "$ROOT/.dev"
-# .test-fixtures/ holds scaffold-maintainer test data — useful in this repo, but not part of a
-# bootstrapped user's project and a root-hygiene warning in multi-repo workspaces.
-rm -rf "$ROOT/.test-fixtures"
+# tests/ and .test-fixtures/ hold scaffold-maintainer checks and test data — useful in this
+# repo, but not part of a bootstrapped user's project and root-hygiene warnings in multi-repo
+# workspaces.
+rm -rf "$ROOT/tests" "$ROOT/.test-fixtures"
 # brand/ (Throughstone's brand brief, logo, social card, landing-page source) and docs/ (the
 # built landing page served via GitHub Pages) are Throughstone's *own* marketing — they assert
 # the Throughstone trademark and aren't part of your project. Drop them so your repo doesn't
@@ -338,6 +439,8 @@ done
 [ -d "Code/{{PROJECT}}-docs" ] && mv "Code/{{PROJECT}}-docs" "Code/${SLUG}-docs"
 
 DOCS="Code/${SLUG}-docs"
+mkdir -p "$DOCS/.throughstone"
+printf '%s\n' "$PROJECT_LICENSE_ID" > "$DOCS/.throughstone/project-license"
 
 # description: fill {{PROJECT_DESCRIPTION}} EVERYWHERE it appears (AGENTS.md + every
 # architecture/planning-session "About" blurb) so no literal placeholder is left dangling.
@@ -347,9 +450,19 @@ grep -rlF '{{PROJECT_DESCRIPTION}}' . --exclude-dir=.git 2>/dev/null | while rea
 done
 
 # Relocate the scaffold's BSD license into the docs hub (retained as attribution per BSD-3,
-# next to the method files it covers — not deleted). Your project's own license is stamped
-# separately into each repo in step 6.
+# next to the method files it covers — not deleted). Open-source project licenses are stamped
+# separately into each repo in step 6; private projects get no project LICENSE.
 [ -f "$ROOT/LICENSE" ] && mv "$ROOT/LICENSE" "$DOCS/LICENSE-THROUGHSTONE"
+# In multi-repo mode, prompts/ is distributed independently and contains Throughstone-authored
+# seed content. Retain the scaffold notice there too; this is distinct from the user's project
+# LICENSE stamped below for open-source projects.
+if [ -f "$DOCS/LICENSE-THROUGHSTONE" ]; then
+  if [ "$LAYOUT" = "1" ]; then
+    cp "$DOCS/LICENSE-THROUGHSTONE" "prompts/LICENSE-THROUGHSTONE"
+  else
+    cp "$DOCS/LICENSE-THROUGHSTONE" "$ROOT/LICENSE-THROUGHSTONE"
+  fi
+fi
 
 # --- 4. Prune optional pieces -----------------------------------------------
 # runbooks/ is kept: it now ships method-level runbooks (check-in, collaboration) that
@@ -395,23 +508,49 @@ write_gitignore() { # dir
 .secrets/
 GI
 }
-stamp_license() { # dir — write the chosen LICENSE, filling {{YEAR}}/{{HOLDER}}
+stamp_license() { # dir — write the chosen open-source LICENSE, if any
   local src
-  case "$LICENSE_CHOICE" in
-    1)           src="$DOCS/templates/licenses/MIT.txt" ;;
-    2)           src="$DOCS/templates/licenses/BSD-3-Clause.txt" ;;
-    3)           src="$DOCS/templates/licenses/Apache-2.0.txt" ;;
-    proprietary) src="$DOCS/templates/licenses/Proprietary.txt" ;;
-    *) return 0 ;;
-  esac
-  [ -f "$src" ] || { echo "  (license source $src missing; skipped)"; return 0; }
+  [ "$LICENSE_CHOICE" = "private" ] && return 0
+  src="$DOCS/templates/licenses/$LICENSE_TEMPLATE_NAME"
+  [ -f "$src" ] || {
+    echo "init.sh: project license template disappeared during setup: $src" >&2
+    return 1
+  }
   YEAR="$(date +%Y)" HOLDER="$HOLDER" perl -pe \
     's/\Q{{YEAR}}\E/$ENV{YEAR}/g; s/\Q{{HOLDER}}\E/$ENV{HOLDER}/g' "$src" > "$1/LICENSE"
   echo "  license: $1/LICENSE"
+  if [ "$LAYOUT" = "2" ] && [ "$1" = "." ]; then
+    cp "$1/LICENSE" "$DOCS/LICENSE"
+    echo "  canonical project license: $DOCS/LICENSE"
+  fi
+}
+write_licensing_summary() { # dir — make the project/Throughstone license boundary visible
+  if [ "$LICENSE_CHOICE" = "private" ]; then
+    cat > "$1/LICENSING.md" <<'EOF'
+# Licensing
+
+Project-authored content in this repository is proprietary. No project `LICENSE` is
+provided, and the presence of `LICENSE-THROUGHSTONE` does not grant permission to copy,
+modify, or distribute the project's application code.
+
+`LICENSE-THROUGHSTONE` applies only to retained Throughstone-authored scaffold material.
+EOF
+  else
+    cat > "$1/LICENSING.md" <<EOF
+# Licensing
+
+Project-authored content in this repository is licensed under $PROJECT_LICENSE_ID. See
+\`LICENSE\` for the full project license.
+
+\`LICENSE-THROUGHSTONE\` applies only to retained Throughstone-authored scaffold material;
+it does not replace or alter the project license.
+EOF
+  fi
 }
 init_repo() { # dir
   write_gitignore "$1"
   stamp_license "$1"
+  write_licensing_summary "$1"
   ( cd "$1" && git init -q && git add -A && git commit -qm "Initial commit (bootstrapped)" \
     && git branch -M main; )   # pin trunk to main (collaboration.md assumes a 'main' trunk)
   echo "  git repo: $1"
@@ -453,7 +592,7 @@ commit_registry_remotes() {
 make_remote() { # dir reponame
   MADE_REMOTE_URL=""
   [ "$MK_REMOTES" = "1" ] || return 0
-  if ( cd "$1" && gh repo create "$OWNER/$2" --private --source=. --remote=origin --push >/dev/null ); then
+  if ( cd "$1" && gh repo create "$OWNER/$2" "--$REMOTE_VISIBILITY" --source=. --remote=origin --push >/dev/null ); then
     MADE_REMOTE_URL="$(git -C "$1" remote get-url origin 2>/dev/null || true)"
     echo "  remote: $OWNER/$2"
     return 0

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -4,6 +4,13 @@ This is where the project's roadmap and archived STEP plans/prompts live — the
 *how* the project was built, STEP by STEP. See `Code/{{PROJECT}}-docs/METHOD.md` for the
 full method; this README covers the conventions here and the recipe for adding a STEP.
 
+**Licensing:** project-authored roadmap and prompt content follows the posture recorded in the
+docs hub's `.throughstone/project-license`. Open-source projects carry that selected project
+license in the root `LICENSE`; proprietary projects intentionally do not. A missing
+open-source `LICENSE` is an error, not a change of posture. Retained Throughstone-authored seed
+content and conventions remain under BSD-3-Clause; see `LICENSE-THROUGHSTONE`. The two scopes
+describe different material and neither replaces the other.
+
 **`prompts/` is its own repo** — project-wide, spanning all the code repos. It is
 **history** (never rewritten); the docs hub (`Code/{{PROJECT}}-docs/`) is **state** (kept
 current). `Upcoming Prompts/` is a workspace folder for the in-flight STEP, not generally a

--- a/tests/fixtures/gh-stub.sh
+++ b/tests/fixtures/gh-stub.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Minimal gh repo create stub for local init.sh integration tests.
+
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "${1:-}" != "repo" ] || [ "${2:-}" != "create" ] || [ -z "${3:-}" ]; then
+  echo "gh-stub.sh: unsupported command: $*" >&2
+  exit 2
+fi
+
+repo_name="${3##*/}"
+remote="$GH_REMOTE_ROOT/$repo_name.git"
+git init --bare -q "$remote"
+git remote add origin "$remote"

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -1,0 +1,530 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for init.sh interactive license validation.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-license-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — copy HEAD plus current working-tree changes, without Git metadata.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+      cmp -s "$ROOT/$file" "$dest/$file" || {
+        echo "FAIL: working-tree file was not copied exactly: $file" >&2
+        return 1
+      }
+    else
+      rm -f "$dest/$file"
+      [ ! -e "$dest/$file" ] || {
+        echo "FAIL: working-tree deletion was not applied: $file" >&2
+        return 1
+      }
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+# run_interactive_case NAME INPUT EXPECTED_TEXT — bootstrap and verify both repo licenses.
+run_interactive_case() {
+  local name="$1" input="$2" expected_text="$3" conflict_status
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    printf '%s' "$input" | ./init.sh \
+      --slug="$name" \
+      --desc="License validation test" \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  for license_file in \
+    "$work/Code/$name-docs/LICENSE" \
+    "$work/prompts/LICENSE"; do
+    [ -f "$license_file" ] || {
+      echo "FAIL: $name did not create $license_file" >&2
+      return 1
+    }
+    grep -Fq "$expected_text" "$license_file" || {
+      echo "FAIL: $license_file did not contain '$expected_text'" >&2
+      return 1
+    }
+  done
+  for notice_file in \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE" \
+    "$work/prompts/LICENSE-THROUGHSTONE"; do
+    [ -f "$notice_file" ] || {
+      echo "FAIL: $name did not retain $notice_file" >&2
+      return 1
+    }
+  done
+  cmp -s \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE" \
+    "$work/prompts/LICENSE-THROUGHSTONE"
+
+  mkdir -p "$work/Code/$name-api"
+  "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+    "$work/Code/$name-api" >"$TMP_ROOT/$name-code-license.out"
+  cmp -s \
+    "$work/Code/$name-docs/LICENSE" \
+    "$work/Code/$name-api/LICENSE"
+  cmp -s \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE" \
+    "$work/Code/$name-api/LICENSE-THROUGHSTONE"
+  [ -f "$work/Code/$name-api/LICENSING.md" ]
+  grep -Fq "does not replace or alter the project license" \
+    "$work/Code/$name-api/LICENSING.md"
+  "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+    "$work/Code/$name-api" >"$TMP_ROOT/$name-code-license-repeat.out"
+
+  printf 'different license\n' > "$work/Code/$name-api/LICENSE"
+  set +e
+  "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+    "$work/Code/$name-api" >"$TMP_ROOT/$name-code-license-conflict.out" 2>&1
+  conflict_status=$?
+  set -e
+  [ "$conflict_status" -eq 1 ]
+  grep -Fq "refusing to overwrite different project license" \
+    "$TMP_ROOT/$name-code-license-conflict.out"
+
+  mkdir -p "$work/Code/$name-conflict"
+  printf 'different license\n' > "$work/Code/$name-conflict/LICENSE"
+  set +e
+  "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+    "$work/Code/$name-conflict" >"$TMP_ROOT/$name-fresh-conflict.out" 2>&1
+  conflict_status=$?
+  set -e
+  [ "$conflict_status" -eq 1 ]
+  [ ! -e "$work/Code/$name-conflict/LICENSE-THROUGHSTONE" ]
+
+  [ ! -d "$work/tests" ] || {
+    echo "FAIL: $name retained maintainer-only tests/" >&2
+    return 1
+  }
+}
+
+# run_flag_case NAME LICENSE EXPECTED_TEXT — preserve flag-path normalization behavior.
+run_flag_case() {
+  local name="$1" license="$2" expected_text="$3"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="License validation test" \
+      --license="$license" \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  grep -Fq "$expected_text" "$work/Code/$name-docs/LICENSE"
+  grep -Fq "$expected_text" "$work/prompts/LICENSE"
+}
+
+# run_private_case NAME ARGS... — private projects should not get a project LICENSE.
+run_private_case() {
+  local name="$1"
+  shift
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    "$@"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ ! -e "$work/Code/$name-docs/LICENSE" ]
+  [ ! -e "$work/prompts/LICENSE" ]
+  [ -f "$work/Code/$name-docs/LICENSE-THROUGHSTONE" ]
+  [ -f "$work/prompts/LICENSE-THROUGHSTONE" ]
+  cmp -s \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE" \
+    "$work/prompts/LICENSE-THROUGHSTONE"
+
+  mkdir -p "$work/Code/$name-api"
+  "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+    "$work/Code/$name-api" >"$TMP_ROOT/$name-code-license.out"
+  [ ! -e "$work/Code/$name-api/LICENSE" ]
+  cmp -s \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE" \
+    "$work/Code/$name-api/LICENSE-THROUGHSTONE"
+  [ -f "$work/Code/$name-api/LICENSING.md" ]
+  grep -Fq "Project-authored content in this repository is proprietary" \
+    "$work/Code/$name-api/LICENSING.md"
+  grep -Fq "does not grant permission" "$work/Code/$name-api/LICENSING.md"
+
+  [ ! -d "$work/tests" ]
+  ! grep -Fq "Copyright holder" "$TMP_ROOT/$name.out"
+}
+
+# run_mono_case — mono mode keeps a canonical docs-hub copy for future code repos.
+run_mono_case() {
+  local name="license-mono"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="License validation test" \
+      --license=apache-2.0 \
+      --holder="Throughstone Test" \
+      --layout=mono \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  cmp -s "$work/LICENSE" "$work/Code/$name-docs/LICENSE"
+  [ -f "$work/Code/$name-docs/LICENSE-THROUGHSTONE" ]
+  [ -f "$work/LICENSE-THROUGHSTONE" ]
+  cmp -s \
+    "$work/LICENSE-THROUGHSTONE" \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE"
+  [ -f "$work/LICENSING.md" ]
+  grep -Fq "licensed under Apache-2.0" "$work/LICENSING.md"
+  grep -Fxq "Apache-2.0" "$work/Code/$name-docs/.throughstone/project-license"
+
+  mkdir -p "$work/Code/$name-api"
+  "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+    "$work/Code/$name-api" >"$TMP_ROOT/$name-code-license.out"
+  cmp -s "$work/LICENSE" "$work/Code/$name-api/LICENSE"
+  cmp -s \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE" \
+    "$work/Code/$name-api/LICENSE-THROUGHSTONE"
+}
+
+# run_visibility_case NAME VISIBILITY — verify gh receives the requested remote visibility.
+run_visibility_case() {
+  local name="$1" visibility="$2"
+  local work="$TMP_ROOT/$name"
+  local stub_bin="$TMP_ROOT/$name-bin"
+  local remote_root="$TMP_ROOT/$name-remotes"
+  local gh_log="$TMP_ROOT/$name-gh.log"
+
+  copy_template "$work"
+  mkdir -p "$stub_bin" "$remote_root"
+  cp "$ROOT/tests/fixtures/gh-stub.sh" "$stub_bin/gh"
+  chmod +x "$stub_bin/gh"
+  (
+    cd "$work"
+    PATH="$stub_bin:$PATH" \
+      GH_LOG="$gh_log" \
+      GH_REMOTE_ROOT="$remote_root" \
+      ./init.sh \
+        --non-interactive \
+        --slug="$name" \
+        --desc="Visibility validation test" \
+        --license=mit \
+        --holder="Throughstone Test" \
+        --layout=multi \
+        --collab=solo \
+        --remotes=yes \
+        --owner=throughstone-test \
+        --visibility="$visibility"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ "$(grep -Fc -- "--$visibility" "$gh_log")" -eq 2 ]
+  if [ "$visibility" = "public" ]; then
+    if grep -Fq -- "--private" "$gh_log"; then
+      echo "FAIL: public visibility case invoked gh with --private" >&2
+      return 1
+    fi
+  else
+    if grep -Fq -- "--public" "$gh_log"; then
+      echo "FAIL: private visibility case invoked gh with --public" >&2
+      return 1
+    fi
+  fi
+}
+
+# run_public_proprietary_case — public source visibility must warn about proprietary rights.
+run_public_proprietary_case() {
+  local name="visibility-public-proprietary"
+  local work="$TMP_ROOT/$name"
+  local cancel_name="visibility-public-proprietary-cancel"
+  local cancel_work="$TMP_ROOT/$cancel_name"
+  local stub_bin="$TMP_ROOT/$name-bin"
+  local remote_root="$TMP_ROOT/$name-remotes"
+  local gh_log="$TMP_ROOT/$name-gh.log"
+  local cancel_status
+
+  copy_template "$work"
+  mkdir -p "$stub_bin" "$remote_root"
+  cp "$ROOT/tests/fixtures/gh-stub.sh" "$stub_bin/gh"
+  chmod +x "$stub_bin/gh"
+  (
+    cd "$work"
+    PATH="$stub_bin:$PATH" \
+      GH_LOG="$gh_log" \
+      GH_REMOTE_ROOT="$remote_root" \
+      ./init.sh \
+        --non-interactive \
+        --slug="$name" \
+        --desc="Public proprietary warning test" \
+        --license=private \
+        --layout=multi \
+        --collab=solo \
+        --remotes=yes \
+        --owner=throughstone-test \
+        --visibility=public
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ "$(grep -Fc -- "--public" "$gh_log")" -eq 2 ]
+  grep -Fq "public visibility with a proprietary license" "$TMP_ROOT/$name.out"
+  [ ! -e "$work/Code/$name-docs/LICENSE" ]
+  [ ! -e "$work/prompts/LICENSE" ]
+  grep -Fxq "Proprietary" "$work/Code/$name-docs/.throughstone/project-license"
+  grep -Fq "Project-authored content in this repository is proprietary" \
+    "$work/Code/$name-docs/LICENSING.md"
+
+  copy_template "$cancel_work"
+  : > "$gh_log"
+  set +e
+  (
+    cd "$cancel_work"
+    printf 'n\n' | \
+      PATH="$stub_bin:$PATH" \
+      GH_LOG="$gh_log" \
+      GH_REMOTE_ROOT="$remote_root" \
+      ./init.sh \
+        --slug="$cancel_name" \
+        --desc="Public proprietary cancellation test" \
+        --license=private \
+        --layout=multi \
+        --collab=solo \
+        --remotes=yes \
+        --owner=throughstone-test \
+        --visibility=public
+  ) >"$TMP_ROOT/$cancel_name.out" 2>&1
+  cancel_status=$?
+  set -e
+
+  [ "$cancel_status" -eq 2 ]
+  grep -Fq "public proprietary repository creation cancelled" \
+    "$TMP_ROOT/$cancel_name.out"
+  [ -d "$cancel_work/Code/{{PROJECT}}-docs" ]
+  [ -f "$cancel_work/README.md" ]
+  [ ! -s "$gh_log" ]
+}
+
+# run_missing_canonical_license_case — metadata prevents silent open-source-to-private drift.
+run_missing_canonical_license_case() {
+  local name="license-missing-canonical"
+  local work="$TMP_ROOT/$name"
+  local target="$work/Code/$name-api"
+  local status
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Missing canonical license test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  grep -Fxq "MIT" "$work/Code/$name-docs/.throughstone/project-license"
+  rm "$work/Code/$name-docs/LICENSE"
+  mkdir -p "$target"
+  set +e
+  "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+    "$target" >"$TMP_ROOT/$name-helper.out" 2>&1
+  status=$?
+  set -e
+
+  [ "$status" -eq 1 ]
+  grep -Fq "project posture is MIT, but the canonical license is missing" \
+    "$TMP_ROOT/$name-helper.out"
+  [ -z "$(find "$target" -mindepth 1 -print -quit)" ]
+}
+
+# run_private_mono_case — the single repo retains and explains Throughstone's notice at root.
+run_private_mono_case() {
+  local name="license-private-mono"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Private mono license test" \
+      --license=private \
+      --layout=mono \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ ! -e "$work/LICENSE" ]
+  [ -f "$work/LICENSE-THROUGHSTONE" ]
+  cmp -s \
+    "$work/LICENSE-THROUGHSTONE" \
+    "$work/Code/$name-docs/LICENSE-THROUGHSTONE"
+  grep -Fxq "Proprietary" "$work/Code/$name-docs/.throughstone/project-license"
+  grep -Fq "does not grant permission" "$work/LICENSING.md"
+}
+
+# run_invalid_visibility_case — reject bad visibility before destructive bootstrap work.
+run_invalid_visibility_case() {
+  local name="visibility-invalid"
+  local work="$TMP_ROOT/$name"
+  local stub_bin="$TMP_ROOT/$name-bin"
+  local remote_root="$TMP_ROOT/$name-remotes"
+  local gh_log="$TMP_ROOT/$name-gh.log"
+  local status
+
+  copy_template "$work"
+  mkdir -p "$stub_bin" "$remote_root"
+  cp "$ROOT/tests/fixtures/gh-stub.sh" "$stub_bin/gh"
+  chmod +x "$stub_bin/gh"
+  set +e
+  (
+    cd "$work"
+    PATH="$stub_bin:$PATH" \
+      GH_LOG="$gh_log" \
+      GH_REMOTE_ROOT="$remote_root" \
+      ./init.sh \
+        --non-interactive \
+        --slug="$name" \
+        --desc="Visibility validation test" \
+        --license=mit \
+        --holder="Throughstone Test" \
+        --layout=multi \
+        --collab=solo \
+        --remotes=yes \
+        --owner=throughstone-test \
+        --visibility=internal
+  ) >"$TMP_ROOT/$name.out" 2>&1
+  status=$?
+  set -e
+
+  [ "$status" -eq 2 ]
+  [ -d "$work/Code/{{PROJECT}}-docs" ]
+  [ -f "$work/README.md" ]
+  [ ! -s "$gh_log" ]
+  grep -Fq "invalid --visibility 'internal'" "$TMP_ROOT/$name.out"
+}
+
+run_interactive_case \
+  "license-mit" \
+  $'1\nMIT\n' \
+  "MIT License"
+
+run_interactive_case \
+  "license-default" \
+  $'1\n\n' \
+  "MIT License"
+
+run_interactive_case \
+  "license-reprompt" \
+  $'invalid\n1\nnonsense\nApache-2.0\n' \
+  "Apache License"
+
+grep -Fq \
+  "choose 1 for open source or 2 for private / proprietary" \
+  "$TMP_ROOT/license-reprompt.out"
+grep -Fq \
+  "choose 1/mit, 2/bsd-3, or 3/apache-2.0" \
+  "$TMP_ROOT/license-reprompt.out"
+
+run_private_case \
+  "license-private" \
+  bash -c \
+  "printf '2\n' | ./init.sh --slug=license-private --desc='License validation test' --layout=multi --collab=solo --remotes=no"
+
+run_private_case \
+  "license-private-flag" \
+  ./init.sh \
+  --non-interactive \
+  --slug=license-private-flag \
+  --desc="License validation test" \
+  --license=private \
+  --layout=multi \
+  --collab=solo \
+  --remotes=no
+
+run_flag_case \
+  "license-bsd" \
+  "BSD-3" \
+  "BSD 3-Clause License"
+
+run_mono_case
+run_private_mono_case
+
+run_visibility_case "visibility-public" "public"
+run_visibility_case "visibility-private" "private"
+run_public_proprietary_case
+run_invalid_visibility_case
+run_missing_canonical_license_case
+
+invalid_work="$TMP_ROOT/license-invalid-flag"
+copy_template "$invalid_work"
+set +e
+(
+  cd "$invalid_work"
+  ./init.sh \
+    --non-interactive \
+    --slug="license-invalid-flag" \
+    --desc="License validation test" \
+    --license="not-a-license" \
+    --holder="Throughstone Test"
+) >"$TMP_ROOT/license-invalid-flag.out" 2>&1
+invalid_status=$?
+set -e
+
+[ "$invalid_status" -eq 2 ]
+[ -d "$invalid_work/Code/{{PROJECT}}-docs" ]
+[ -d "$invalid_work/tests" ]
+grep -Fq "invalid --license 'not-a-license'" "$TMP_ROOT/license-invalid-flag.out"
+
+missing_template_work="$TMP_ROOT/license-missing-template"
+copy_template "$missing_template_work"
+rm "$missing_template_work/Code/{{PROJECT}}-docs/templates/licenses/MIT.txt"
+set +e
+(
+  cd "$missing_template_work"
+  ./init.sh \
+    --non-interactive \
+    --slug="license-missing-template" \
+    --desc="License validation test" \
+    --license=mit \
+    --holder="Throughstone Test"
+) >"$TMP_ROOT/license-missing-template.out" 2>&1
+missing_template_status=$?
+set -e
+
+[ "$missing_template_status" -eq 1 ]
+[ -d "$missing_template_work/Code/{{PROJECT}}-docs" ]
+[ -f "$missing_template_work/README.md" ]
+grep -Fq "project license template is missing" "$TMP_ROOT/license-missing-template.out"
+
+echo "init.sh license choice validation: PASS"


### PR DESCRIPTION
## What this changes
- validates interactive open-source/private license choices and stamps only selected open-source licenses
- records the generated project license posture durably and propagates it to future code repositories
- preserves Throughstone BSD attribution separately across docs, prompts, code repos, and mono-repo roots
- makes proprietary application-code scope visible and warns before creating public proprietary repositories
- adds working-tree-aware regression coverage for license, visibility, conflict, and propagation paths

## Related issue
Closes the TODO item: Validate interactive license choices in init.sh

## Type of change
- [x] Bug fix
- [x] Documentation / wording
- [x] New or updated template / coding-standard
- [ ] Methodology change (discussed in an issue first)
- [ ] Other

## Verification
- `bash -n init.sh Code/{{PROJECT}}-docs/scripts/apply-project-license.sh tests/init-license-validation.sh tests/fixtures/gh-stub.sh`
- `shellcheck init.sh Code/{{PROJECT}}-docs/scripts/apply-project-license.sh tests/init-license-validation.sh tests/fixtures/gh-stub.sh`
- `./tests/init-license-validation.sh`
- `Code/{{PROJECT}}-docs/scripts/check.sh` (0 failures; 2 expected uninitialized-template warnings)