### PR TITLE
Add incident quick-start card

### DIFF
--- a/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
+++ b/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
@@ -1,5 +1,11 @@
 # Runbook — Incident Response & Postmortem
 
+> **Quick start during an incident:** stabilize service first — roll back, fail over, or
+> disable the bad path before diagnosing. Capture the raw facts while fresh: timeline,
+> symptom/blast radius, affected data, and alerts/logs. Open an **Incident STEP**, start
+> `templates/incident-postmortem.md`, and put unclear fields as `Unknown`. Hand off the
+> RCA → find-similar → fix work to that STEP; use the detailed runbook below for the rest.
+
 > **How to run:** Two modes, run in sequence.
 > - **An incident is happening right now** → this is an **operational procedure**: tell your
 >   agent *"run the incident runbook"* and follow **Part 1** to stabilize and capture the facts.


### PR DESCRIPTION
## Summary
- Add a short quick-start card at the top of the incident response/postmortem runbook.
- Keep the detailed two-mode runbook below intact.
- Leave the postmortem template unchanged because it is the durable incident record, not the during-incident operating guide.

## Why
During an active incident, responders need the critical first-response sequence before the full explanation: stabilize service, capture the timeline and facts, open an Incident STEP, then hand off RCA, find-similar, and fix work to that STEP.

## Validation
- bash 'Code/{{PROJECT}}-docs/scripts/check.sh' (passes: 0 failures; expected scaffold warnings about no initialized prompts/STEP-index.md)