### PR TITLE
Clarify scaffold agent pointer behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # AGENTS.md
 
+<!-- THROUGHSTONE-TEMPLATE-GUARD:BEGIN -->
+## Template-checkout guard
+
+If the docs path below still contains an unresolved `PROJECT` placeholder in braces, this
+checkout is the **Throughstone scaffold before project initialization**, not an initialized
+app/project workspace. In that mode, do **not** start the generated-project kickoff/resume
+flow. Treat the files under the template docs path as templates for future projects, and
+work on the scaffold repo like a normal repository unless the user explicitly asks to run
+`./init.sh` or to simulate/test a generated project.
+
+If the docs path below is a concrete project path such as `Code/<name>-docs/AGENTS.md`,
+ignore this guard and follow the normal handoff below.
+<!-- THROUGHSTONE-TEMPLATE-GUARD:END -->
+
 The canonical agent context lives in the docs repo:
 **`Code/{{PROJECT}}-docs/AGENTS.md`** (tool-agnostic). Read it — and the methodology it
 points to in `Code/{{PROJECT}}-docs/METHOD.md` — before working here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # CLAUDE.md
 
+<!-- THROUGHSTONE-TEMPLATE-GUARD:BEGIN -->
+## Template-checkout guard
+
+If the docs path below still contains an unresolved `PROJECT` placeholder in braces, this
+checkout is the **Throughstone scaffold before project initialization**, not an initialized
+app/project workspace. In that mode, do **not** start the generated-project kickoff/resume
+flow. Treat the files under the template docs path as templates for future projects, and
+work on the scaffold repo like a normal repository unless the user explicitly asks to run
+`./init.sh` or to simulate/test a generated project.
+
+If the docs path below is a concrete project path such as `Code/<name>-docs/AGENTS.md`,
+ignore this guard and follow the normal handoff below.
+<!-- THROUGHSTONE-TEMPLATE-GUARD:END -->
+
 The canonical agent context lives in the docs repo:
 **`Code/{{PROJECT}}-docs/AGENTS.md`** (tool-agnostic). Read it — and the methodology it
 points to in `Code/{{PROJECT}}-docs/METHOD.md` — before working here.

--- a/init.sh
+++ b/init.sh
@@ -438,6 +438,13 @@ done
 # directory name (rename BEFORE the description fill below, so its grep walks the new path)
 [ -d "Code/{{PROJECT}}-docs" ] && mv "Code/{{PROJECT}}-docs" "Code/${SLUG}-docs"
 
+# The root pointers carry a guard for agents working on the raw Throughstone scaffold. Once
+# the project placeholder is resolved, generated projects should get the clean handoff only.
+for f in AGENTS.md CLAUDE.md; do
+  [ -f "$f" ] || continue
+  perl -0pi -e 's/<!-- THROUGHSTONE-TEMPLATE-GUARD:BEGIN -->\n.*?<!-- THROUGHSTONE-TEMPLATE-GUARD:END -->\n\n//s' "$f"
+done
+
 DOCS="Code/${SLUG}-docs"
 mkdir -p "$DOCS/.throughstone"
 printf '%s\n' "$PROJECT_LICENSE_ID" > "$DOCS/.throughstone/project-license"


### PR DESCRIPTION
## Summary
- Add scaffold-maintenance guard to root AGENTS.md and CLAUDE.md
- Clarify that unresolved project placeholders mean this is the Throughstone scaffold, not an initialized project workspace

## Tests
- Not run; docs-only change