### PR TITLE
Clarify brand asset generators

### DIFF
--- a/brand/logo/generate_logo.py
+++ b/brand/logo/generate_logo.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
 """Generate the Throughstone logo SVG set.
 
-The mark is hand-built from rectangles (a coursed wall + an ochre through-stone on a
-dark tile). The wordmark "THROUGHSTONE" is outlined from Cinzel into vector paths so the
-final SVGs have NO font dependency. Run with the venv python that has fonttools.
+Inputs:
+  - brand/site/assets/fonts/Cinzel.ttf for the wordmark
+  - fonttools for reading the font and outlining glyphs to SVG paths
+
+Outputs:
+  - standalone mark SVGs: primary, on-dark, monochrome, and favicon
+  - standalone wordmark SVG
+  - horizontal and stacked lockups
+
+The mark is hand-built from rectangles (a coursed wall plus an ochre through-stone).
+The wordmark "THROUGHSTONE" is outlined from Cinzel so the final SVGs do not depend on
+fonts being installed wherever the assets are viewed.
 """
 import os
 from fontTools.ttLib import TTFont
@@ -23,7 +32,8 @@ MORTAR = "#857667"
 INK    = "#2A2521"
 
 # ---------------------------------------------------------------- mark builder
-# all coordinates live in a 0..100 box
+# Mark geometry uses a normalized 0..100 coordinate system. Output variants scale this box
+# instead of duplicating wall/block measurements for each final SVG size.
 BLOCKS = [  # sand courses (x, y, w)  h=12
     (16,16,21.33),(39.33,16,21.33),(62.66,16,21.34),
     (16,30,10.66),(28.66,30,21.33),(51.99,30,21.33),(75.32,30,8.68),
@@ -33,12 +43,17 @@ BLOCKS = [  # sand courses (x, y, w)  h=12
 STONE = (11,44,78,12)  # ochre through-stone (protrudes past the 16..84 wall faces)
 
 def _block_rects(fill):
+    """Return the sand wall blocks as SVG rects in the normalized mark coordinate system."""
     return "".join(
         f'<rect x="{x}" y="{y}" width="{w}" height="12" rx="1.5" fill="{fill}"/>'
         for (x,y,w) in BLOCKS)
 
 def mark(tile=None, block=SAND, stone=OCHRE):
-    """Full mark. tile=None => no background tile (for dark / floating use)."""
+    """Return the full wall mark.
+
+    The wall is two staggered pairs of courses. The middle row is replaced by the longer
+    through-stone, which visually breaks past the 16..84 wall faces.
+    """
     s = ""
     if tile:
         s += f'<rect x="2" y="2" width="96" height="96" rx="18" fill="{tile}"/>'
@@ -48,14 +63,18 @@ def mark(tile=None, block=SAND, stone=OCHRE):
     return s
 
 def mark_mono(color="currentColor"):
-    """One-colour mark: blocks + protruding stone in a single colour, no tile.
-    The stone is identifiable because it is longer and breaks the wall faces."""
+    """Return the one-colour mark with no tile.
+
+    Blocks and through-stone share one fill; the stone remains identifiable because it is
+    longer and breaks the wall faces.
+    """
     s = _block_rects(color)
     x,y,w,h = STONE
     s += f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="2.5" fill="{color}"/>'
     return s
 
 def favicon(tile=INK, block=SAND, stone=OCHRE):
+    """Return a simplified mark for small icon use."""
     return (f'<rect x="2" y="2" width="96" height="96" rx="18" fill="{tile}"/>'
             f'<rect x="16" y="18" width="68" height="12" rx="2" fill="{block}"/>'
             f'<rect x="11" y="44" width="78" height="12" rx="2.5" fill="{stone}"/>'
@@ -63,6 +82,12 @@ def favicon(tile=INK, block=SAND, stone=OCHRE):
 
 # ---------------------------------------------------------------- wordmark
 def wordmark_path(text="THROUGHSTONE", tracking=0.045):
+    """Outline the Cinzel wordmark and return its SVG path plus font-unit bounds.
+
+    The font is read once per call from the bundled TTF. Glyphs are placed manually with
+    tracking in font units so the generated SVG owns the exact typography rather than relying
+    on a client-side font lookup.
+    """
     font = TTFont(FONT)
     upem = font["head"].unitsPerEm
     cmap = font.getBestCmap()
@@ -85,6 +110,7 @@ def wordmark_path(text="THROUGHSTONE", tracking=0.045):
 
 # ---------------------------------------------------------------- svg writer
 def write(name, w, h, body, comment=""):
+    """Write one standalone SVG asset."""
     svg = (f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w:g} {h:g}" '
            f'width="{w:g}" height="{h:g}" fill="none">'
            f'{comment}{body}</svg>\n')
@@ -93,7 +119,11 @@ def write(name, w, h, body, comment=""):
     print(f"  wrote {name}  ({w:g}x{h:g})")
 
 def wordmark_group(d, xmin, ymin, xmax, ymax, fill, cap_px, x_off=0, y_center=None):
-    """Return (svg_group, width_px, height_px) for the wordmark scaled to cap_px."""
+    """Return (svg_group, width_px, height_px) for the wordmark scaled to cap_px.
+
+    Font outlines use a y-up coordinate system. SVG uses y-down, so the transform scales y by
+    -1 and translates from font bounds into the requested SVG position.
+    """
     fh = ymax - ymin
     fw = xmax - xmin
     scale = cap_px / fh
@@ -110,6 +140,7 @@ print("Building Throughstone logo set:")
 d, xmin, ymin, xmax, ymax = wordmark_path()
 TM = '<!-- Throughstone (TM) — Mark A. Herschberg. Mark may not be altered. -->'
 
+# Standalone mark variants.
 # 1. primary colour mark (ink tile)
 write("throughstone-mark.svg", 100, 100, mark(tile=INK), TM)
 # 2. on-dark colour mark (no tile; sand+ochre float on the dark surface)
@@ -124,6 +155,8 @@ gw, wpx, hpx = wordmark_group(d, xmin, ymin, xmax, ymax, INK, cap_px=100, x_off=
 write("throughstone-wordmark.svg", round(wpx,1), 100, gw)
 
 # ---- lockups ----
+# Horizontal lockups share a 100px-high canvas: a scaled 0..100 mark on the left and an
+# outlined wordmark centered vertically on the right.
 # layout constants (in a 100-tall canvas)
 MARK = 78.0          # mark box size
 MX, MY = 0.0, 11.0   # mark position
@@ -131,6 +164,7 @@ GAP = 24.0           # gap between mark and wordmark
 CAP = 46.0           # wordmark cap height in lockup
 
 def lockup_horizontal(filename, tile, block, stone, wm_fill, mono=False):
+    """Write one horizontal lockup variant."""
     if mono:
         markbody = mark_mono("currentColor")
     else:
@@ -150,6 +184,7 @@ lockup_horizontal("throughstone-lockup-mono.svg", None, None, None, "currentColo
 
 # 9. stacked lockup (mark centred above wordmark)
 def lockup_stacked(filename, tile, block, stone, wm_fill):
+    """Write the stacked lockup with the mark centered over the wordmark."""
     markbox = 96.0
     gw_tmp, wpx, _ = wordmark_group(d, xmin, ymin, xmax, ymax, wm_fill, cap_px=30)
     total_w = max(markbox, wpx)

--- a/brand/social/generate_social.py
+++ b/brand/social/generate_social.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
-"""Generate the Throughstone social card (Option C) as a self-contained SVG with
-ALL text outlined to vector paths (no font dependency). 1280x640."""
+"""Generate the Throughstone social card SVG.
+
+The card is a 1280x640 Open Graph-style canvas with a dark left brand column and a
+paper right text column. All copy is outlined to SVG paths via fonttools so the output is
+self-contained and does not depend on installed fonts.
+"""
 import os
 from fontTools.ttLib import TTFont
 from fontTools.pens.svgPathPen import SVGPathPen
@@ -8,81 +12,133 @@ from fontTools.pens.transformPen import TransformPen
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 FDIR = os.path.join(HERE, "..", "site", "assets", "fonts")
-def fp(n): return os.path.join(FDIR, n)
 
-PAPER="#F4EEE2"; SAND="#DEC9A0"; OCHRE="#B07A35"; OCHRED="#8F6024"; MORTAR="#857667"; INK="#2A2521"
+PAPER = "#F4EEE2"
+SAND = "#DEC9A0"
+OCHRE = "#B07A35"
+OCHRED = "#8F6024"
+MORTAR = "#857667"
+INK = "#2A2521"
 
-_cache={}
+CINZEL = os.path.join(FDIR, "Cinzel.ttf")
+SANS = os.path.join(FDIR, "SourceSans3-400.ttf")
+SANS600 = os.path.join(FDIR, "SourceSans3-600.ttf")
+MONO = os.path.join(FDIR, "IBMPlexMono-400.ttf")
+
+# Font cache stores the parsed font plus the tables needed by path/width helpers. Reusing
+# TTFont objects keeps wrapping and composition from repeatedly parsing the same TTF files.
+_cache = {}
+
 def load(path):
+    """Return cached fonttools data for one font path."""
     if path not in _cache:
-        f=TTFont(path)
-        _cache[path]=(f, f["head"].unitsPerEm, f.getBestCmap(), f.getGlyphSet(), f["hmtx"])
+        f = TTFont(path)
+        _cache[path] = (
+            f,
+            f["head"].unitsPerEm,
+            f.getBestCmap(),
+            f.getGlyphSet(),
+            f["hmtx"],
+        )
     return _cache[path]
 
 def text_path(text, font_path, size, x, baseline, fill, tracking=0.0, return_w=False):
-    f,upem,cmap,gs,hmtx = load(font_path)
-    scale=size/upem
-    track_u = (tracking*size)/scale  # tracking given as em fraction
-    pen=SVGPathPen(gs)
-    cur=0.0
-    space=cmap.get(0x20)
+    """Return SVG path markup for text drawn at a baseline.
+
+    Fonts are y-up while SVG is y-down, so each glyph transform scales y by -scale and places
+    the glyph at the requested SVG baseline. The optional width return lets the footer place
+    mixed-color text without relying on browser text measurement.
+    """
+    f, upem, cmap, gs, hmtx = load(font_path)
+    scale = size / upem
+    track_u = (tracking * size) / scale  # tracking is an em fraction, converted to font units
+    pen = SVGPathPen(gs)
+    cur = 0.0
+    space = cmap.get(0x20)
+
     for ch in text:
-        gname=cmap.get(ord(ch), space)
+        gname = cmap.get(ord(ch), space)
         if gname is None:
-            cur += 0.5*upem + track_u; continue
-        # affine: xx=scale, yy=-scale, dx=x+cur*scale, dy=baseline
-        t=(scale,0,0,-scale, x+cur*scale, baseline)
+            cur += 0.5 * upem + track_u
+            continue
+
+        # Affine transform: xx=scale, yy=-scale, dx=x+cur*scale, dy=baseline.
+        t = (scale, 0, 0, -scale, x + cur * scale, baseline)
         gs[gname].draw(TransformPen(pen, t))
         cur += hmtx[gname][0] + track_u
-    d=pen.getCommands()
-    g=f'<path d="{d}" fill="{fill}"/>'
-    if return_w: return g, cur*scale
+
+    d = pen.getCommands()
+    g = f'<path d="{d}" fill="{fill}"/>'
+    if return_w:
+        return g, cur * scale
     return g
 
 def width_of(text, font_path, size, tracking=0.0):
-    f,upem,cmap,gs,hmtx=load(font_path)
-    scale=size/upem; track_u=(tracking*size)/scale; cur=0.0; space=cmap.get(0x20)
+    """Measure outlined text using the same glyph advances used by text_path."""
+    f, upem, cmap, gs, hmtx = load(font_path)
+    scale = size / upem
+    track_u = (tracking * size) / scale
+    cur = 0.0
+    space = cmap.get(0x20)
+
     for ch in text:
-        gname=cmap.get(ord(ch),space)
-        cur += (hmtx[gname][0] if gname else 0.5*upem) + track_u
-    return cur*scale
+        gname = cmap.get(ord(ch), space)
+        cur += (hmtx[gname][0] if gname else 0.5 * upem) + track_u
+    return cur * scale
 
 def wrap(text, font_path, size, maxw):
-    words=text.split(); lines=[]; cur=""
+    """Greedy-wrap copy to maxw using vector advance widths."""
+    words = text.split()
+    lines = []
+    cur = ""
+
     for w in words:
-        t=(cur+" "+w).strip()
-        if width_of(t,font_path,size)<=maxw or not cur: cur=t
-        else: lines.append(cur); cur=w
-    if cur: lines.append(cur)
+        t = (cur + " " + w).strip()
+        if width_of(t, font_path, size) <= maxw or not cur:
+            cur = t
+        else:
+            lines.append(cur)
+            cur = w
+    if cur:
+        lines.append(cur)
     return lines
 
-CINZEL=fp("Cinzel.ttf"); SANS=fp("SourceSans3-400.ttf"); SANS600=fp("SourceSans3-600.ttf"); MONO=fp("IBMPlexMono-400.ttf")
-
-# ----- mark wall (rows 16/30/58/72; row 44 left open for the stone) -----
-ROWS={
- 16:[(16,21.33),(39.33,21.33),(62.66,21.34)],
- 30:[(16,10.66),(28.66,21.33),(51.99,21.33),(75.32,8.68)],
- 58:[(16,21.33),(39.33,21.33),(62.66,21.34)],
- 72:[(16,10.66),(28.66,21.33),(51.99,21.33),(75.32,8.68)],
+# ----- mark wall -----
+# The wall reuses the logo's 0..100 mark coordinates, scaled up and placed in the left column.
+# Rows 16/30/58/72 are sand blocks; row 44 is intentionally open for the ochre through-stone.
+ROWS = {
+    16: [(16, 21.33), (39.33, 21.33), (62.66, 21.34)],
+    30: [(16, 10.66), (28.66, 21.33), (51.99, 21.33), (75.32, 8.68)],
+    58: [(16, 21.33), (39.33, 21.33), (62.66, 21.34)],
+    72: [(16, 10.66), (28.66, 21.33), (51.99, 21.33), (75.32, 8.68)],
 }
 WALL_X, WALL_Y, WALL_S = 64, 154, 3.32
+
 def wall():
-    s=""
-    for y,blocks in ROWS.items():
-        for (bx,bw) in blocks:
-            X=WALL_X+bx*WALL_S; Y=WALL_Y+y*WALL_S; W=bw*WALL_S; H=12*WALL_S
-            s+=f'<rect x="{X:.1f}" y="{Y:.1f}" width="{W:.1f}" height="{H:.1f}" rx="5" fill="{SAND}"/>'
+    """Return the scaled wall blocks for the social-card illustration."""
+    s = ""
+    for y, blocks in ROWS.items():
+        for bx, bw in blocks:
+            X = WALL_X + bx * WALL_S
+            Y = WALL_Y + y * WALL_S
+            W = bw * WALL_S
+            H = 12 * WALL_S
+            s += f'<rect x="{X:.1f}" y="{Y:.1f}" width="{W:.1f}" height="{H:.1f}" rx="5" fill="{SAND}"/>'
     return s
 
 # ----- compose -----
+# 1280x640 canvas: the left 460px is the dark brand column; the right column starts at X=540.
+# The through-stone crosses out of the wall and toward the right column, echoing the mark.
 X = 540  # right-column left edge
-parts=[]
+parts = []
 parts.append(f'<rect x="0" y="0" width="1280" height="640" fill="{PAPER}"/>')
 parts.append(f'<rect x="0" y="0" width="460" height="640" fill="{INK}"/>')
 parts.append(wall())
 parts.append(f'<rect x="96" y="300" width="430" height="40" rx="6" fill="{OCHRE}"/>')  # through-stone bridges seam
 
-# wordmark THROUGHSTONE (Cinzel caps, tracking .05), cap height 40, baseline 210
+# Every text run below is converted to vector paths so the social card renders consistently in
+# previews, crawlers, and static hosts that may not have the brand fonts.
+# Wordmark THROUGHSTONE (Cinzel caps, tracking .05), cap height 40, baseline 210.
 parts.append(text_path("THROUGHSTONE", CINZEL, 53, X, 212, INK, tracking=0.05))
 # eyebrow
 parts.append(text_path("DISCIPLINED SOFTWARE DEVELOPMENT", CINZEL, 17, X, 262, OCHRED, tracking=0.13))
@@ -90,20 +146,22 @@ parts.append(text_path("DISCIPLINED SOFTWARE DEVELOPMENT", CINZEL, 17, X, 262, O
 parts.append(text_path("From idea to blueprint", SANS600, 56, X, 330, INK))
 parts.append(text_path("to built.", SANS600, 56, X, 392, INK))
 # descriptor, Source Sans 22, wrapped
-desc="Start with your software idea — your AI agent turns it into a planned, documented, well-architected project."
-lines=wrap(desc, SANS, 22, 600)
-y=452
+desc = "Start with your software idea — your AI agent turns it into a planned, documented, well-architected project."
+lines = wrap(desc, SANS, 22, 600)
+y = 452
 for ln in lines:
-    parts.append(text_path(ln, SANS, 22, X, y, MORTAR)); y+=31
+    parts.append(text_path(ln, SANS, 22, X, y, MORTAR))
+    y += 31
 # footer, Plex Mono 15 — url ink, rest mortar
-url="github.com/mherschberg/Throughstone"
-sep="   ·   BSD-3-Clause · Throughstone™"
-g1,w1=text_path(url, MONO, 15, X, 592, INK, return_w=True)
+url = "github.com/mherschberg/Throughstone"
+sep = "   ·   BSD-3-Clause · Throughstone™"
+g1, w1 = text_path(url, MONO, 15, X, 592, INK, return_w=True)
 parts.append(g1)
-parts.append(text_path(sep, MONO, 15, X+w1, 592, MORTAR))
+parts.append(text_path(sep, MONO, 15, X + w1, 592, MORTAR))
 
-svg=('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" width="1280" height="640">'
-     '<!-- Throughstone (TM) social card -->'+"".join(parts)+'</svg>\n')
-out=os.path.join(HERE,"throughstone-social.svg")
-with open(out,"w") as f: f.write(svg)
+svg = ('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" width="1280" height="640">'
+       '<!-- Throughstone (TM) social card -->' + "".join(parts) + '</svg>\n')
+out = os.path.join(HERE, "throughstone-social.svg")
+with open(out, "w") as f:
+    f.write(svg)
 print("wrote", out, f"({len(svg)} bytes)")


### PR DESCRIPTION
## Summary
- Add concise docstrings and intent comments to the logo generator covering fonttools, mark geometry, vector outlines, transforms, and output variants.
- Add comments/docstrings to the social-card generator for font caching, text outlining, wrapping, wall construction, and 1280x640 composition.
- Lightly clean up dense social generator assignments and helper code while preserving generated output.

## Verification
- python3 -m py_compile brand/logo/generate_logo.py brand/social/generate_social.py
- git diff --check
- Ran old and new generators with the same temporary fonttools environment and confirmed every generated SVG matched byte-for-byte.