### PR TITLE
Add test results reporting guidance

### DIFF
--- a/ARTIFACT-TRAIL.md
+++ b/ARTIFACT-TRAIL.md
@@ -19,6 +19,7 @@ shape is stable.
 | Substep prompts | `Upcoming Prompts/` while active, then archived with the STEP | Cold-start instructions for one focused task. |
 | Check-in reports | `Code/<project>-docs/reports/` | Periodic reconciliation: docs vs. code, conditional coverage, risks, and tests. |
 | Security reports | `Code/<project>-docs/reports/security/` | Durable S0/S1/S2 security baseline, sweep, and audit reports. |
+| Test-result reports | `Code/<project>-docs/reports/test-results/` | Durable test-suite, coverage, and quality-gate result reports. |
 
 The split matters:
 

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -92,7 +92,8 @@ spin up an Incident STEP to RCA → find similar → fix, with a postmortem repo
 audit dependencies for vulns/licenses on a cadence); add your own operational ones),
 `reports/` (durable review and operational reports, kept in the docs hub rather than inside
 STEP folders — check-in reports live directly in `reports/`, `reports/incidents/` holds
-incident postmortem reports, and `reports/security/` holds security baseline, sweep, and audit
+incident postmortem reports, `reports/security/` holds security baseline, sweep, and audit
+reports, and `reports/test-results/` holds durable test, coverage, and quality-gate result
 reports),
 `registries/`
 (e.g. `repos.yml`, the repo inventory for multi-repo projects, and `risks.yml`, the accepted

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -29,7 +29,7 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 | [`coding-standards/`](coding-standards/README.md) | Per-language engineering standards (indexed). |
 | [`runbooks/`](runbooks/README.md) | Repeatable procedures — check-in, release, incident, dependencies, secrets, collaboration (indexed). |
 | [`registries/`](registries/README.md) | Machine-readable inventories — repo map (`repos.yml`) and accepted risk / tech-debt index (`risks.yml`) (indexed). |
-| [`reports/`](reports/README.md) | Durable review and operational reports, including check-in, incident, and security review reports. |
+| [`reports/`](reports/README.md) | Durable review and operational reports, including check-in, incident, security review, and test-result reports. |
 | [`templates/`](templates/) | The session, STEP, and doc templates the method runs from. |
 | [`scripts/`](scripts/) | Setup and doctor helpers — status, structural checks, stale-link checks, workspace setup, and project-license propagation. |
 

--- a/Code/{{PROJECT}}-docs/reports/README.md
+++ b/Code/{{PROJECT}}-docs/reports/README.md
@@ -17,6 +17,7 @@ folders; STEPs may create reports, but the reports themselves live here.
 | `./` | Check-in reports produced by `runbooks/check-in.md`. |
 | [`incidents/`](incidents/README.md) | Incident postmortem reports produced by `runbooks/incident-postmortem.md`. |
 | [`security/`](security/README.md) | Security baseline, sweep, and audit reports produced by `runbooks/security-review.md`. |
+| [`test-results/`](test-results/README.md) | Durable test, coverage, and quality-gate result reports. |
 
 ## Check-In Reports
 

--- a/Code/{{PROJECT}}-docs/reports/test-results/README.md
+++ b/Code/{{PROJECT}}-docs/reports/test-results/README.md
@@ -1,0 +1,64 @@
+# Test Results
+
+Durable test, coverage, and quality-gate result reports for {{PROJECT}}.
+
+Use this folder for completed evidence that should survive beyond an individual CI run or STEP:
+coverage summaries, full-suite summaries, release-candidate test evidence, and notable failed
+runs that create follow-up work. Routine transient build output still belongs in CI artifacts or
+local ignored files; commit only the report or compact artifact that future maintainers should be
+able to read.
+
+Do not commit a generated multi-file coverage site by default. Tools such as JaCoCo,
+pytest-cov/htmlcov, Istanbul, and LCOV viewers often produce an HTML tree that mirrors the source
+tree. That is useful for inspection, but it is usually too noisy for the docs repo. Prefer a
+Markdown summary here that points to the CI artifact, coverage service, or local command that
+produced the full tree.
+
+## When To Write One
+
+Write a summary when the test result is evidence for a project checkpoint or decision: a check-in,
+release candidate, incident follow-up, security review, major quality-gate change, or a failed run
+that creates follow-up work — or when requested by a user. Do not write one for every routine CI pass.
+
+## Naming
+
+Prefer stable, sortable filenames:
+
+```text
+YYYY-MM-DD-step-NNNN-test-results.md
+YYYY-MM-DD-step-NNNN-coverage-report.md
+```
+
+If a report covers a specific repo, language, or suite, append a short scope:
+
+```text
+YYYY-MM-DD-step-NNNN-api-coverage-report.md
+YYYY-MM-DD-step-NNNN-web-e2e-test-results.md
+YYYY-MM-DD-release-candidate-1-test-results.md
+```
+
+If a project has a real release, audit, or compliance reason to retain generated artifact trees in
+git, define that project-specific convention in the Test Strategy architecture doc. Otherwise,
+keep generated trees out of the docs repo.
+
+## What To Record
+
+Start from
+[`../../templates/reports/test-results/test-results-summary-template.md`](../../templates/reports/test-results/test-results-summary-template.md)
+when writing a Markdown summary.
+
+Each report should include:
+
+- STEP or release context, who ran it, environment, repo(s), branch(es), and commit SHA(s).
+- Overall result and run source, such as a local command, CI run, PR, or release job.
+- Commands or CI jobs run.
+- Pass/fail/skip counts and important failures.
+- Coverage tool, coverage result, and whether any configured threshold or changed-lines gate passed.
+- Location of the full generated artifact, if any: CI artifact URL, coverage-service URL, or local
+  ignored path.
+- Follow-up issue, STEP, ADR, or accepted-risk reference for anything not fixed immediately.
+- Additional notes for unusual context, manual verification, temporary workarounds, or known CI
+  instability.
+
+Coverage is a visibility and trend signal, not proof of quality. Pair the number with the
+critical paths covered and the important gaps that remain.

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -135,7 +135,9 @@ the gate was evaluated.
 
 ## Part 2 — Run all tests  *(substep N.2)*
 - Run the **full** test suite (all repos), not just the area you last touched.
-- Record the result: pass/fail counts, anything skipped, and coverage if you track it.
+- Record the result: pass/fail counts, anything skipped, and coverage if you track it. Put
+  durable test-result or coverage-report details under `reports/test-results/` and summarize the
+  important outcome in the check-in report.
 - Any failure is a finding for this check-in — fix it here if small, or file it as a bug
   STEP if not. A red suite must not be left for "later."
 

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
@@ -56,9 +56,26 @@ where the pieces have to work *together*.
    wiring this up ships in `templates/ci/` (a method-integrity workflow that runs
    `scripts/check.sh`, plus a per-repo test workflow to fill in) — see `templates/ci/README.md`.
    Include the contract-validation gates chosen in the Interface Contracts architecture doc where they apply.
-7. **Performance / load testing.** Whether and when load tests run (ties to the performance
+7. **Coverage tooling and reporting.** For each real implementation language, choose the
+   coverage tool and where its report appears. Default durable coverage/test summaries to
+   `reports/test-results/` in the docs hub for meaningful runs such as check-ins, releases,
+   incidents, security reviews, major quality-gate changes, or when requested by a user. Keep
+   generated multi-file HTML trees as CI artifacts, coverage-service output, or ignored local output by default; only define
+   a docs-retained artifact convention when the project has a real release, audit, or compliance
+   reason. Treat coverage as a visibility/trend signal, not proof of quality; decide whether
+   there is a minimum threshold, changed-lines threshold, or no numeric gate. Good defaults:
+   Python `coverage.py` via `pytest-cov`; Java JaCoCo via Maven/Gradle; TypeScript/JavaScript
+   Vitest/Jest coverage with V8 or Istanbul/nyc; Go `go test -coverprofile=coverage.out ./...`;
+   Rust `cargo llvm-cov` (or `grcov`/`tarpaulin` when it fits better); Dart/Flutter
+   `dart test --coverage` / `flutter test --coverage` with LCOV output; C#/.NET Coverlet or
+   `dotnet test --collect:"XPlat Code Coverage"`. For substantial shell scripts, consider
+   `kcov`; for SQL, prefer migration/query tests or DB-specific tools such as pgTAP/tSQLt
+   rather than pretending there is universal line coverage; for APIs, track contract/e2e
+   coverage with OpenAPI/GraphQL/protobuf validation and tools such as Schemathesis, Dredd, or
+   Newman-style checks.
+8. **Performance / load testing.** Whether and when load tests run (ties to the performance
    targets in the Scaling & Performance architecture doc).
-8. **Coding standards per language.** Confirm the implementation language(s) from the
+9. **Coding standards per language.** Confirm the implementation language(s) from the
    high-level stack (the Architecture Overview architecture doc's stack decision). Then reconcile `coding-standards/` to that list, **one
    language at a time**:
    - **If a `coding-standards/<lang>.md` already ships** (e.g. `python.md`, `typescript.md`,
@@ -81,12 +98,17 @@ Write `architecture/12-test-strategy.md` — the Test Strategy architecture doc 
 `templates/architecture-doc-template.md`). Body:
 - **Test tiers** — tier | scope | tools | where it runs
 - **Coverage priorities** — must-cover paths
+- **Coverage tooling and reporting** — language/surface | tool | durable summary location
+  (default: `reports/test-results/`) | generated artifact location | threshold/gate
 - **Test data & isolation**, **mocking strategy**
 - **System/e2e testing** (and its home in a multi-repo setup)
 - **CI gates** — what blocks merge / deploy
 - **Coding standards** — link the per-language file(s) in `coding-standards/` that apply
 
-Also reconcile the `coding-standards/` directory itself (decision 8): keep and user-review
+When durable Markdown summaries are written, start them from
+`templates/reports/test-results/test-results-summary-template.md`.
+
+Also reconcile the `coding-standards/` directory itself (decision 9): keep and user-review
 the standards for the chosen languages, add any missing ones from the existing pattern, and
 delete the rest. Update the file table in `coding-standards/README.md`.
 

--- a/Code/{{PROJECT}}-docs/templates/reports/test-results/test-results-summary-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/test-results/test-results-summary-template.md
@@ -1,0 +1,56 @@
+# {{PROJECT}} — Test Results Summary
+
+**Run date:** {{YYYY-MM-DD}}
+**Report path:** `reports/test-results/{{YYYY-MM-DD}}-{{scope}}-test-results.md`
+**Context:** {{STEP-{{N}} / release candidate / incident follow-up / security review / check-in}}
+**Overall result:** {{passed / failed / partially passed / skipped}}
+**Run by:** {{person / agent / CI workflow}}
+**Run source:** {{local command / CI run URL / PR URL / release job / other}}
+**Environment:** {{local / CI / staging / production-like / other}}
+**Architecture source:** `architecture/12-test-strategy.md`
+
+## Scope
+
+| Repo | Branch | Commit | Suites / gates covered | Notes |
+|------|--------|--------|------------------------|-------|
+| {{repo}} | `{{branch}}` | `{{sha}}` | {{unit / integration / e2e / lint / typecheck / build / coverage}} | {{single-repo or multi-repo notes}} |
+
+For a single-repo project, keep one row. For a multi-repo project, add one row for each repo whose
+code, contracts, tests, or quality gates were part of this run.
+
+## Result Summary
+
+| Repo / suite | Command or CI job | Result | Counts | Notes |
+|--------------|-------------------|--------|--------|-------|
+| {{repo / suite}} | `{{command-or-job}}` | {{passed / failed / skipped}} | {{passed/failed/skipped counts}} | {{important failures, skips, flakes, retries, duration if useful}} |
+
+## Coverage Summary
+
+| Repo / surface | Language / tool | Result | Threshold / gate | Full artifact |
+|----------------|-----------------|--------|------------------|---------------|
+| {{repo / surface}} | {{language}} / {{tool}} | {{coverage result or N/A}} | {{passed / failed / not gated}} | {{CI artifact URL / coverage-service URL / local ignored path / N/A}} |
+
+Coverage is a visibility and trend signal, not proof of quality. Summarize what matters: critical
+paths covered, important gaps, and whether the configured gate passed.
+
+## Notable Findings
+
+| Finding | Impact | Action |
+|---------|--------|--------|
+| {{failure / coverage gap / flaky test / skipped suite / none}} | {{risk or user impact}} | {{fixed / follow-up STEP or issue / accepted risk / none}} |
+
+## Follow-Up
+
+| Item | Owner | Target |
+|------|-------|--------|
+| {{STEP-N / issue / ADR / risk / none}} | {{owner}} | {{when or trigger}} |
+
+## Additional Notes
+
+{{Any extra context that does not fit the structured fields: unusual environment conditions,
+temporary workarounds, known CI instability, manual verification notes, or why this run matters.}}
+
+## Summary
+
+{{Briefly state whether the tested scope is healthy, what changed since the last meaningful run if
+known, and any remaining risk the reader should understand.}}


### PR DESCRIPTION
## Summary

- Adds a new docs-hub report family under `reports/test-results/` for durable test, coverage, and quality-gate summaries.
- Adds a reusable test-results summary template covering runner, run source, environment, repo/branch/commit scope, suite results, coverage gates, artifact locations, findings, follow-up, additional notes, and summary.
- Updates the Test Strategy session to include coverage tooling/reporting decisions per implementation language and default to Markdown summaries for meaningful runs.
- Updates the reports index, docs README, METHOD overview, artifact trail, and check-in runbook so the new report family is discoverable.

## Policy

Generated multi-file coverage trees stay out of the docs repo by default. They should live in CI artifacts, coverage-service output, or ignored local output unless a project has a real release, audit, or compliance reason to retain them.

## Verification

- `bash tests/links.sh`
- `git diff --check --cached`