### PR TITLE
Clarify interactive STEP planning guidance

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -127,6 +127,10 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
   explaining a decision, read `Code/{{PROJECT}}-docs/overview.md` and use the recorded
   **Your experience level** value as the communication baseline. Keep `overview.md` as the
   single source of truth; don't duplicate the value into STEP plans or prompts.
+- **Honor the saved planning style.** Before planning a STEP, read
+  `Code/{{PROJECT}}-docs/overview.md` and use the recorded **Planning communication style**
+  as the default verbosity. Don't re-ask for every STEP unless the value is missing or the
+  user asks to change it.
 - During the architecture STEP, produce **Markdown docs + ADRs only — no code**.
 - Significant decisions become **ADRs** (`Code/{{PROJECT}}-docs/templates/adr.md`); never
   rewrite an accepted ADR's decision — supersede it or append an amendment.

--- a/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
@@ -45,6 +45,12 @@ or request to clarify — however worded — as a cue to explain plainly. **When
 level, tell the user in plain terms they can ask you to explain any question at any time** —
 don't make them discover it. (See `METHOD.md` §4.)
 
+Also ask how terse or explanatory they want STEP planning discussions to be by default:
+**Terse**, **Normal**, or **Explanatory**. Record the answer in `overview.md` under
+*Planning communication style*. This is a saved preference for future STEP planning
+sessions, not something to re-ask for every STEP; the user can change it in `overview.md` or
+override it in chat for a single session.
+
 Then read `overview.md` and fill the gaps a brief usually misses. Ask about: who uses it and
 who else is affected; expected scale now vs. in a year; hard constraints (regulatory,
 budget, timeline, team, existing systems); data sensitivity; integrations; and — most

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -229,6 +229,12 @@ the decisions reached are the same; only the explaining changes:
 The level is advisory, not a gate: if the conversation shows the user is more or less
 comfortable than they marked, adjust on the fly and correct the value in `overview.md`.
 
+`overview.md` also records the user's default **Planning communication style** for STEP
+planning sessions: **Terse**, **Normal**, or **Explanatory**. Read it before planning a STEP
+and treat it as the saved default, so the user is not asked the same verbosity question for
+each new STEP. The user can change it in `overview.md` or override it in chat for the
+current session.
+
 **Worked examples** — the *same* canonical question, rendered at each level. The substance is
 identical; only the framing changes. Notice the recurring moves: Level 1 names the failure it
 prevents and ends with a yes/no default so the user is never facing a blank prompt; Level 2
@@ -280,6 +286,13 @@ session holds the whole STEP in mind, so the substeps are coherent. But they are
 frozen**: while executing the substeps, decisions made in an earlier substep often change
 what a later substep should do. Update the affected substep prompts (and the PLAN) as you
 go — the prompts should reflect the current intent, not the original guess.
+
+Treat STEP planning as an interactive discussion, not a silent document-generation task.
+Before writing the PLAN, confirm the scope with the user and ask for clarification when
+requirements, sequencing, dependencies, or ownership are unclear. When the user needs to
+make a planning choice, offer plausible options with brief pros and cons, then wait for
+direction. Use the saved **Planning communication style** in `overview.md` as the default
+level of detail while still asking the questions needed to make the STEP coherent.
 
 ### Check-in STEPs
 Roughly **every 10–20 STEPs**, the roadmap includes a **Check-in STEP** — a full STEP whose

--- a/Code/{{PROJECT}}-docs/templates/overview-template.md
+++ b/Code/{{PROJECT}}-docs/templates/overview-template.md
@@ -22,6 +22,14 @@
 - [ ] **2 — Basic coding experience** (some terms are new; define the unfamiliar ones)
 - [ ] **3 — Senior developer or above** (assume fluency; keep it terse)
 
+## Planning communication style
+<!-- Pick one. This is the saved default for STEP planning sessions, so the agent does not
+     need to ask how terse or explanatory to be for each new STEP. You can change it anytime,
+     and a one-off request in chat can override it for the current session. -->
+- [ ] **Terse** (decision-focused; minimal explanation unless requested)
+- [ ] **Normal** (brief context, options, and pros/cons)
+- [ ] **Explanatory** (more background and rationale before decisions)
+
 ## In one sentence
 <!-- What is this, for whom? e.g. "A scheduling assistant that negotiates meeting times
      between busy professionals on their behalf." -->

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -13,7 +13,7 @@
 > `architecture/*-interface-contracts.md`), `adr/*`,
 > `prompts/STEP-index.md`, and — for multi-repo
 > projects — `registries/repos.yml`.
-> **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
+> **Calibrate to experience and planning style.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. Also check **Planning communication style** in `overview.md` and use it as the default verbosity for this planning session. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
 
 ## About {{PROJECT}}
 {{PROJECT_DESCRIPTION}}
@@ -39,6 +39,9 @@ STEP's PLAN with its owner rather than silently replacing its index row.
 
 ## How this session works
 - One decision at a time; show options where useful; **wait** for the answer.
+- When a decision is not obvious, offer plausible options with brief pros and cons.
+  Ask clarifying questions instead of guessing, and use the saved planning style in
+  `overview.md` unless the user asks to change it.
 - Pull the Phase-1 scope from the Phasing & Roadmap architecture doc
   (`architecture/*-phasing-roadmap.md`) and the component
   boundaries from the Architecture Overview architecture doc

--- a/Code/{{PROJECT}}-docs/templates/step-plan.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan.md
@@ -16,7 +16,8 @@
 <!-- Decisions from prior STEPs/ADRs that this STEP must respect. Reference by ADR number
      or architecture doc. Carrying these forward keeps a shared mental model. -->
 - `overview.md` — read **Your experience level** before user-facing questions or
-  explanations; keep that file as the single source of truth for the value.
+  explanations, and read **Planning communication style** before planning discussions; keep
+  that file as the single source of truth for both values.
 - `registries/risks.yml` — review relevant accepted risks/debt before planning work that
   touches their area.
 - ADR-XXXX — …
@@ -64,8 +65,14 @@
 <!-- The working agreement for this STEP. e.g. "no code in this STEP", commit discipline,
      what 'done' means for a substep, review gates. -->
 - **Calibrate communication from `overview.md`.** Substep prompts should read the recorded
-  **Your experience level** and adjust explanations/questions accordingly; don't copy the
-  value into this PLAN.
+  **Your experience level** and adjust explanations/questions accordingly. STEP planning
+  should use the saved **Planning communication style** as the default verbosity. Don't copy
+  either value into this PLAN.
+- **Plan interactively.** Before this PLAN is finalized, confirm scope with the user and ask
+  clarifying questions for ambiguous requirements, sequencing, dependencies, ownership, or
+  repo boundaries. When a planning decision is needed, offer appropriate options with brief
+  pros and cons. Respect the saved planning style while still asking the questions needed to
+  make the STEP coherent.
 - **Tests ship with the code.** Every substep that writes or changes code also writes the
   tests for it and runs the relevant tests before it's done (see
   `templates/substep-prompt.md`). Override per substep only with a stated reason.

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ things keep them approachable whatever your background:
    That's the whole handoff — the same command for every project and every agent (no paths
    or project name to fill in). The agent reads the context, sees the project hasn't been
    started yet, and **begins the kickoff on its own**: it greets you, asks your experience
-   level, and helps you write the project brief (`Code/{{PROJECT}}-docs/overview.md`) right
-   in the chat. Just describe your idea when it asks — you don't have to pre-write anything.
+   level and preferred STEP planning style, and helps you write the project brief
+   (`Code/{{PROJECT}}-docs/overview.md`) right in the chat. Just describe your idea when it
+   asks — you don't have to pre-write anything.
 
    From there the agent proposes a roadmap and starts the architecture STEP; you work
    through the architecture sessions one at a time (*"run session 1.1"*), then move into

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -69,6 +69,14 @@ one at a sensible breakpoint if it's been about that long since the last (see `M
 > substeps, expect to revise later ones: decisions made in an earlier substep often change
 > what a later substep should do. Update those prompts (and the PLAN) as you go — they
 > should reflect current intent, not the original guess.
+>
+> STEP planning is an interactive discussion. Confirm the scope before drafting, ask for
+> clarification whenever the work is ambiguous, and when a decision is needed offer
+> appropriate options with brief pros and cons rather than forcing the user to start from a
+> blank page.
+> Read the saved **Planning communication style** in `Code/{{PROJECT}}-docs/overview.md`
+> and use it as the default verbosity; don't re-ask for every STEP unless the value is
+> missing or the user asks to change it.
 
 1. **Reserve the number in the index.** Look up the STEP in `prompts/STEP-index.md`. If it's
    not there, add a row — and that row *is* the number reservation. **Pull first**, take the
@@ -80,8 +88,10 @@ one at a sensible breakpoint if it's been about that long since the last (see `M
    with no conflict into a silent duplicate. (Solo with no remote, this is just a local edit.)
    See `Code/{{PROJECT}}-docs/runbooks/collaboration.md`.
 2. **Confirm scope** with the user before writing anything — a STEP is a real commitment.
-   Work the STEP on a branch named `step-NNNN-short-name` (the same name in every repo it
-   touches).
+   Ask clarifying questions where the planned work, dependencies, repo ownership, or order
+   are uncertain. When there are real alternatives, present appropriate options with short
+   pros and cons and let the user choose or adjust. Work the STEP on a branch named
+   `step-NNNN-short-name` (the same name in every repo it touches).
 3. **Write the PLAN** from `Code/{{PROJECT}}-docs/templates/step-plan.md`: motivation,
    locked decisions (reference the ADRs/architecture docs it must respect), the substep
    table, ground rules, and a definition of done. Save it in `Upcoming Prompts/`.


### PR DESCRIPTION
## Summary
- Clarify that STEP planning should be an interactive discussion, not silent document generation
- Tell agents to ask clarifying questions and present appropriate options with brief pros/cons
- Add user-controlled planning verbosity guidance to the STEP planning docs/templates

## Testing
- Not run; documentation-only change