### PR TITLE
Clarify when work needs a STEP

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -48,6 +48,9 @@ treat it as resume unless `prompts/STEP-index.md` is still the bare `init.sh` se
 ## How this project is built
 This project follows the method in **`Code/{{PROJECT}}-docs/METHOD.md`** — read it. In short:
 - Work is **Phase ▸ STEP ▸ substep**. Phase 1 is the MVP. STEP numbers are global.
+- Not every change is a STEP. Small, well-understood, low-risk tickets or fixes can use the
+  normal issue/branch/PR/test/commit flow. Promote to a STEP when the work needs planning,
+  sequencing, coordination, architecture/doc review, or durable context for a future agent.
 - **STEP-1 is architecture-first**: design docs + ADRs, *no application code*.
 - Durable docs live in `Code/{{PROJECT}}-docs/`:
   - `architecture/` — *what* the system is (versioned, living).
@@ -131,6 +134,10 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
   `Code/{{PROJECT}}-docs/overview.md` and use the recorded **Planning communication style**
   as the default verbosity. Don't re-ask for every STEP unless the value is missing or the
   user asks to change it.
+- **Use judgment before creating a STEP.** For tiny, well-understood changes that do not affect
+  architecture, public contracts, data model, security posture, deployment behavior, multiple
+  repos, or accepted risk/debt, keep the record in the issue/PR/commit trail instead of adding
+  process overhead.
 - During the architecture STEP, produce **Markdown docs + ADRs only — no code**.
 - Significant decisions become **ADRs** (`Code/{{PROJECT}}-docs/templates/adr.md`); never
   rewrite an accepted ADR's decision — supersede it or append an amendment.

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -43,6 +43,14 @@ Phase            e.g. Phase 1 = "MVP"          a release-level milestone
   in a fresh chat. Numbered with dotted notation (`1.1`, `1.2`, `1.5a`). For the
   architecture STEP, each substep is an interactive **session** (see §4).
 
+Not every change needs to become a STEP. A STEP is for work that benefits from explicit
+planning, sequencing, coordination, preserved context, or architecture/doc review. Small,
+well-understood changes can use the team's normal issue, branch, PR, test, and commit flow
+without reserving a STEP number or writing a PLAN. Promote the work to a STEP when it changes
+architecture, public contracts, data model, security posture, deployment behavior, multiple
+repos, accepted risk/debt, or when the work is large or ambiguous enough that a future agent
+would need durable planning context.
+
 ## 2. Architecture-first
 
 **STEP-1 produces architecture docs and ADRs — no application code.** This is the most

--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ into small STEPs, each STEP has review criteria, and periodic check-ins reconcil
 against the docs. The goal is not to make the AI incapable of being wrong; it is to make wrong
 turns smaller, easier to see, and less likely to compound into an unmaintainable project.
 
+Not every change has to become a STEP. Tiny, well-understood fixes can stay in the normal
+issue, branch, PR, test, and commit trail. STEPs are for work that needs planning, sequencing,
+coordination, architecture/doc review, or durable context for the next person or agent.
+
 Throughstone doesn't fix AI coding problems, but it reduces project risk.
 
 ### Why does Throughstone do architecture before code?
@@ -402,6 +406,11 @@ project state, not a museum.
 No. The generated project is yours, and the files are plain Markdown and normal repos. But the
 value comes from continuing the discipline: working in scoped STEPs, keeping the roadmap
 current, recording important decisions, and updating architecture docs when reality changes.
+
+That does not mean every ticket needs a STEP. For small one-off changes, use your normal issue
+tracker and PR process. Create or promote to a STEP when the work is large, ambiguous,
+cross-repo, architecture-affecting, or important enough that future contributors need the
+planning record.
 
 ### How do I update my project when Throughstone improves?
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -62,6 +62,18 @@ conditional-session coverage, review accepted risks/debt in
 one at a sensible breakpoint if it's been about that long since the last (see `METHOD.md`
 §5).
 
+## When not to add a STEP
+
+Not every ticket, bug fix, or small feature needs this recipe. If the work is small,
+well-understood, low-risk, and does not change architecture, public contracts, data model,
+security posture, deployment behavior, multiple repos, or accepted risk/debt, use the team's
+normal issue, branch, PR, test, and commit flow. Reference any external ticket in the branch,
+PR, or commit message instead of reserving a STEP number.
+
+Add or promote to a STEP when the work needs planning context, sequencing, coordination,
+cross-repo handling, architecture/doc review, or a durable record that a fresh agent or
+teammate will need later.
+
 ## Recipe: adding a new STEP
 
 > **Write the PLAN and all its substep prompts in a single chat.** One session that holds


### PR DESCRIPTION
## Summary
- Clarify that not every change or ticket needs a Throughstone STEP
- Document when small work can stay in normal issue/PR/commit flow
- Add promotion criteria for when work should become a STEP

## Testing
- Not run; docs-only change