### PR TITLE
Avoid reusing non-empty template origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,21 @@ things keep them approachable whatever your background:
      git clone https://github.com/mherschberg/Throughstone.git acme
      cd acme
      ```
-   - **Or use GitHub "Use this template" ▸ Create a new repository.** This is mainly useful
-     if you're choosing **mono-repo for now**; `init.sh` will reuse that repo's `origin`.
-     In the default **multi-repo** setup, the root is only a workspace shell, so the template
-     repo is just a download vehicle — use `--remotes=yes` or add remotes later for the docs
-     and prompts repos. Name the new repo for your project, then clone it into a folder of
-     that name (e.g. `acme`):
+   - **Or use GitHub "Use this template" ▸ Create a new repository.** Name the new repo for
+     your project, then clone it into a folder of that name (e.g. `acme`):
      ```bash
      git clone <your-new-repo-url> acme
      cd acme
      ```
+     GitHub template repos already contain a template-created commit. Because `init.sh`
+     creates fresh project history, it will not automatically reuse that non-empty `origin`
+     in **mono-repo** mode; otherwise a normal `git push -u origin main` would fail. Use
+     the template path as a download vehicle, then add an empty remote later, delete/recreate
+     the GitHub repo before using `--remotes=yes`, or deliberately replace the
+     template-created remote yourself after reviewing the history. In the default
+     **multi-repo** setup, the root is only a workspace shell, so the template repo is just a
+     download vehicle — use `--remotes=yes` or add remotes later for the docs and prompts
+     repos.
    Everything from here runs *inside* this folder. After setup it holds your repo(s); the
    root folder itself is just the shell around them (see [Layout](#layout)), so its name is
    cosmetic — but matching it to your project keeps things clear.
@@ -123,7 +128,10 @@ things keep them approachable whatever your background:
    It asks a few questions (project slug, repo layout, **license**, optional pieces), then
    detaches this download from the template's git history, renames the `{{PROJECT}}`
    placeholder everywhere to your slug, stamps your chosen open-source `LICENSE` when
-   applicable, and initializes your repo(s). See [`init.sh`](init.sh).
+   applicable, and initializes your repo(s). In mono-repo mode it reuses an existing root
+   `origin` only when that origin appears empty; non-empty template-created origins are left
+   unattached so setup does not lead you into a failed or destructive push. See
+   [`init.sh`](init.sh).
 
    Prefer to script it? Every question has a flag — run `./init.sh --help` to see them, or
    pre-answer non-interactively, e.g.:

--- a/init.sh
+++ b/init.sh
@@ -335,6 +335,31 @@ case "$ROOT_ORIGIN" in
   *github.com[:/]mherschberg/Throughstone|*github.com[:/]mherschberg/Throughstone.git)
     ROOT_ORIGIN_IS_THROUGHSTONE=1 ;;
 esac
+ROOT_ORIGIN_HAS_LOCAL_REFS=0
+if [ -n "$ROOT_ORIGIN" ] \
+  && git -C "$ROOT" for-each-ref --format='%(refname)' refs/remotes/origin | grep -q .; then
+  ROOT_ORIGIN_HAS_LOCAL_REFS=1
+fi
+ROOT_ORIGIN_REUSABLE=0
+ROOT_ORIGIN_REUSE_SKIP_REASON=""
+if [ -n "$ROOT_ORIGIN" ] && [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ]; then
+  if [ "$ROOT_ORIGIN_HAS_LOCAL_REFS" = "1" ]; then
+    ROOT_ORIGIN_REUSE_SKIP_REASON="already has Git history"
+  elif ROOT_ORIGIN_REMOTE_REFS="$(
+    GIT_TERMINAL_PROMPT=0 git -C "$ROOT" ls-remote --heads --tags origin 2>/dev/null
+  )"; then
+    if [ -z "$ROOT_ORIGIN_REMOTE_REFS" ]; then
+      ROOT_ORIGIN_REUSABLE=1
+    else
+      ROOT_ORIGIN_REUSE_SKIP_REASON="already has Git history"
+    fi
+  else
+    ROOT_ORIGIN_REUSE_SKIP_REASON="could not be verified as empty"
+  fi
+fi
+root_origin_can_be_reused() {
+  [ "$ROOT_ORIGIN_REUSABLE" = "1" ]
+}
 
 # GitHub remotes (needs gh). Default off; --remotes=yes requires gh and an owner.
 # Visibility is independent of the project license: private repos may use open-source
@@ -371,7 +396,7 @@ if [ "$MK_REMOTES" = "1" ]; then
       esac
     done
   fi
-  if [ "$LAYOUT" = "2" ] && [ -n "$ROOT_ORIGIN" ] && [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ]; then
+  if [ "$LAYOUT" = "2" ] && root_origin_can_be_reused; then
     OWNER=""
   else
     OWNER="$(want "$OWNER_IN" 'GitHub owner/org')"
@@ -617,8 +642,16 @@ make_remote() { # dir reponame
   return 1
 }
 reuse_root_origin() { # dir
-  [ -n "$ROOT_ORIGIN" ] || return 1
-  [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ] || return 1
+  root_origin_can_be_reused || {
+    if [ -n "$ROOT_ORIGIN" ] \
+      && [ "$ROOT_ORIGIN_IS_THROUGHSTONE" = "0" ] \
+      && [ -n "$ROOT_ORIGIN_REUSE_SKIP_REASON" ]; then
+      echo "  note: existing root origin $ROOT_ORIGIN_REUSE_SKIP_REASON and was not reused:"
+      echo "        $ROOT_ORIGIN"
+      echo "        Add a fresh remote, or replace that remote only after an explicit review."
+    fi
+    return 1
+  }
   ( cd "$1" && git remote add origin "$ROOT_ORIGIN" )
   echo "  remote: reused existing origin ($ROOT_ORIGIN)"
   if [ "$MK_REMOTES" = "1" ]; then

--- a/tests/init-mono-origin-reuse.sh
+++ b/tests/init-mono-origin-reuse.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for mono-repo reuse of an existing root origin.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-mono-origin-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST - copy HEAD plus current working-tree changes, without Git metadata.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+commit_all() {
+  git -c user.name="Throughstone Test" \
+    -c user.email="throughstone-test@example.invalid" \
+    commit -qm "$1"
+}
+
+run_non_empty_origin_case() {
+  local name="mono-template-origin"
+  local seed="$TMP_ROOT/$name-seed"
+  local work="$TMP_ROOT/$name"
+  local remote="$TMP_ROOT/$name-origin.git"
+
+  copy_template "$seed"
+  (
+    cd "$seed"
+    git init -q
+    git add -A
+    commit_all "Template-created commit"
+    git branch -M main
+    git init --bare -q "$remote"
+    git remote add origin "$remote"
+    git push -q -u origin main
+  )
+  git clone -q -b main "$remote" "$work"
+
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Mono origin reuse test" \
+      --license=private \
+      --layout=mono \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ "$(git -C "$work" rev-list --count main)" -eq 1 ]
+  if git -C "$work" remote get-url origin >/dev/null 2>&1; then
+    echo "FAIL: non-empty template origin was reused automatically" >&2
+    return 1
+  fi
+  grep -Fq "existing root origin already has Git history and was not reused" \
+    "$TMP_ROOT/$name.out"
+  grep -Fq "$remote" "$TMP_ROOT/$name.out"
+}
+
+run_empty_origin_case() {
+  local name="mono-empty-origin"
+  local work="$TMP_ROOT/$name"
+  local remote="$TMP_ROOT/$name-origin.git"
+
+  copy_template "$work"
+  git init --bare -q "$remote"
+  (
+    cd "$work"
+    git init -q
+    git remote add origin "$remote"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Mono empty origin reuse test" \
+      --license=private \
+      --layout=mono \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ "$(git -C "$work" remote get-url origin)" = "$remote" ]
+  grep -Fq "remote: reused existing origin ($remote)" "$TMP_ROOT/$name.out"
+}
+
+run_non_empty_origin_case
+run_empty_origin_case
+
+echo "init.sh mono origin reuse: PASS"


### PR DESCRIPTION
## Summary
- stop mono init from auto-reusing root origins unless they can be verified empty
- warn when an existing template-created origin has history or cannot be verified
- update README guidance and add focused mono-origin regression coverage

## Verification
- shellcheck init.sh tests/init-mono-origin-reuse.sh
- bash -n init.sh tests/init-mono-origin-reuse.sh tests/init-license-validation.sh tests/init-adr-authority.sh
- tests/init-mono-origin-reuse.sh
- tests/init-license-validation.sh
- tests/init-adr-authority.sh
- tests/status-conditional-priority.sh
- git diff --check