### PR TITLE
Add generated project onboarding guide

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -111,6 +111,9 @@ README and CI scaffolding, and writes `LICENSING.md` to make those scopes explic
 the root pointers). From the workspace root, `./doctor.sh status`, `./doctor.sh check`, and
 `./doctor.sh links` are thin shortcuts to the docs hub's `scripts/status.sh`,
 `scripts/check.sh`, and `scripts/links.sh`.
+New human or agent contributor joining an existing project? Read
+`Code/{{PROJECT}}-docs/ONBOARDING.md` for the ordered setup and first-STEP path. It covers
+later contributor onboarding; initial project bootstrap still starts from `./init.sh`.
 
 **Workspace-root hygiene:** the workspace root should contain only per-machine pointers
 and config (`CLAUDE.md`, `AGENTS.md`, `.claude/`), the root helper (`doctor.sh`), the repo

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -112,8 +112,8 @@ the root pointers). From the workspace root, `./doctor.sh status`, `./doctor.sh 
 `./doctor.sh links` are thin shortcuts to the docs hub's `scripts/status.sh`,
 `scripts/check.sh`, and `scripts/links.sh`.
 New human or agent contributor joining an existing project? Read
-`Code/{{PROJECT}}-docs/ONBOARDING.md` for the ordered setup and first-STEP path. It covers
-later contributor onboarding; initial project bootstrap still starts from `./init.sh`.
+`Code/{{PROJECT}}-docs/ONBOARDING.md` for the ordered setup and first-contribution STEP path.
+It covers later contributor onboarding; initial project bootstrap still starts from `./init.sh`.
 
 **Workspace-root hygiene:** the workspace root should contain only per-machine pointers
 and config (`CLAUDE.md`, `AGENTS.md`, `.claude/`), the root helper (`doctor.sh`), the repo

--- a/Code/{{PROJECT}}-docs/ONBOARDING.md
+++ b/Code/{{PROJECT}}-docs/ONBOARDING.md
@@ -1,0 +1,106 @@
+# New Contributor Onboarding
+
+This guide is for a new human or agent contributor joining an existing, initialized
+Throughstone project. It gives the first end-to-end path: assemble the workspace, read the
+project state from disk, and start the first STEP without guessing.
+
+This is not the first project bootstrap. The first maintainer ran `./init.sh` from the
+Throughstone scaffold to create the project. Later contributors use the generated project
+workspace and, for multi-repo projects, `Code/<project>-docs/scripts/setup-workspace.sh`.
+
+## 1. Identify the project shape
+
+Most Throughstone projects are **multi-repo**:
+
+- The workspace root is a per-machine shell, not a repo.
+- The docs hub lives at `Code/<project>-docs/`.
+- The prompt/history repo lives at `prompts/`.
+- Code repos live as siblings under `Code/<project>-*`.
+
+Some early projects are **mono-repo-for-now**:
+
+- There is one repo.
+- `AGENTS.md`, `CLAUDE.md`, and `doctor.sh` are committed in that repo.
+- `setup-workspace.sh` is not needed. Clone the repo, open it, and continue at
+  [Read the project state](#3-read-the-project-state).
+
+## 2. Set up a multi-repo workspace
+
+Create or choose the workspace root, then clone the docs hub into the expected location:
+
+```sh
+git clone <docs-repo-url> Code/<project>-docs
+```
+
+From the workspace root, run the generated setup helper:
+
+```sh
+Code/<project>-docs/scripts/setup-workspace.sh
+```
+
+The helper clones sibling repos listed in `Code/<project>-docs/registries/repos.yml` when
+they have remotes, then writes the per-machine root files. Verify these exist at the
+workspace root:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `doctor.sh`
+
+If a sibling repo has no remote in `registries/repos.yml`, `setup-workspace.sh` cannot clone
+it. Read its registry entry and ask the maintainer how that repo is provided.
+
+## 3. Read the project state
+
+Start with these files, in this order:
+
+1. `AGENTS.md` - agent and contributor operating context, including kickoff versus resume.
+2. `Code/<project>-docs/METHOD.md` - the method, read once before working.
+3. `Code/<project>-docs/overview.md` - project brief and bootstrap status marker.
+4. `prompts/STEP-index.md` - roadmap, STEP status, owners, and repo projections.
+5. `Code/<project>-docs/registries/repos.yml` - canonical repo inventory.
+
+Then run the local checks from the workspace root:
+
+```sh
+./doctor.sh status
+./doctor.sh check
+./doctor.sh links
+```
+
+Use `./doctor.sh status` as the source of the next action. It reads the project state from
+disk and applies the next-action resolver from `METHOD.md`. Confirm its result against
+`prompts/STEP-index.md`, and if a STEP is already in progress, read its PLAN in
+`Upcoming Prompts/`.
+
+## 4. Start your first STEP
+
+Before editing code or durable docs:
+
+1. Read the README for every repo you expect to touch. The repo README is the local setup and
+   "about" document for that repo.
+2. Read `prompts/STEP-index.md` and select the next appropriate STEP. If you are adding an
+   ad-hoc STEP, reserve a number according to `Code/<project>-docs/runbooks/collaboration.md`.
+3. Check the selected STEP's `Repos (projection)` against other in-flight rows. If there is
+   overlap, call it out before proceeding.
+4. Create a branch named `step-NNNN-short-name`. Use the same branch name in every repo the
+   STEP touches.
+5. Update only your STEP row in `prompts/STEP-index.md` to `In progress` when you start, and
+   push that small status change to the shared trunk.
+6. Work from the STEP PLAN in `Upcoming Prompts/`, running the lowest open substep first.
+7. Edit shared tables narrowly: your own STEP row, your own ADR/registry row, or the row the
+   STEP explicitly owns. Do not re-sort or reformat shared tables as drive-by cleanup.
+8. When complete, update the STEP review state, archive the PLAN and substep prompts from
+   `Upcoming Prompts/` into the appropriate `prompts/<phase>/step-NNNN/` folder, and mark the
+   STEP `Done` in `prompts/STEP-index.md`.
+
+For team and concurrency details, read
+[`runbooks/collaboration.md`](runbooks/collaboration.md). That runbook owns the full rules
+for reserving STEP numbers, branch naming, shared-file edits, ADR numbering, overlap
+warnings, and push races.
+
+## 5. Keep paths straight
+
+This scaffold stores the template at `Code/{{PROJECT}}-docs/ONBOARDING.md`. In an
+initialized project, the generated docs hub path is `Code/<project>-docs/ONBOARDING.md`.
+When editing template files, keep the literal `{{PROJECT}}` placeholder. When instructing
+contributors in generated projects, use `Code/<project>-docs`.

--- a/Code/{{PROJECT}}-docs/ONBOARDING.md
+++ b/Code/{{PROJECT}}-docs/ONBOARDING.md
@@ -1,8 +1,9 @@
 # New Contributor Onboarding
 
 This guide is for a new human or agent contributor joining an existing, initialized
-Throughstone project. It gives the first end-to-end path: assemble the workspace, read the
-project state from disk, and start the first STEP without guessing.
+Throughstone project. It gives the contributor's first end-to-end path: assemble the
+workspace, read the project state from disk, and start their first contribution STEP without
+guessing.
 
 This is not the first project bootstrap. The first maintainer ran `./init.sh` from the
 Throughstone scaffold to create the project. Later contributors use the generated project
@@ -72,7 +73,7 @@ disk and applies the next-action resolver from `METHOD.md`. Confirm its result a
 `prompts/STEP-index.md`, and if a STEP is already in progress, read its PLAN in
 `Upcoming Prompts/`.
 
-## 4. Start your first STEP
+## 4. Start your first contribution STEP
 
 Before editing code or durable docs:
 

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -11,7 +11,8 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
   STEP ▸ substep, architecture-first, the durable doc genres). The project brief is
   `overview.md` (written during kickoff).
 - **New contributors:** read [`ONBOARDING.md`](ONBOARDING.md) for the first end-to-end path:
-  set up an existing project workspace, read state from disk, and start your first STEP.
+  set up an existing project workspace, read state from disk, and start your first
+  contribution STEP.
 - **AI agents:** [`AGENTS.md`](AGENTS.md) is your canonical context — start there. The
   workspace-root `CLAUDE.md` / `AGENTS.md` just point to it. New project? It routes you to
   [`BOOTSTRAP-PROMPT.md`](BOOTSTRAP-PROMPT.md) for kickoff.
@@ -21,7 +22,7 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 |------|------|
 | [`METHOD.md`](METHOD.md) | The method — read once before working here. |
 | [`AGENTS.md`](AGENTS.md) | Canonical agent context + the next-action resolver. |
-| [`ONBOARDING.md`](ONBOARDING.md) | New contributor setup guide for joining an existing project and starting the first STEP. |
+| [`ONBOARDING.md`](ONBOARDING.md) | New contributor setup guide for joining an existing project and starting the contributor's first STEP. |
 | [`UPDATING-THROUGHSTONE.md`](UPDATING-THROUGHSTONE.md) | How to compare and selectively adopt newer Throughstone scaffold/process changes after bootstrap. |
 | [`architecture/`](architecture/README.md) | *What* the system is — living, versioned design docs (indexed). |
 | [`adr/`](adr/README.md) | *Why* it's that way — point-in-time decision records (indexed). |

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -10,6 +10,8 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 - **Humans:** read [`METHOD.md`](METHOD.md) once — how this project is structured (Phase ▸
   STEP ▸ substep, architecture-first, the durable doc genres). The project brief is
   `overview.md` (written during kickoff).
+- **New contributors:** read [`ONBOARDING.md`](ONBOARDING.md) for the first end-to-end path:
+  set up an existing project workspace, read state from disk, and start your first STEP.
 - **AI agents:** [`AGENTS.md`](AGENTS.md) is your canonical context — start there. The
   workspace-root `CLAUDE.md` / `AGENTS.md` just point to it. New project? It routes you to
   [`BOOTSTRAP-PROMPT.md`](BOOTSTRAP-PROMPT.md) for kickoff.
@@ -19,6 +21,7 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 |------|------|
 | [`METHOD.md`](METHOD.md) | The method — read once before working here. |
 | [`AGENTS.md`](AGENTS.md) | Canonical agent context + the next-action resolver. |
+| [`ONBOARDING.md`](ONBOARDING.md) | New contributor setup guide for joining an existing project and starting the first STEP. |
 | [`UPDATING-THROUGHSTONE.md`](UPDATING-THROUGHSTONE.md) | How to compare and selectively adopt newer Throughstone scaffold/process changes after bootstrap. |
 | [`architecture/`](architecture/README.md) | *What* the system is — living, versioned design docs (indexed). |
 | [`adr/`](adr/README.md) | *Why* it's that way — point-in-time decision records (indexed). |

--- a/Code/{{PROJECT}}-docs/runbooks/README.md
+++ b/Code/{{PROJECT}}-docs/runbooks/README.md
@@ -23,8 +23,8 @@ The shipped runbooks are **defaults you customize** — they deliberately leave 
 versioning, and ecosystem-specific commands to your team's tooling. The *discipline* is the
 durable part; fill in your project's specifics.
 
-New-contributor onboarding is intentionally not a runbook. It is project setup and first-STEP
-guidance, so it lives at [`../ONBOARDING.md`](../ONBOARDING.md).
+New-contributor onboarding is intentionally not a runbook. It is project setup and
+first-contribution STEP guidance, so it lives at [`../ONBOARDING.md`](../ONBOARDING.md).
 
 ## Index
 

--- a/Code/{{PROJECT}}-docs/runbooks/README.md
+++ b/Code/{{PROJECT}}-docs/runbooks/README.md
@@ -23,6 +23,9 @@ The shipped runbooks are **defaults you customize** — they deliberately leave 
 versioning, and ecosystem-specific commands to your team's tooling. The *discipline* is the
 durable part; fill in your project's specifics.
 
+New-contributor onboarding is intentionally not a runbook. It is project setup and first-STEP
+guidance, so it lives at [`../ONBOARDING.md`](../ONBOARDING.md).
+
 ## Index
 
 | Runbook | Purpose (one line) | When it fires | Governed by |


### PR DESCRIPTION
## Summary
- Add Code/{{PROJECT}}-docs/ONBOARDING.md as the generated-project onboarding guide for new human or agent contributors
- Link the guide from the docs hub README and AGENTS workspace/setup section
- Clarify in runbooks/README.md that onboarding is setup/first-STEP guidance, not a recurring runbook

## Verification
- ./doctor.sh check
- ./doctor.sh links
- bash tests/links.sh
- bash tests/doctor-dispatcher.sh

## Notes
- TODO.md was updated locally per maintainer task tracking, but it is intentionally ignored as maintainer scratch and is not part of this PR.