### PR TITLE
Clarify STEP evidence references

### DIFF
--- a/Code/{{PROJECT}}-docs/registries/risks.yml
+++ b/Code/{{PROJECT}}-docs/registries/risks.yml
@@ -13,9 +13,9 @@
 # Recording rule (hybrid):
 # - This YAML file is the compact index: status, owner, severity, revisit trigger, and links.
 # - The explanation lives in a durable source artifact. Every row should have at least one
-#   `refs` entry pointing at the architecture decision/section, ADR, issue, incident
-#   postmortem report under `reports/incidents/`, check-in report under `reports/`, or STEP
-#   report that records the details.
+#   `refs` entry pointing at the architecture decision/section, ADR, issue, archived STEP
+#   plan/execution notes, incident postmortem report under `reports/incidents/`, or check-in
+#   report under `reports/` that records the details.
 # - If no such artifact exists yet, create the right one first (usually an architecture
 #   decision/section for design posture, an ADR for a significant/contested decision, an issue
 #   or follow-up STEP for implementation debt, an incident report under `reports/incidents/`

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -106,11 +106,11 @@ Beyond the architecture docs, sweep four things that rot just as quietly:
   fix, not a bug STEP).
 - **Accepted risks / tech debt** — review `registries/risks.yml`. For every open or monitoring
   item, decide whether the revisit trigger has fired, the severity/owner still matches reality,
-  and the referenced architecture section, ADR, issue, STEP report, incident postmortem report
-  under `reports/incidents/`, or check-in report under `reports/` still exists and still
-  explains the risk. Close items that are mitigated, update stale rows, create missing source
-  artifacts, and file follow-up STEPs for anything whose trigger has fired or whose severity is
-  no longer acceptable.
+  and the referenced architecture section, ADR, issue, archived STEP plan/execution notes,
+  incident postmortem report under `reports/incidents/`, or check-in report under `reports/`
+  still exists and still explains the risk. Close items that are mitigated, update stale rows,
+  create missing source artifacts, and file follow-up STEPs for anything whose trigger has
+  fired or whose severity is no longer acceptable.
 
 ### Security-review gate
 

--- a/Code/{{PROJECT}}-docs/runbooks/security-review-s0-checklist.md
+++ b/Code/{{PROJECT}}-docs/runbooks/security-review-s0-checklist.md
@@ -25,7 +25,8 @@ Use exactly one status for every applicable row:
 ## Evidence Rules
 
 - Prefer durable evidence: settings pages, policy files, workflow files, scanner reports,
-  command output snapshots, ADRs, STEP reports, vendor dashboards, tickets, or issue URLs.
+  command output snapshots, ADRs, archived STEP plan/execution notes, vendor dashboards,
+  tickets, or issue URLs.
 - Do not paste secrets, private tokens, customer data, or sensitive infrastructure details into
   the report. Reference the secure system that holds them.
 - Use `registries/risks.yml` for accepted security risks and meaningful deferrals. The S0 report

--- a/Code/{{PROJECT}}-docs/templates/reports/security/s1-security-sweep-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/security/s1-security-sweep-report-template.md
@@ -133,7 +133,8 @@ other tooling reports: TBD
 
 **Reviewed:** Yes / No
 
-**Evidence / source:** Commits, PRs, releases, deployment history, roadmap, or STEP reports: TBD
+**Evidence / source:** Commits, PRs, releases, deployment history, roadmap, archived STEP
+plan/execution notes, or related issue evidence: TBD
 
 **Notes:** Focus on security-sensitive changes: auth/AuthZ, data, deployment, AI/tool-calling,
 integrations, public surfaces, dependencies, and incident follow-up: TBD


### PR DESCRIPTION
## Summary
- replace stale STEP report wording with archived STEP plan/execution notes
- clarify related evidence sources in risk and security review guidance

## Validation
- Code/{{PROJECT}}-docs/scripts/check.sh
- Code/{{PROJECT}}-docs/scripts/links.sh