### PR TITLE
Add planning session project description hint

### DIFF
--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -17,6 +17,7 @@
 
 ## About {{PROJECT}}
 {{PROJECT_DESCRIPTION}}
+<!-- The kickoff fills this from overview.md. Running standalone? Read overview.md first. -->
 
 ## Why this session matters
 STEP-1 leaves you with a coherent architecture but no path into code. The instinct is to


### PR DESCRIPTION
## Summary
- Add the standalone-run overview hint after {{PROJECT_DESCRIPTION}} in the planning session template for parity with the system overview session.

## Check
- git diff --check