### PR TITLE
Show Throughstone artifact trail on site

### DIFF
--- a/ARTIFACT-TRAIL.md
+++ b/ARTIFACT-TRAIL.md
@@ -1,0 +1,219 @@
+# Throughstone Artifact Trail
+
+Throughstone's main output is not a pile of prompts. It is a durable project memory: a set
+of Markdown files that records what the project is, why decisions were made, what work is
+planned next, and how later code should keep those decisions true.
+
+This page is a guided tour of that trail. The exact content is project-specific, but the
+shape is stable.
+
+## The Short Version
+
+| Artifact | Where it lives | What it gives you |
+|----------|----------------|-------------------|
+| Project brief | `Code/<project>-docs/overview.md` | The seed: users, scope, constraints, risks, and experience level. |
+| STEP roadmap | `prompts/STEP-index.md` | The project plan: every STEP, status, owner, touched repos, and one-line scope. |
+| Architecture docs | `Code/<project>-docs/architecture/NN-*.md` | Current design: the system as it is supposed to work now. |
+| ADRs | `Code/<project>-docs/adr/ADR-NNNN-*.md` | Decision history: why important choices were made. |
+| STEP plans | `Upcoming Prompts/` while active, then `prompts/<phase>/step-NNNN/` | The work contract for a STEP: scope, substeps, ground rules, and done criteria. |
+| Substep prompts | `Upcoming Prompts/` while active, then archived with the STEP | Cold-start instructions for one focused task. |
+| Check-in reports | Archived with check-in STEPs under `prompts/` | Periodic reconciliation: docs vs. code, conditional coverage, risks, and tests. |
+
+The split matters:
+
+- `Code/<project>-docs/` is **state**: what the system is now.
+- `prompts/` is **history**: how the system got there, STEP by STEP.
+- `Upcoming Prompts/` is **working scratch** for the active STEP.
+
+## 1. Project Brief
+
+`overview.md` is the project seed. The kickoff interview creates it from your idea, then
+later sessions read it so the project does not depend on chat memory.
+
+Representative excerpt:
+
+```md
+# acme — Project Overview
+
+<!-- PROJECT-STATUS: kickoff-complete -->
+
+## Your experience level
+- [x] 2 — Basic coding experience
+
+## In one sentence
+A scheduling assistant that negotiates meeting times for small consulting teams.
+
+## What it does (core capabilities)
+- Connect calendar accounts.
+- Propose meeting windows across participants.
+- Send confirmation links and reminders.
+
+## Sensitive data & risk
+Calendar metadata, attendee emails, and meeting notes require careful access control.
+```
+
+The template source is
+[`Code/{{PROJECT}}-docs/templates/overview-template.md`](Code/{{PROJECT}}-docs/templates/overview-template.md).
+
+## 2. STEP Roadmap
+
+`prompts/STEP-index.md` is the first place to look when resuming. It tells a person or an
+agent what exists, what is active, and what comes next.
+
+Representative excerpt:
+
+```md
+| STEP | Title | Owner | Status | Repos (projection) | Scope |
+|------|-------|-------|--------|--------------------|-------|
+| STEP-1 | Architecture | Sam | Done | `acme-docs`, `prompts` | Architecture docs + ADRs, no app code. |
+| STEP-2 | Scaffold API service | Sam | Done | `acme-api` | Create service skeleton, CI, health endpoint. |
+| STEP-3 | Calendar OAuth | Priya | In progress | `acme-api`, `acme-web` | Connect Google Calendar account flow. |
+| STEP-4 | Check-in |  | Planned | all | Reconcile docs/code drift and run full tests. |
+```
+
+The seed file is
+[`Code/{{PROJECT}}-docs/templates/step-index-seed.md`](Code/{{PROJECT}}-docs/templates/step-index-seed.md).
+
+## 3. Architecture Docs
+
+Architecture docs are living documents. They say what the system is now, carry a version,
+and keep decision summaries close to the design.
+
+Representative excerpt:
+
+```md
+# Doc 03 — Architecture Overview & Component Boundaries
+
+**Version:** v0.2.0
+**Status:** Draft
+**Last updated:** 2026-06-23 (STEP-3)
+**Audience:** Builders, reviewers, future agents
+
+## Decision Summary
+
+| # | Decision | Choice | Rationale | Forecloses / tradeoff |
+|---|----------|--------|-----------|-----------------------|
+| 1 | Service split | API + web client | Keeps calendar sync server-side. | More deployment pieces than a static app. |
+
+## Version Log
+
+| Version | Date | STEP | Change |
+|---------|------|------|--------|
+| v0.2.0 | 2026-06-23 | STEP-3 | Added OAuth callback boundary. |
+```
+
+The shared skeleton is
+[`Code/{{PROJECT}}-docs/templates/architecture-doc.md`](Code/{{PROJECT}}-docs/templates/architecture-doc.md).
+
+## 4. ADRs
+
+ADRs are point-in-time records. They preserve the why behind important choices without
+turning the architecture docs into a debate transcript.
+
+Representative excerpt:
+
+```md
+# ADR-0003: Use Postgres for scheduling state
+
+**Status:** Accepted
+**Date:** 2026-06-23
+
+## Context
+The product needs transactional updates for invitations, holds, and confirmations.
+
+## Decision
+Use Postgres as the primary datastore for Phase 1.
+
+## Consequences
+Relational constraints make double-booking easier to prevent, but local development needs a
+database service instead of a single embedded file.
+```
+
+The template is
+[`Code/{{PROJECT}}-docs/templates/adr.md`](Code/{{PROJECT}}-docs/templates/adr.md).
+
+## 5. STEP Plans and Substep Prompts
+
+A STEP plan defines the unit of work. Substep prompts are written so a fresh agent can run
+one task cold, without relying on the conversation that created the plan.
+
+Representative STEP-plan excerpt:
+
+```md
+# acme — STEP-3 PLAN: Calendar OAuth
+
+## Decisions already locked
+- ADR-0002 — Use hosted OAuth provider.
+- architecture/06-security-threat-model.md — tokens are encrypted at rest.
+
+## Substeps
+
+| # | Title | Produces | Depends on | Open questions |
+|---|-------|----------|------------|----------------|
+| 3.1 | OAuth callback endpoint | API route + tests | ADR-0002 | None |
+| 3.2 | Connect-calendar UI | Settings flow + tests | 3.1 | Button copy |
+```
+
+Representative substep excerpt:
+
+```md
+## Read these first
+- overview.md
+- architecture/06-security-threat-model.md
+- ADR-0002-hosted-oauth-provider.md
+- acme-api/README.md
+
+## Verification
+- Write tests for success, denied consent, expired state, and provider error.
+- Run the API test suite before marking this substep done.
+
+## Keeping the docs true
+If token storage changes, update the security architecture doc or write a new ADR.
+```
+
+The templates are
+[`Code/{{PROJECT}}-docs/templates/step-plan.md`](Code/{{PROJECT}}-docs/templates/step-plan.md)
+and
+[`Code/{{PROJECT}}-docs/templates/substep-prompt.md`](Code/{{PROJECT}}-docs/templates/substep-prompt.md).
+
+## 6. Check-In Reports
+
+Every 10-20 STEPs, a check-in STEP runs a deliberate sweep. It compares architecture docs
+against code in both directions, re-evaluates conditional architecture sessions, reviews
+accepted risks and debt, and runs the full test suite.
+
+Representative report excerpt:
+
+```md
+# STEP-12 Check-In Report
+
+## Drift
+- Updated architecture/03-architecture-overview.md for the new worker repo.
+- Filed STEP-13 for API pagination drift; the doc was still correct.
+
+## Conditional coverage
+- Identity & auth: still included and current.
+- Privacy/compliance: trigger fired after calendar metadata retention changed; opened STEP-14.
+
+## Risks/debt
+- Closed RISK-002 after token-rotation automation shipped.
+
+## Tests
+- API: 218 passed.
+- Web: 96 passed.
+```
+
+The runbook is
+[`Code/{{PROJECT}}-docs/runbooks/check-in.md`](Code/{{PROJECT}}-docs/runbooks/check-in.md).
+
+## Why This Helps
+
+The artifact trail gives future work a place to start:
+
+- A new chat can resume from disk instead of asking you to reconstruct context.
+- A reviewer can see whether code matches the architecture or drifted from it.
+- A later decision can supersede an ADR instead of silently rewriting history.
+- A check-in can catch stale docs, missing conditionals, accepted risks, and broken tests.
+
+This does not make AI coding error-proof. It makes the work inspectable and keeps wrong turns
+smaller.

--- a/Code/{{PROJECT}}-docs/scripts/links.sh
+++ b/Code/{{PROJECT}}-docs/scripts/links.sh
@@ -2,7 +2,7 @@
 #
 # links.sh — read-only stale-link checker for durable Throughstone documentation.
 #
-# Scope is intentionally narrow: root pointer/readme files and durable docs-hub Markdown.
+# Scope is intentionally narrow: root pointer/readme/artifact-tour files and durable docs-hub Markdown.
 # It skips prompts/, Upcoming Prompts/, templates/, app repos, links outside the local
 # workspace, and all external URLs so the result stays useful as a cheap check-in/CI guard
 # instead of becoming a noisy site crawler.
@@ -50,7 +50,7 @@ def fail(source, line_no, message, hint=None):
 # scoped_markdown_files — list the durable Markdown files this checker owns.
 def scoped_markdown_files():
     files = []
-    for name in ("AGENTS.md", "CLAUDE.md", "README.md"):
+    for name in ("AGENTS.md", "CLAUDE.md", "README.md", "ARTIFACT-TRAIL.md"):
         candidate = root / name
         if candidate.is_file():
             files.append(candidate)
@@ -389,7 +389,7 @@ for source in files:
 print(f"Throughstone links — {root}")
 print()
 print("Scope:")
-print("  root AGENTS.md / CLAUDE.md / README.md when present")
+print("  root AGENTS.md / CLAUDE.md / README.md / ARTIFACT-TRAIL.md when present")
 print(f"  {rel(docs_dir)}/**/*.md except templates/")
 print("  prompts/, Upcoming Prompts/, app repos, external URLs, and paths outside the workspace are skipped")
 print()

--- a/README.md
+++ b/README.md
@@ -299,8 +299,9 @@ what future work is supposed to respect. That matters especially with AI-assiste
 where it is easy to generate a lot of code faster than anyone can reconstruct the reasoning
 behind it.
 
-Throughstone creates a project documentation hub under `Code/{{PROJECT}}-docs/`. The core
-files include:
+See [Throughstone Artifact Trail](ARTIFACT-TRAIL.md) for a guided tour with representative
+snippets. In short, Throughstone creates a project documentation hub under
+`Code/{{PROJECT}}-docs/` and a sibling `prompts/` history repo. The core files include:
 
 - `overview.md` — the project brief.
 - `METHOD.md` and `AGENTS.md` — the process and agent instructions.

--- a/brand/site/index.html
+++ b/brand/site/index.html
@@ -81,6 +81,16 @@
   .pcard h3{font-size:21px;margin-bottom:8px;}
   .pcard p{color:var(--mortar);font-size:16px;margin:0;}
 
+  /* artifacts */
+  .artifacts{background:var(--paper);}
+  .artifact-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;}
+  .artifact-card{background:var(--lime);border:1px solid #e8ddc8;border-radius:8px;padding:20px;min-width:0;}
+  .artifact-card h3{font-size:18px;margin-bottom:12px;}
+  .artifact-card pre{margin:0;font-family:var(--mono);font-size:12.5px;line-height:1.55;color:#3d342c;white-space:pre-wrap;overflow-wrap:anywhere;}
+  .artifact-card .path{font-family:var(--mono);font-size:12px;color:var(--ochreD);margin-bottom:10px;}
+  .artifact-note{margin-top:28px;display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap;color:var(--mortar);font-size:16px;}
+  .artifact-note p{margin:0;max-width:640px;}
+
   /* who */
   .who .cards3 .pcard{background:var(--lime);}
   .who .pcard h3{font-size:19px;}
@@ -104,7 +114,7 @@
   @media(max-width:860px){
     .hero-grid{grid-template-columns:1fr;gap:40px;}
     .hero h1{font-size:46px;}
-    .cards3{grid-template-columns:1fr;}
+    .cards3,.artifact-grid{grid-template-columns:1fr;}
     h2{font-size:28px;}
   }
 </style>
@@ -116,6 +126,7 @@
     <a class="brand" href="#top"><img src="assets/throughstone-lockup.svg" alt="Throughstone"></a>
     <div class="links">
       <a class="navlink" href="#principles">Principles</a>
+      <a class="navlink" href="#artifacts">Artifacts</a>
       <a class="navlink" href="#who">Who it's for</a>
       <a class="navlink" href="#quickstart">Quickstart</a>
       <a class="navlink" href="https://github.com/mherschberg/Throughstone">GitHub</a>
@@ -153,6 +164,86 @@
       <div class="pcard"><div class="num">01</div><h3>Think before you code.</h3><p>Start with architecture docs and decision records, then code. You begin from a plan you can read and question.</p></div>
       <div class="pcard"><div class="num">02</div><h3>Decisions get recorded.</h3><p>Every meaningful choice is written down as a decision record, not buried in a chat log — so the “why” survives.</p></div>
       <div class="pcard"><div class="num">03</div><h3>Work in runnable units.</h3><p>Build proceeds in phases → steps → substeps, each a runnable unit with check-ins, so progress stays reviewable.</p></div>
+    </div>
+  </div>
+</section>
+
+<section class="artifacts" id="artifacts">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Project memory</div>
+      <h2>The output is an artifact trail, not just a chat.</h2>
+      <p>Throughstone leaves durable Markdown behind: a brief, roadmap, architecture, decisions, executable prompts, and periodic check-ins.</p>
+    </div>
+    <div class="artifact-grid">
+      <div class="artifact-card">
+        <div class="path">overview.md</div>
+        <h3>Project brief</h3>
+        <pre>## In one sentence
+A scheduling assistant for small consulting teams.
+
+## Sensitive data &amp; risk
+Calendar metadata and attendee emails require careful access control.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">prompts/STEP-index.md</div>
+        <h3>Living roadmap</h3>
+        <pre>| STEP | Title | Status |
+|------|-------|--------|
+| STEP-1 | Architecture | Done |
+| STEP-2 | API skeleton | Done |
+| STEP-3 | Calendar OAuth | In progress |
+| STEP-4 | Check-in | Planned |</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">architecture/03-*.md</div>
+        <h3>Current design</h3>
+        <pre>**Version:** v0.2.0
+**Status:** Draft
+
+## Decision Summary
+Service split: API + web client.
+Rationale: keep calendar sync server-side.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">adr/ADR-0003-*.md</div>
+        <h3>Decision record</h3>
+        <pre>## Context
+Scheduling needs transactional updates.
+
+## Decision
+Use Postgres for Phase 1.
+
+## Consequences
+Local development needs a database service.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">STEP-3.1-PROMPT.md</div>
+        <h3>Cold-start prompt</h3>
+        <pre>## Read these first
+- architecture/06-security-threat-model.md
+- ADR-0002-hosted-oauth-provider.md
+
+## Verification
+Test success, denied consent, expired state, and provider errors.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">STEP-12 check-in report</div>
+        <h3>Periodic reconciliation</h3>
+        <pre>## Drift
+Updated architecture overview for the new worker repo.
+
+## Tests
+API: 218 passed.
+Web: 96 passed.
+
+## Carry-forward
+Opened STEP-13 for pagination drift.</pre>
+      </div>
+    </div>
+    <div class="artifact-note">
+      <p>The docs hub records what the system is now; the prompts repo records how it got there.</p>
+      <a class="btn btn-ghost" href="https://github.com/mherschberg/Throughstone/blob/main/ARTIFACT-TRAIL.md">Read the artifact tour</a>
     </div>
   </div>
 </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,6 +81,16 @@
   .pcard h3{font-size:21px;margin-bottom:8px;}
   .pcard p{color:var(--mortar);font-size:16px;margin:0;}
 
+  /* artifacts */
+  .artifacts{background:var(--paper);}
+  .artifact-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;}
+  .artifact-card{background:var(--lime);border:1px solid #e8ddc8;border-radius:8px;padding:20px;min-width:0;}
+  .artifact-card h3{font-size:18px;margin-bottom:12px;}
+  .artifact-card pre{margin:0;font-family:var(--mono);font-size:12.5px;line-height:1.55;color:#3d342c;white-space:pre-wrap;overflow-wrap:anywhere;}
+  .artifact-card .path{font-family:var(--mono);font-size:12px;color:var(--ochreD);margin-bottom:10px;}
+  .artifact-note{margin-top:28px;display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap;color:var(--mortar);font-size:16px;}
+  .artifact-note p{margin:0;max-width:640px;}
+
   /* who */
   .who .cards3 .pcard{background:var(--lime);}
   .who .pcard h3{font-size:19px;}
@@ -104,7 +114,7 @@
   @media(max-width:860px){
     .hero-grid{grid-template-columns:1fr;gap:40px;}
     .hero h1{font-size:46px;}
-    .cards3{grid-template-columns:1fr;}
+    .cards3,.artifact-grid{grid-template-columns:1fr;}
     h2{font-size:28px;}
   }
 </style>
@@ -116,6 +126,7 @@
     <a class="brand" href="#top"><img src="assets/throughstone-lockup.svg" alt="Throughstone"></a>
     <div class="links">
       <a class="navlink" href="#principles">Principles</a>
+      <a class="navlink" href="#artifacts">Artifacts</a>
       <a class="navlink" href="#who">Who it's for</a>
       <a class="navlink" href="#quickstart">Quickstart</a>
       <a class="navlink" href="https://github.com/mherschberg/Throughstone">GitHub</a>
@@ -153,6 +164,86 @@
       <div class="pcard"><div class="num">01</div><h3>Think before you code.</h3><p>Start with architecture docs and decision records, then code. You begin from a plan you can read and question.</p></div>
       <div class="pcard"><div class="num">02</div><h3>Decisions get recorded.</h3><p>Every meaningful choice is written down as a decision record, not buried in a chat log — so the “why” survives.</p></div>
       <div class="pcard"><div class="num">03</div><h3>Work in runnable units.</h3><p>Build proceeds in phases → steps → substeps, each a runnable unit with check-ins, so progress stays reviewable.</p></div>
+    </div>
+  </div>
+</section>
+
+<section class="artifacts" id="artifacts">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="eyebrow">Project memory</div>
+      <h2>The output is an artifact trail, not just a chat.</h2>
+      <p>Throughstone leaves durable Markdown behind: a brief, roadmap, architecture, decisions, executable prompts, and periodic check-ins.</p>
+    </div>
+    <div class="artifact-grid">
+      <div class="artifact-card">
+        <div class="path">overview.md</div>
+        <h3>Project brief</h3>
+        <pre>## In one sentence
+A scheduling assistant for small consulting teams.
+
+## Sensitive data &amp; risk
+Calendar metadata and attendee emails require careful access control.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">prompts/STEP-index.md</div>
+        <h3>Living roadmap</h3>
+        <pre>| STEP | Title | Status |
+|------|-------|--------|
+| STEP-1 | Architecture | Done |
+| STEP-2 | API skeleton | Done |
+| STEP-3 | Calendar OAuth | In progress |
+| STEP-4 | Check-in | Planned |</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">architecture/03-*.md</div>
+        <h3>Current design</h3>
+        <pre>**Version:** v0.2.0
+**Status:** Draft
+
+## Decision Summary
+Service split: API + web client.
+Rationale: keep calendar sync server-side.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">adr/ADR-0003-*.md</div>
+        <h3>Decision record</h3>
+        <pre>## Context
+Scheduling needs transactional updates.
+
+## Decision
+Use Postgres for Phase 1.
+
+## Consequences
+Local development needs a database service.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">STEP-3.1-PROMPT.md</div>
+        <h3>Cold-start prompt</h3>
+        <pre>## Read these first
+- architecture/06-security-threat-model.md
+- ADR-0002-hosted-oauth-provider.md
+
+## Verification
+Test success, denied consent, expired state, and provider errors.</pre>
+      </div>
+      <div class="artifact-card">
+        <div class="path">STEP-12 check-in report</div>
+        <h3>Periodic reconciliation</h3>
+        <pre>## Drift
+Updated architecture overview for the new worker repo.
+
+## Tests
+API: 218 passed.
+Web: 96 passed.
+
+## Carry-forward
+Opened STEP-13 for pagination drift.</pre>
+      </div>
+    </div>
+    <div class="artifact-note">
+      <p>The docs hub records what the system is now; the prompts repo records how it got there.</p>
+      <a class="btn btn-ghost" href="https://github.com/mherschberg/Throughstone/blob/main/ARTIFACT-TRAIL.md">Read the artifact tour</a>
     </div>
   </div>
 </section>

--- a/init.sh
+++ b/init.sh
@@ -654,11 +654,12 @@ rm -rf "$ROOT/.git"
 # notice. Relocate it as LICENSE-THROUGHSTONE below; open-source projects get their selected
 # project LICENSE separately, while proprietary projects intentionally do not.
 #
-# README/CHANGELOG/TODO are Throughstone-template files: the front door, release history, and
-# maintainer backlog. After bootstrap they are stale project content, and in multi-repo mode
-# they would be stray files at the non-repo workspace root. Drop them; generated-project context
-# starts in the docs hub. Mono-repo projects can add their own versions later.
-rm -f "$ROOT/README.md" "$ROOT/CHANGELOG.md" "$ROOT/TODO.md"
+# README/CHANGELOG/TODO/ARTIFACT-TRAIL are Throughstone-template files: the front door, release
+# history, maintainer backlog, and public explanation of the scaffold's output. After bootstrap
+# they are stale project content, and in multi-repo mode they would be stray files at the non-repo
+# workspace root. Drop them; generated-project context starts in the docs hub. Mono-repo projects
+# can add their own versions later.
+rm -f "$ROOT/README.md" "$ROOT/CHANGELOG.md" "$ROOT/TODO.md" "$ROOT/ARTIFACT-TRAIL.md"
 # Community/health files describe the Throughstone template itself: contribution policy,
 # security contact, code of conduct, and trademark posture. Carrying them forward would leak the
 # template maintainer's contacts and assert Throughstone governance inside the user's project.

--- a/tests/links.sh
+++ b/tests/links.sh
@@ -36,6 +36,12 @@ See [docs](Code/acme-docs/README.md), [local heading](#root-readme), and
 [docs-ref]: Code/acme-docs/README.md
 README
 
+cat > "$fixture/ARTIFACT-TRAIL.md" <<'ARTIFACTS'
+# Artifact Trail
+
+See [docs](Code/acme-docs/README.md).
+ARTIFACTS
+
 cat > "$fixture/Code/acme-docs/README.md" <<'DOCS'
 # Docs Hub
 


### PR DESCRIPTION
## Summary
- Add ARTIFACT-TRAIL.md as a guided tour of Throughstone's durable output artifacts
- Link the artifact tour from the README FAQ and add a compact artifact section to the website
- Keep generated projects clean by removing the root artifact tour during bootstrap
- Include ARTIFACT-TRAIL.md in stale-link checks and cover that scope in the link-checker test

## Verification
- ./doctor.sh check
- ./doctor.sh links
- tests/links.sh
- Browser-checked docs/index.html via a temporary local server at desktop and mobile widths