### PR TITLE
Add configurable init trunk branch

### DIFF
--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -53,7 +53,7 @@ write anything.
 3. **Add the row** to `prompts/STEP-index.md` (number, title, owner = you, status, one-line scope,
    and the repos you expect to touch).
 4. **Commit small and push immediately** — a dedicated `reserve STEP-N` commit on `prompts/`'s
-   **shared trunk** (e.g. `main`), separate from any other change. `prompts/STEP-index.md` is a shared
+   **shared trunk** (`{{TRUNK_BRANCH}}`), separate from any other change. `prompts/STEP-index.md` is a shared
    registry: the reserve commit *and every later edit to it* (status flips, archival rows) land
    on the trunk, **never on a `step-NNNN` branch** — the push-reject that referees the race only
    fires when everyone pushes to the same branch, and the duplicate scan (step 6) only works if

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ things keep them approachable whatever your background:
      ```
      GitHub template repos already contain a template-created commit. Because `init.sh`
      creates fresh project history, it will not automatically reuse that non-empty `origin`
-     in **mono-repo** mode; otherwise a normal `git push -u origin main` would fail. Use
+     in **mono-repo** mode; otherwise a normal push to the generated trunk branch would fail. Use
      the template path as a download vehicle, then add an empty remote later, delete/recreate
      the GitHub repo before using GitHub remote creation, or deliberately replace the
      template-created remote yourself after reviewing the history. In the default
@@ -143,6 +143,10 @@ things keep them approachable whatever your background:
    Any flag you omit is still prompted (without `--non-interactive`); with it, a missing
    required value is an error. `init.sh` first checks that `git` and `perl` are present. When
    it finishes you can delete `init.sh` — it has done its job.
+
+   Generated repos use `main` as their trunk branch by default. If your team uses another
+   convention, pass `--trunk-branch=master` (or another valid Git branch name) and the
+   initialized repos, pushes, and generated collaboration docs will use that branch.
 
    Repository visibility is separate from licensing. When creating GitHub remotes, use
    `--visibility=private` or `--visibility=public`; the default is private. Public visibility

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ things keep them approachable whatever your background:
    unattached so setup does not lead you into a failed or destructive push. See
    [`init.sh`](init.sh).
 
-   Prefer to script it? Every question has a flag — run `./init.sh --help` to see them, or
-   pre-answer non-interactively, e.g.:
+   Prefer to script it? Every question has a flag — run `./init.sh --help` or see
+   [What `init.sh` flags are available?](#what-initsh-flags-are-available) for the full list.
+   You can pre-answer non-interactively, e.g.:
    ```bash
    ./init.sh --non-interactive --slug=acme --desc="platform for roadrunner catching" \
              --license=mit --holder="Acme Inc." --layout=multi
@@ -143,10 +144,6 @@ things keep them approachable whatever your background:
    Any flag you omit is still prompted (without `--non-interactive`); with it, a missing
    required value is an error. `init.sh` first checks that `git` and `perl` are present. When
    it finishes you can delete `init.sh` — it has done its job.
-
-   Generated repos use `main` as their trunk branch by default. If your team uses another
-   convention, pass `--trunk-branch=master` (or another valid Git branch name) and the
-   initialized repos, pushes, and generated collaboration docs will use that branch.
 
    Repository visibility is separate from licensing. When creating GitHub remotes, use
    `--visibility=private` or `--visibility=public`; the default is private. Public visibility
@@ -261,6 +258,33 @@ You need an idea and a local AI coding agent. A page or two of notes helps, but 
 required; the kickoff interview can help you turn a rough idea into the initial project
 brief. For setup, you need a POSIX shell, `git`, and `perl` as described in the
 [Quickstart](#quickstart).
+
+### What `init.sh` flags are available?
+
+`./init.sh` runs interactively by default. Flags pre-answer setup questions; any omitted
+answer is still prompted unless you pass `--non-interactive`. Flags take precedence over the
+matching environment variables.
+
+| Flag | Env var | Values | Purpose |
+|------|---------|--------|---------|
+| `--slug=SLUG` | `INIT_SLUG` | lowercase kebab-case | Project slug used for generated paths and placeholders. |
+| `--desc=TEXT` | `INIT_DESC` | one-line text | Seed project description. |
+| `--license=NAME` | `INIT_LICENSE` | `mit`, `bsd-3`, `apache-2.0`, `private` | Project license posture. |
+| `--holder=NAME` | `INIT_HOLDER` | text | Copyright holder for open-source licenses. |
+| `--layout=LAYOUT` | `INIT_LAYOUT` | `multi`, `mono` | Repo layout; default is `multi`. |
+| `--registries=yes\|no` | `INIT_REGISTRIES` | `yes`, `no` | Keep `registries/` in mono-repo mode; default is `yes`. |
+| `--collab=MODE` | `INIT_COLLAB` | `solo`, `team` | Collaboration wording and ADR authority defaults; default is `solo`. |
+| `--adr-authority=TEXT` | `INIT_ADR_AUTHORITY` | text | Who accepts ADRs in team mode. |
+| `--trunk-branch=NAME` | `INIT_TRUNK_BRANCH` | valid Git branch name | Generated repo trunk branch; default is `main`. |
+| `--remotes=yes\|no` | `INIT_REMOTES` | `yes`, `no` | Set up Git remotes during init; default is `no`. |
+| `--remote-provider=PROVIDER` | `INIT_REMOTE_PROVIDER` | `github`, `manual` | Use GitHub CLI or existing remote URLs; default is `github` when remotes are enabled. |
+| `--owner=OWNER` | `INIT_OWNER` | GitHub user/org | GitHub owner/org for `--remote-provider=github`. |
+| `--remote-url=URL` | `INIT_REMOTE_URL` | Git URL | Existing mono-repo remote URL for manual setup. |
+| `--docs-remote=URL` | `INIT_DOCS_REMOTE` | Git URL | Existing docs repo remote URL for manual multi-repo setup. |
+| `--prompts-remote=URL` | `INIT_PROMPTS_REMOTE` | Git URL | Existing prompts repo remote URL for manual multi-repo setup. |
+| `--visibility=VALUE` | `INIT_VISIBILITY` | `private`, `public` | GitHub repo visibility; default is `private`. |
+| `-y`, `--yes`, `--non-interactive` | `INIT_NONINTERACTIVE` | none / truthy env value | Never prompt; error on missing required values. |
+| `-h`, `--help` | | none | Show the help text and exit. |
 
 ### What documents does Throughstone create?
 

--- a/init.sh
+++ b/init.sh
@@ -52,6 +52,17 @@ normalize_license_choice() {
   esac
 }
 
+# validate_trunk_branch NAME — accept ordinary Git branch names, reject empty/pathological
+# values before bootstrap removes the template history.
+validate_trunk_branch() {
+  local branch="$1"
+  [ -n "$branch" ] || return 1
+  case "$branch" in
+    -*|HEAD) return 1 ;;
+  esac
+  git check-ref-format "refs/heads/$branch" >/dev/null 2>&1
+}
+
 # choose_license_interactively — prompt until the project type and license are valid.
 # Proprietary is a project-license posture, not a GitHub visibility setting. Open-source
 # projects choose a concrete permissive license template; proprietary projects intentionally
@@ -151,6 +162,7 @@ Options:
   --registries=yes|no   Keep registries/ (mono-repo only; default: yes)
   --collab=MODE         solo | team                     (default: solo)
   --adr-authority=TEXT  Who accepts ADRs (team only; default: consensus of maintainers)
+  --trunk-branch=NAME   Generated repo trunk branch     (default: main)
   --remotes=yes|no      Set up remotes now              (default: no)
   --remote-provider=PROVIDER
                          github | manual                (default: github)
@@ -165,7 +177,7 @@ Options:
 Env vars (flags take precedence): INIT_SLUG, INIT_DESC, INIT_LICENSE, INIT_HOLDER,
   INIT_LAYOUT, INIT_REGISTRIES, INIT_COLLAB, INIT_ADR_AUTHORITY, INIT_REMOTES,
   INIT_REMOTE_PROVIDER, INIT_OWNER, INIT_REMOTE_URL, INIT_DOCS_REMOTE,
-  INIT_PROMPTS_REMOTE, INIT_VISIBILITY, INIT_NONINTERACTIVE.
+  INIT_PROMPTS_REMOTE, INIT_VISIBILITY, INIT_TRUNK_BRANCH, INIT_NONINTERACTIVE.
 USAGE
 }
 
@@ -177,6 +189,7 @@ SLUG_IN="${INIT_SLUG:-}";       DESC_IN="${INIT_DESC:-}"
 LICENSE_IN="${INIT_LICENSE:-}"; HOLDER_IN="${INIT_HOLDER:-}"
 LAYOUT_IN="${INIT_LAYOUT:-}";   REGISTRIES_IN="${INIT_REGISTRIES:-}"
 COLLAB_IN="${INIT_COLLAB:-}";   ADR_AUTHORITY_IN="${INIT_ADR_AUTHORITY:-}"
+TRUNK_BRANCH_IN="${INIT_TRUNK_BRANCH:-}"; TRUNK_BRANCH_FLAG_SET=0
 REMOTES_IN="${INIT_REMOTES:-}"; REMOTE_PROVIDER_IN="${INIT_REMOTE_PROVIDER:-}"
 OWNER_IN="${INIT_OWNER:-}";     REMOTE_URL_IN="${INIT_REMOTE_URL:-}"
 DOCS_REMOTE_IN="${INIT_DOCS_REMOTE:-}"; PROMPTS_REMOTE_IN="${INIT_PROMPTS_REMOTE:-}"
@@ -201,6 +214,8 @@ while [ $# -gt 0 ]; do
     --collab)          COLLAB_IN="${2:-}"; shift ;;
     --adr-authority=*) ADR_AUTHORITY_IN="${1#*=}" ;;
     --adr-authority)   ADR_AUTHORITY_IN="${2:-}"; shift ;;
+    --trunk-branch=*)  TRUNK_BRANCH_IN="${1#*=}"; TRUNK_BRANCH_FLAG_SET=1 ;;
+    --trunk-branch)    TRUNK_BRANCH_IN="${2:-}"; TRUNK_BRANCH_FLAG_SET=1; shift ;;
     --remotes=*)       REMOTES_IN="${1#*=}" ;;
     --remotes)         REMOTES_IN="${2:-}"; shift ;;
     --remote-provider=*) REMOTE_PROVIDER_IN="${1#*=}" ;;
@@ -380,6 +395,17 @@ if [ "$COLLAB" = "2" ]; then
       echo "  before the team grows — see METHOD.md §7 (\"Mono-repo for now\")."
     fi
   fi
+fi
+
+# Generated repos default to a `main` trunk, but teams that still standardize on `master` or
+# another branch name can stamp that convention into Git and the generated collaboration docs.
+TRUNK_BRANCH="main"
+if [ "$TRUNK_BRANCH_FLAG_SET" = "1" ] || [ -n "$TRUNK_BRANCH_IN" ]; then
+  TRUNK_BRANCH="$TRUNK_BRANCH_IN"
+fi
+if ! validate_trunk_branch "$TRUNK_BRANCH"; then
+  echo "init.sh: invalid --trunk-branch '$TRUNK_BRANCH' (valid Git branch name, e.g. main, master, trunk, release/stable)." >&2
+  exit 2
 fi
 
 # Remember whether this download came from an existing project repo before we detach it. A
@@ -682,6 +708,11 @@ printf '%s\n' "$PROJECT_LICENSE_ID" > "$DOCS/.throughstone/project-license"
 grep -rlF '{{PROJECT_DESCRIPTION}}' . --exclude-dir=.git 2>/dev/null | while read -r f; do
   DESC="$DESC" perl -pi -e 's/\Q{{PROJECT_DESCRIPTION}}\E/$ENV{DESC}/g' "$f"
 done
+# Fill generated collaboration docs with the actual initialized trunk branch. The scaffold
+# keeps the placeholder only where generated-project text should name the branch.
+grep -rlF '{{TRUNK_BRANCH}}' . --exclude-dir=.git 2>/dev/null | while read -r f; do
+  TRUNK_BRANCH="$TRUNK_BRANCH" perl -pi -e 's/\Q{{TRUNK_BRANCH}}\E/$ENV{TRUNK_BRANCH}/g' "$f"
+done
 
 # Relocate the scaffold's BSD license into the docs hub (retained as attribution per BSD-3,
 # next to the method files it covers — not deleted). Open-source project licenses are stamped
@@ -806,7 +837,7 @@ EOF
   fi
 }
 
-# init_repo DIR — create one generated repo with baseline files and an initial main commit.
+# init_repo DIR — create one generated repo with baseline files and an initial trunk commit.
 # Callers decide which directories are durable repos; this helper keeps their initial commit
 # shape consistent.
 init_repo() {
@@ -814,7 +845,7 @@ init_repo() {
   stamp_license "$1"
   write_licensing_summary "$1"
   ( cd "$1" && git init -q && git add -A && git commit -qm "Initial commit (bootstrapped)" \
-    && git branch -M main; )   # pin trunk to main (collaboration.md assumes a 'main' trunk)
+    && git branch -M "$TRUNK_BRANCH"; )
   echo "  git repo: $1"
 }
 
@@ -855,21 +886,21 @@ commit_registry_remotes() {
   ( cd "$DOCS" && git add registries/repos.yml && git commit -qm "Record bootstrap remotes" )
   echo "  registry: recorded bootstrap remotes"
   if git -C "$DOCS" remote get-url origin >/dev/null 2>&1; then
-    ( cd "$DOCS" && git push -q origin main && echo "  registry: pushed remote updates" ) \
+    ( cd "$DOCS" && git push -q origin "$TRUNK_BRANCH" && echo "  registry: pushed remote updates" ) \
       || echo "  (could not push registry remote updates; push ${DOCS} manually later)"
   fi
 }
 
 # setup_remote DIR REPONAME MANUAL_URL — create/attach and push a remote.
 # GitHub mode creates a repo with gh. Manual mode attaches an existing remote URL from any Git
-# host and pushes the initialized main branch. MADE_REMOTE_URL is a small out-parameter used only
-# by the multi-repo registry recorder.
+# host and pushes the initialized trunk branch. MADE_REMOTE_URL is a small out-parameter used
+# only by the multi-repo registry recorder.
 setup_remote() {
   MADE_REMOTE_URL=""
   [ "$MK_REMOTES" = "1" ] || return 0
   if [ "$REMOTE_PROVIDER" = "manual" ]; then
     [ -n "${3:-}" ] || return 1
-    if ( cd "$1" && git remote add origin "$3" && git push -u origin main >/dev/null ); then
+    if ( cd "$1" && git remote add origin "$3" && git push -u origin "$TRUNK_BRANCH" >/dev/null ); then
       MADE_REMOTE_URL="$3"
       echo "  remote: $3"
       return 0
@@ -907,7 +938,7 @@ reuse_root_origin() {
   ( cd "$1" && git remote add origin "$ROOT_ORIGIN" )
   echo "  remote: reused existing origin ($ROOT_ORIGIN)"
   if [ "$MK_REMOTES" = "1" ]; then
-    ( cd "$1" && git push -u origin main >/dev/null \
+    ( cd "$1" && git push -u origin "$TRUNK_BRANCH" >/dev/null \
       && echo "  pushed: $ROOT_ORIGIN" ) || echo "  (could not push existing origin; push manually later)"
   fi
   return 0
@@ -962,7 +993,7 @@ Recommended optional backup:
 
   GitHub, Bitbucket, GitLab, and other Git hosts all work with the generated repos.
   If you did not set up remotes during init, create empty repos on your host, add
-  their URLs to registries/repos.yml, and push each local repo's main branch.
+  their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch.
 
   GitHub:
     https://github.com/

--- a/tests/init-trunk-branch.sh
+++ b/tests/init-trunk-branch.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for init.sh trunk branch selection.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-trunk-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — build an init.sh fixture from HEAD, then overlay current worktree
+# changes so this test covers uncommitted bootstrap edits.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+assert_no_ref() {
+  local git_dir="$1" ref="$2"
+  ! git --git-dir="$git_dir" rev-parse --verify "$ref" >/dev/null 2>&1
+}
+
+run_default_case() {
+  local name="trunk-default"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Trunk branch default test" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ "$(git -C "$work/Code/$name-docs" symbolic-ref --short HEAD)" = "main" ]
+  [ "$(git -C "$work/prompts" symbolic-ref --short HEAD)" = "main" ]
+  grep -Fq '**shared trunk** (`main`)' \
+    "$work/Code/$name-docs/runbooks/collaboration.md"
+  ! grep -R '{{TRUNK_BRANCH}}' "$work/Code/$name-docs" "$work/prompts" >/dev/null
+}
+
+run_manual_remote_custom_case() {
+  local name="trunk-master"
+  local work="$TMP_ROOT/$name"
+  local docs_remote="$TMP_ROOT/$name-docs.git"
+  local prompts_remote="$TMP_ROOT/$name-prompts.git"
+
+  copy_template "$work"
+  git init --bare -q "$docs_remote"
+  git init --bare -q "$prompts_remote"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Trunk branch manual remote test" \
+      --license=private \
+      --layout=multi \
+      --collab=team \
+      --adr-authority="consensus of maintainers" \
+      --trunk-branch=master \
+      --remotes=yes \
+      --remote-provider=manual \
+      --docs-remote="$docs_remote" \
+      --prompts-remote="$prompts_remote"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ "$(git -C "$work/Code/$name-docs" symbolic-ref --short HEAD)" = "master" ]
+  [ "$(git -C "$work/prompts" symbolic-ref --short HEAD)" = "master" ]
+  git --git-dir="$docs_remote" rev-parse --verify refs/heads/master >/dev/null
+  git --git-dir="$prompts_remote" rev-parse --verify refs/heads/master >/dev/null
+  assert_no_ref "$docs_remote" refs/heads/main
+  assert_no_ref "$prompts_remote" refs/heads/main
+  git --git-dir="$docs_remote" show master:registries/repos.yml \
+    | grep -Fq "remote: \"$docs_remote\""
+  grep -Fq '**shared trunk** (`master`)' \
+    "$work/Code/$name-docs/runbooks/collaboration.md"
+  grep -Fq "push each local repo's master branch" "$TMP_ROOT/$name.out"
+}
+
+run_mono_reused_origin_custom_case() {
+  local name="trunk-mono"
+  local work="$TMP_ROOT/$name"
+  local remote="$TMP_ROOT/$name-origin.git"
+
+  copy_template "$work"
+  git init --bare -q "$remote"
+  (
+    cd "$work"
+    git init -q
+    git remote add origin "$remote"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Trunk branch mono origin reuse test" \
+      --license=private \
+      --layout=mono \
+      --collab=solo \
+      --trunk-branch=release/stable \
+      --remotes=yes
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  [ "$(git -C "$work" symbolic-ref --short HEAD)" = "release/stable" ]
+  git --git-dir="$remote" rev-parse --verify refs/heads/release/stable >/dev/null
+  assert_no_ref "$remote" refs/heads/main
+  grep -Fq "pushed: $remote" "$TMP_ROOT/$name.out"
+}
+
+run_invalid_case() {
+  local name="$1"
+  local branch_arg="$2"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  if (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Invalid trunk branch test" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no \
+      "$branch_arg"
+  ) >"$TMP_ROOT/$name.out" 2>&1; then
+    echo "FAIL: invalid trunk branch was accepted: $branch_arg" >&2
+    return 1
+  fi
+
+  grep -Fq "init.sh: invalid --trunk-branch" "$TMP_ROOT/$name.out"
+  [ -f "$work/README.md" ]
+  [ -d "$work/Code/{{PROJECT}}-docs" ]
+}
+
+run_default_case
+run_manual_remote_custom_case
+run_mono_reused_origin_custom_case
+run_invalid_case "trunk-empty" "--trunk-branch="
+run_invalid_case "trunk-dotdot" "--trunk-branch=bad..name"
+run_invalid_case "trunk-dash" "--trunk-branch=-bad"
+
+echo "init.sh trunk branch selection: PASS"


### PR DESCRIPTION
## Summary
- add --trunk-branch and INIT_TRUNK_BRANCH to init.sh, keeping main as the default
- validate trunk names before bootstrap mutates the checkout, then use the selected trunk for branch creation and push paths
- stamp generated collaboration docs with the selected trunk and document the option in README
- add focused regression coverage for default, custom, remote push, mono-origin reuse, and invalid-branch behavior

## Tests
- bash -n init.sh
- bash -n tests/init-trunk-branch.sh
- tests/init-trunk-branch.sh
- tests/init-mono-origin-reuse.sh
- tests/init-adr-authority.sh
- tests/init-license-validation.sh
- tests/status-conditional-priority.sh