### PR TITLE
Require explicit test planning in STEP workflow

### DIFF
--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -306,6 +306,12 @@ requirements, sequencing, dependencies, or ownership are unclear. When the user 
 make a planning choice, offer plausible options with brief pros and cons, then wait for
 direction. Use the saved **Planning communication style** in `overview.md` as the default
 level of detail while still asking the questions needed to make the STEP coherent.
+For any code-changing STEP, read the Test Strategy architecture doc during planning, assign
+the relevant test tiers (unit, integration, API/contract, end-to-end, security/authorization,
+migration/data, performance, or project-specific) to the substeps that introduce the behavior,
+and make the STEP's final test command or CI gate explicit. Tests may run per substep or in a
+dedicated final verification substep; choose deliberately in the PLAN. A code-changing substep
+without tests needs a stated reason, not silence.
 
 ### Check-in STEPs
 Roughly **every 10–20 STEPs**, the roadmap includes a **Check-in STEP** — a full STEP whose

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -100,11 +100,13 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    judgment.
 4. **Outline each STEP — briefly.** For each STEP (including the check-ins), a short outline:
    what it delivers and how it depends on the others. Roughly **2–3 sentences each** — a
-   guideline, not a rule. When the scope clearly creates a new test surface (API, user flow,
-   data path, integration boundary, migration, authorization rule, or performance-sensitive
-   path), mention the expected test tier at the outline level so it is not discovered only
-   after coding starts. Don't write the detailed plan, the substeps, or the definition of done
-   here; those come when the STEP is started.
+   guideline, not a rule. Don't write the detailed plan, the substeps, or the definition of
+   done here; those come when the STEP is started.
+
+**Testing note.** When a planned STEP clearly creates a new test surface (API, user flow, data
+path, integration boundary, migration, authorization rule, or performance-sensitive path),
+mention the expected test tier in the STEP outline. Keep this at the outline level; the
+detailed test plan belongs in the STEP PLAN when that STEP starts.
 
 ## Output
 - **Update `prompts/STEP-index.md`:** add a row for every Phase-1 implementation STEP —

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -100,8 +100,11 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    judgment.
 4. **Outline each STEP — briefly.** For each STEP (including the check-ins), a short outline:
    what it delivers and how it depends on the others. Roughly **2–3 sentences each** — a
-   guideline, not a rule. Don't write the detailed plan, the substeps, or the definition of
-   done here; those come when the STEP is started.
+   guideline, not a rule. When the scope clearly creates a new test surface (API, user flow,
+   data path, integration boundary, migration, authorization rule, or performance-sensitive
+   path), mention the expected test tier at the outline level so it is not discovered only
+   after coding starts. Don't write the detailed plan, the substeps, or the definition of done
+   here; those come when the STEP is started.
 
 ## Output
 - **Update `prompts/STEP-index.md`:** add a row for every Phase-1 implementation STEP —

--- a/Code/{{PROJECT}}-docs/templates/step-plan-template.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan-template.md
@@ -20,6 +20,9 @@
   that file as the single source of truth for both values.
 - `registries/risks.yml` — review relevant accepted risks/debt before planning work that
   touches their area.
+- The Test Strategy architecture doc (`architecture/*-test-strategy.md`) — use it to decide
+  which test tiers this STEP must add or update and which command or CI gate proves the STEP
+  is done.
 - For security-sensitive feature work, reference the Security & Threat Model architecture doc
   (`architecture/*-security-threat-model.md`) and relevant risk rows. Do not pull in
   `runbooks/security-review.md`, S0/S1/S2 checklists, or security report templates unless this
@@ -48,6 +51,22 @@
      runbooks/incident-postmortem.md; its durable postmortem report starts from
      templates/reports/incidents/incident-postmortem-report-template.md and is saved under
      reports/incidents/. -->
+
+## Test plan
+<!-- Required for any STEP that writes or changes code. Use the Test Strategy architecture doc
+     to choose the applicable tiers; prune rows that do not apply and add project-specific ones
+     where needed. Every code-changing substep should either appear here or state why tests are
+     not applicable. Choose the run timing deliberately: either per substep, a dedicated final
+     verification substep, or another stated gate. -->
+
+| Test tier / surface | Substep(s) | Tests to create or update | Run timing | Command / gate | Notes |
+|---------------------|------------|---------------------------|------------|----------------|-------|
+| Unit | {{N}}.? |  | Per substep / final verification |  |  |
+| Integration / data | {{N}}.? |  | Per substep / final verification |  |  |
+| API / contract | {{N}}.? |  | Per substep / final verification |  |  |
+| End-to-end / user flow | {{N}}.? |  | Per substep / final verification |  |  |
+| Security / authorization | {{N}}.? |  | Per substep / final verification |  |  |
+| Performance / load | {{N}}.? |  | Per substep / final verification |  |  |
 
 ## Conditional sessions considered  <!-- STEP-1 (architecture) only; delete this section for other STEPs -->
 <!-- Every conditional-*.md session file gets a row and an EXPLICIT decision, never a silent
@@ -78,9 +97,12 @@
   repo boundaries. When a planning decision is needed, offer appropriate options with brief
   pros and cons. Respect the saved planning style while still asking the questions needed to
   make the STEP coherent.
-- **Tests ship with the code.** Every substep that writes or changes code also writes the
-  tests for it and runs the relevant tests before it's done (see
-  `templates/substep-prompt-template.md`). Override per substep only with a stated reason.
+- **Tests ship with the code.** Every substep that writes or changes code also writes or updates
+  the relevant tests for it (unit, integration, API/contract, e2e, security/authorization,
+  migration/data, performance, or project-specific). The PLAN chooses whether tests run as each
+  substep completes or in a dedicated final verification substep; either way, the named test
+  command or CI gate must pass before the STEP is Done. Override per substep only with a stated
+  reason.
 - **Code is documented as it's written.** Every class, function, and method gets a docstring;
   comment the *why* of non-obvious logic (see `coding-standards/README.md`).
 - **Accepted risks stay visible.** If this STEP accepts a risk or defers tech debt, add or
@@ -93,8 +115,11 @@
 <!-- Concrete, checkable criteria for the whole STEP. -->
 - [ ]
 - [ ]
-- [ ] All unit tests pass at the end of this STEP — ideally the full suite (unit +
-      integration/e2e). <!-- the default bar; narrow or widen with a stated reason -->
+- [ ] The STEP test plan is complete: each code-changing substep either added/updated its
+      relevant tests or records why tests were not applicable.
+- [ ] All tests named in the STEP test plan pass at the end of this STEP — ideally the full
+      suite (unit + integration/API/e2e/security as applicable). <!-- the default bar; narrow
+      or widen with a stated reason -->
 - [ ] STEP review passed; prompts/STEP-index.md updated; STEP archived to prompts/.
       <!-- For a Check-in STEP, the completed report is saved under reports/, not in the
            archived STEP folder. -->

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
@@ -33,6 +33,9 @@
      work — auth/AuthZ, secrets, sensitive data, public attack surface, dependency/security
      controls, or accepted security risk — include the Security & Threat Model architecture doc
      (`architecture/*-security-threat-model.md`) and relevant `registries/risks.yml` rows.
+     For any substep that writes or changes code, include the Test Strategy architecture doc
+     (`architecture/*-test-strategy.md`) so the Verification section uses the project's chosen
+     test tiers, tools, coverage policy, and CI gates.
      Do not include `runbooks/security-review.md`, S0/S1/S2 checklists, or security report
      templates in normal implementation substeps; those belong only to explicit Security
      Baseline, Security Review, or Security Audit STEPs. -->
@@ -53,6 +56,13 @@
 - **If this substep writes or changes code, write the tests that cover it** — not just the
   happy path. (Default; override only for a genuinely code-free substep, e.g. docs/config,
   and say why.)
+- Choose the applicable tiers from the STEP test plan and Test Strategy architecture doc:
+  unit, integration, API/contract, end-to-end, security/authorization, migration/data,
+  performance, or project-specific tests. Prune what does not apply; do not silently skip a
+  tier that protects behavior this substep changes.
+- Name the test files/suites to create or update, and the exact command(s) or CI job(s) to run.
+  If this STEP intentionally batches execution into a final verification substep, name that
+  substep and the command/gate it will run instead of requiring this substep to run them now.
 <!-- Kinds of cases to consider — cover the ones that apply, prune the rest:
      - Happy path — the expected, valid case.
      - Empty / zero / null / missing input — empty collections & strings, 0, null/None,
@@ -69,8 +79,9 @@
        (mock at the boundary).
      - Security / authorization (where relevant) — unauthenticated / unauthorized access denied.
      - Regression — when fixing a bug, add a test that reproduces it so it can't return. -->
-- **Run the relevant tests before marking this substep done** — at minimum the tests that
-  exercise the code you touched. They must pass.
+- **Run timing:** either run the relevant tests before marking this substep done, or confirm
+  that the STEP PLAN assigns them to a later final verification substep. Tests that are deferred
+  this way still must pass before the STEP is Done.
 
 ## Keeping the docs true  (always)
 <!-- The architecture docs are the source of truth for the design. Implementation drifts
@@ -107,7 +118,8 @@ Leaving the doc stale is a defect, not a follow-up.
 ## Definition of done
 - [ ]
 - [ ]
-- [ ] Code this substep wrote or changed is covered by tests, and the relevant tests pass.
+- [ ] Code this substep wrote or changed is covered by the relevant tests named above, and
+      those tests either pass now or are assigned to the STEP's final verification substep.
       <!-- default; drop only for a genuinely code-free substep -->
 - [ ] New/changed classes, functions, and methods carry docstrings (see
       `coding-standards/README.md`).

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -105,12 +105,24 @@ teammate will need later.
    are uncertain. When there are real alternatives, present appropriate options with short
    pros and cons and let the user choose or adjust. Work the STEP on a branch named
    `step-NNNN-short-name` (the same name in every repo it touches).
-3. **Write the PLAN** from `Code/{{PROJECT}}-docs/templates/step-plan-template.md`: motivation,
+3. **Plan the tests before finalizing the substeps.** Read the Test Strategy architecture doc
+   (`Code/{{PROJECT}}-docs/architecture/*-test-strategy.md`) and decide which test tiers this
+   STEP needs: unit, integration, API/contract, end-to-end, security/authorization,
+   migration/data, performance, or another project-specific tier. Assign those tests to the
+   substeps that create or change the relevant code, and name the final command or CI gate that
+   must pass at the end of the STEP. Decide whether tests run as each substep completes or in a
+   dedicated final verification substep; both are valid, but the PLAN must say which one this
+   STEP uses. If a code-changing substep does not need tests, state the reason in that substep
+   instead of leaving the gap implicit.
+4. **Write the PLAN** from `Code/{{PROJECT}}-docs/templates/step-plan-template.md`: motivation,
    locked decisions (reference the ADRs/architecture docs it must respect), the substep
-   table, ground rules, and a definition of done. Save it in `Upcoming Prompts/`.
-4. **Write the substep prompts** from `Code/{{PROJECT}}-docs/templates/substep-prompt-template.md` —
+   table, test plan, ground rules, and a definition of done. Save it in `Upcoming Prompts/`.
+5. **Write the substep prompts** from `Code/{{PROJECT}}-docs/templates/substep-prompt-template.md` —
    one per substep, each self-contained (runnable cold in a fresh chat). Author these in
-   the same chat as the PLAN.
+   the same chat as the PLAN. Each code-changing substep's Verification section names the
+   relevant tests to create or update and either the exact test command(s) to run before marking
+   the substep done or the final verification substep/command that will run them before the STEP
+   closes.
    *(For the architecture STEP-1, the substeps are the interview sessions in
    `Code/{{PROJECT}}-docs/templates/architecture-sessions/` — you don't author those from
    scratch. For a **Check-in STEP**, you don't author prompts either — its two substeps are


### PR DESCRIPTION
## Summary
- add a dedicated test-planning pass to the STEP authoring recipe
- add a STEP-level test plan table covering relevant test tiers, run timing, and commands/gates
- clarify that tests may run per substep or in a final verification substep, but must pass before the STEP is Done
- update substep prompts to name test suites/commands and include Test Strategy for code-changing work

## Verification
- bash Code/{{PROJECT}}-docs/scripts/check.sh
- git diff --check