### PR TITLE
Make ADR authority substitution explicit

### DIFF
--- a/Code/{{PROJECT}}-docs/adr/README.md
+++ b/Code/{{PROJECT}}-docs/adr/README.md
@@ -28,7 +28,7 @@ ADRs are how a decision is socialized — especially in a team (see
   others depend on follows the same flow: write the new ADR **Proposed**, review, **Accept**,
   and mark the old one `Superseded by ADR-XXXX` — never revise a shared decision silently.
 
-**Who accepts an ADR in this project:** _solo author_ <!-- record your rule when a team forms:
+**Who accepts an ADR in this project:** <!-- ADR-AUTHORITY -->_solo author_<!-- /ADR-AUTHORITY --> <!-- record your rule when a team forms:
 e.g. "tech lead", "consensus of maintainers", "ADR review on PR". -->
 
 ## Registry

--- a/init.sh
+++ b/init.sh
@@ -476,10 +476,19 @@ fi
 # AGENTS.md and METHOD.md reference.
 [ "$KEEP_REGISTRIES" = "0" ] && rm -rf "$DOCS/registries" && echo "  pruned registries/"
 
-# Team: record who accepts ADRs (replaces the "_solo author_" placeholder in adr/README.md).
-if [ "$COLLAB" = "2" ] && [ -n "$ADR_AUTHORITY" ] && [ -f "$DOCS/adr/README.md" ]; then
-  ADR_AUTHORITY="$ADR_AUTHORITY" perl -pi -e 's/\Q_solo author_\E/$ENV{ADR_AUTHORITY}/' "$DOCS/adr/README.md"
-  echo "  ADR authority: $ADR_AUTHORITY"
+# Record who accepts ADRs by replacing the visible marker block in adr/README.md.
+# Solo keeps the old rendered text; team records the selected authority.
+if [ -f "$DOCS/adr/README.md" ]; then
+  ADR_AUTHORITY_TEXT="_solo author_"
+  if [ "$COLLAB" = "2" ] && [ -n "$ADR_AUTHORITY" ]; then
+    ADR_AUTHORITY_TEXT="$ADR_AUTHORITY"
+  fi
+  ADR_AUTHORITY="$ADR_AUTHORITY_TEXT" perl -0pi -e \
+    's/<!-- ADR-AUTHORITY -->.*?<!-- \/ADR-AUTHORITY -->/$ENV{ADR_AUTHORITY}/s' \
+    "$DOCS/adr/README.md"
+  if [ "$COLLAB" = "2" ] && [ -n "$ADR_AUTHORITY_TEXT" ]; then
+    echo "  ADR authority: $ADR_AUTHORITY_TEXT"
+  fi
 fi
 
 # --- 5. Create the project brief from the template --------------------------

--- a/tests/init-adr-authority.sh
+++ b/tests/init-adr-authority.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for init.sh ADR authority marker substitution.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-adr-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — copy HEAD plus current working-tree changes, without Git metadata.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+run_init_case() {
+  local name="$1"
+  shift
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="ADR authority marker test" \
+      --license=private \
+      --layout=multi \
+      --remotes=no \
+      "$@"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+}
+
+grep -Fq '<!-- ADR-AUTHORITY -->_solo author_<!-- /ADR-AUTHORITY -->' \
+  "$ROOT/Code/{{PROJECT}}-docs/adr/README.md"
+
+run_init_case "adr-solo" --collab=solo
+solo_adr="$TMP_ROOT/adr-solo/Code/adr-solo-docs/adr/README.md"
+grep -Fq '**Who accepts an ADR in this project:** _solo author_' "$solo_adr"
+! grep -Fq 'ADR-AUTHORITY' "$solo_adr"
+
+run_init_case "adr-team" --collab=team --adr-authority="ADR review on PR"
+team_adr="$TMP_ROOT/adr-team/Code/adr-team-docs/adr/README.md"
+grep -Fq '**Who accepts an ADR in this project:** ADR review on PR' "$team_adr"
+! grep -Fq '_solo author_' "$team_adr"
+! grep -Fq 'ADR-AUTHORITY' "$team_adr"
+grep -Fq 'ADR authority: ADR review on PR' "$TMP_ROOT/adr-team.out"
+
+echo "init.sh ADR authority marker substitution: PASS"


### PR DESCRIPTION
## Summary
- Mark the ADR authority placeholder with an explicit ADR-AUTHORITY marker in the template
- Replace the marker block during init for solo and team projects
- Add focused init.sh regression coverage for ADR authority substitution

## Tests
- tests/init-adr-authority.sh
- tests/init-license-validation.sh
- tests/status-conditional-priority.sh
- git diff --check