### PR TITLE
Clarify conditional privacy session handling

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -68,7 +68,8 @@ short command and expects the first question back, not a confirmation prompt.
 
 **Conditional sessions** are invoked **by name**, not by number: *"run the identity-auth
 session"* → `conditional-identity-auth.md`; *"run the native-app session"* →
-`conditional-native-app.md`; *"run the privacy session"* → `conditional-privacy-compliance.md`.
+`conditional-native-app.md`; *"run the privacy session"* (or *"run the privacy-compliance
+session"*) → `conditional-privacy-compliance.md`.
 They're slotted into STEP-1 under a lettered substep (e.g.
 `1.6a`, `1.7a`), so if the index's next open substep has a letter suffix, run the matching
 `conditional-*.md` by topic rather than looking for a `NN-*.md` file for that number. Each

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -117,7 +117,8 @@ client-surfaces question; **Privacy, compliance & data governance** is decided w
 Model / Security sessions identify personal or regulated data; **Identity & auth** is decided
 from the Security session's AuthN/AuthZ posture. Run each **by name**, not by number — *"run
 the identity-auth session"* → `conditional-identity-auth.md` (likewise
-`conditional-native-app.md` and `conditional-privacy-compliance.md`) — slotted under a
+`conditional-native-app.md`; *"run the privacy session"* or *"run the privacy-compliance
+session"* → `conditional-privacy-compliance.md`) — slotted under a
 lettered substep (e.g. `1.6a`, after the related core session). The STEP-1 PLAN records a
 *Conditional sessions considered* table that names the owning session for each conditional and
 tracks the current call: Include (→ substep), Deferred (with a revisit trigger), or N/A (with
@@ -460,8 +461,8 @@ Resolve the next action top-down against the index — the first rule that match
    *"run session N.M"* in a fresh chat. Skip any substep marked `N/A` or `Deferred`. A substep with a
    **letter suffix** (e.g. `1.6a`, `1.7a`) is a **conditional session** the kickoff slotted
    in — invoke it **by name** (*"run the identity-auth session"* / *"run the native-app
-   session"* / *"run the privacy session"*), since its template file is named by topic, not by
-   number (see §4).
+   session"* / *"run the privacy session"* or *"run the privacy-compliance session"*), since
+   its template file is named by topic, not by number (see §4).
 2. **All STEP-1 design sessions done but the Cross-Cutting Review is still open?** → run the
    substep whose Session label is **Cross-Cutting Review**.
 3. **Cross-Cutting Review done and STEP-1 complete, but only the STEP-1 row exists?** →

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
@@ -21,7 +21,10 @@
 > its own reserved slot without a clash.) The substep number and the doc number don't have to match.
 > Reads `overview.md`, the Data Model architecture doc (`architecture/*-data-model.md`), and
 > the Security & Threat Model architecture doc (`architecture/*-security-threat-model.md`)
-> first, plus the active STEP PLAN in `Upcoming Prompts/` when this is a later follow-up.
+> first; also read the Infrastructure & Deployment architecture doc
+> (`architecture/*-infrastructure-deployment.md`) if it already exists, especially in
+> follow-up mode. Read the active STEP PLAN in `Upcoming Prompts/` when this is a later
+> follow-up.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
 
 ## About {{PROJECT}}
@@ -46,8 +49,9 @@ deletion/export requests **now** keeps compliance a design property rather than 
 - Recommend the **least data, least retention, clearest purpose** option that meets the need,
   and flag what each choice obligates you to.
 - Keep it consistent with the Data Model architecture doc and the Security & Threat Model
-  architecture doc; flag where a choice ties to the Infrastructure & Deployment architecture
-  doc's residency decisions.
+  architecture doc; flag where a choice ties to Infrastructure & Deployment residency
+  decisions, or needs to feed the Infrastructure & Deployment session if that doc does not
+  exist yet.
 - This is **not legal advice** — it produces an engineering record of intent and surfaces
   where a lawyer or DPO should confirm. Say so when a question turns on a legal judgment.
 
@@ -90,8 +94,10 @@ since the rest follows from them. Fill the **Decision Summary**, record **Open Q
 (flag any awaiting legal/DPO confirmation), and capture significant choices as **ADRs** —
 applicable regimes, data residency, retention periods, and any consent/sub-processor decision
 that consumers depend on. Cross-check retention against the Data Model architecture doc and
-residency against the Infrastructure & Deployment architecture doc, and note any updates
-those docs need. Update `architecture/README.md` if this is a later follow-up STEP. Update
+residency against the Infrastructure & Deployment architecture doc if it exists; otherwise,
+record the residency constraint as an input to the Infrastructure & Deployment session. Note
+any updates those docs need. If this is a later follow-up STEP, add or update this doc's row
+in `architecture/README.md`. Update
 the active PLAN to mark this substep done. In STEP-1 mode, also mark the lettered substep
 done in `prompts/STEP-index.md`. In follow-up mode, keep the parent STEP `In progress` there
 until its review and normal completion bookkeeping are finished.


### PR DESCRIPTION
Summary:
- Clarify when the privacy/compliance session reads Infrastructure & Deployment.
- Standardize privacy follow-up bookkeeping for architecture/README.md.
- Document privacy-compliance as an alias for the privacy conditional session.

Verification:
- Code/{{PROJECT}}-docs/scripts/check.sh