### PR TITLE
Clarify security report history checks

### DIFF
--- a/Code/{{PROJECT}}-docs/runbooks/security-review-s0-checklist.md
+++ b/Code/{{PROJECT}}-docs/runbooks/security-review-s0-checklist.md
@@ -43,6 +43,7 @@ broader row.
 
 | Area | Baseline item | Status | Decision date | Owner | Reason / evidence | Revisit trigger | Risk ref |
 |------|---------------|--------|---------------|-------|-------------------|-----------------|----------|
+| Setup | Read the last S0 report and `registries/security-reviews.yml`; record elapsed time, commits, rough size change, previous baseline decisions, and carry-forward items. | TBD | YYYY-MM-DD | TBD | TBD | TBD | TBD |
 | Release posture | First-release security baseline decision recorded: S0 done now, planned before release, deferred, or accepted as risk. | TBD | YYYY-MM-DD | TBD | TBD | Before first release; before public launch; when release scope changes. | TBD |
 | Release posture | Release runbook has a security-aware pre-flight: tests green, config/secrets in place, rollback plan, and production verification. | TBD | YYYY-MM-DD | TBD | `runbooks/release-deploy.md`; project-specific release docs or CI evidence. | Before first release; after deployment process changes. | TBD |
 | Ownership | Security owners or accountable maintainers are identified for code, infrastructure, secrets, and incident response. | TBD | YYYY-MM-DD | TBD | Owner list, team rota, repository maintainers, or operations doc. | Team ownership change; production handoff. | TBD |

--- a/Code/{{PROJECT}}-docs/runbooks/security-review.md
+++ b/Code/{{PROJECT}}-docs/runbooks/security-review.md
@@ -157,6 +157,14 @@ live in the STEP folder.
 Use the naming convention in `reports/security/README.md`, then record that report path in
 `registries/security-reviews.yml`.
 
+Before starting a new S0, S1, or S2 report, read `registries/security-reviews.yml` and open the
+latest completed report for each relevant level. S0 reads the latest S0 report. S1 reads the
+latest S1 report and checks whether a newer S2 report should inform the sweep. S2 reads the
+latest S0, S1, and S2 reports when present. Older reports usually do not need separate review
+unless the latest report, ledger, or risk register points to unresolved carry-forward context. If
+the ledger is blank or stale, look in `reports/security/` using the naming convention and record
+whether no prior report was found.
+
 Each report records:
 - Review level and date.
 - Trigger.


### PR DESCRIPTION
## Summary
- Add shared guidance to read the latest relevant completed security reports before S0/S1/S2 reviews
- Add an S0 setup row for reading the latest S0 report and security review ledger

## Tests
- Not run; docs-only change