### PR TITLE
Clarify STEP-1 session invocation prompts

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -58,16 +58,19 @@ This project follows the method in **`Code/{{PROJECT}}-docs/METHOD.md`** — rea
 - The roadmap and status are in `prompts/STEP-index.md`.
 
 ## Architecture sessions  (how to run one)
-When the user says **"run session N.M"** (e.g. *"run session 1.1"*), read the matching file
-in `Code/{{PROJECT}}-docs/templates/architecture-sessions/NN-*.md` and follow it exactly:
-interview the user one decision at a time, then write the output architecture doc and
-update `prompts/STEP-index.md`. No copy-paste, no special commands.
+When the user says **"STEP-1.N"** or **"session N.M"**, with or without a leading "Run" and
+with or without the session label (preferred with the label, e.g.
+*"Run STEP-1.1: System Overview, Requirements & Non-Goals"*), read the matching file in
+`Code/{{PROJECT}}-docs/templates/architecture-sessions/NN-*.md` and follow it exactly:
+interview the user one decision at a time, then write the output architecture doc and update
+`prompts/STEP-index.md`. No copy-paste, no special commands.
 
-**"run session N.M" is the user's go-ahead — begin in that same reply.** Don't acknowledge,
-summarize the file, restate the plan, or ask whether to start (no "Ready when you are"). Read
-`overview.md` and any earlier architecture docs silently, then immediately **ask the
-session's first question**, calibrated to the recorded experience level. The user types one
-short command and expects the first question back, not a confirmation prompt.
+**"STEP-1.N", "Run STEP-1.N: <session label>", "session N.M", and "Run session N.M:
+<session label>" are all the user's go-ahead — begin in that same reply.** Don't
+acknowledge, summarize the file, restate the plan, or ask whether to start (no "Ready when
+you are"). Read `overview.md` and any earlier architecture docs silently, then immediately
+**ask the session's first question**, calibrated to the recorded experience level. The user
+types one short command and expects the first question back, not a confirmation prompt.
 
 **Conditional sessions** are invoked **by name**, not by number: *"run the identity-auth
 session"* → `conditional-identity-auth.md`; *"run the native-app session"* →

--- a/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
@@ -106,7 +106,7 @@ team/shared-remote project, push the `In progress` flip). **Then stop.**
 
 ### Execution (after kickoff)
 The user drives from here, one session at a time:
-> run session 1.1
+> Run STEP-1.1: System Overview, Requirements & Non-Goals
 
 Each session interviews the user and writes its architecture doc + any ADRs, then updates
 `prompts/STEP-index.md`. Encourage the user to clear the chat between sessions — state

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -148,12 +148,14 @@ conditional by name.
 
 To run an architecture session, tell your agent:
 
-> run session 1.1
+> Run STEP-1.1: System Overview, Requirements & Non-Goals
 
 The agent reads the matching file in
 `Code/{{PROJECT}}-docs/templates/architecture-sessions/NN-*.md` and follows it exactly:
 it interviews you one decision at a time, then writes the output doc and updates
-`prompts/STEP-index.md`. No copy-paste, no special commands.
+`prompts/STEP-index.md`. No copy-paste, no special commands. The shorter
+*"STEP-1.N"* and *"session N.M"* forms also work, with or without a leading "Run" and with
+or without `: <session label>`, but the labeled form gives chat/task UIs a clearer title.
 
 Each session reads what it needs (`overview.md` + earlier architecture docs) from disk, so
 **you can clear the chat / start fresh between sessions** — the state lives in files, not
@@ -161,7 +163,8 @@ in the conversation. This keeps STEP-1's many sessions from piling up in one con
 
 ### Sessions are re-runnable
 A session isn't a one-time gate. If an assumption changes later — scaling needs grow, the
-threat model shifts, a phase gets re-cut — **re-run that session** (*"run session 1.5"*).
+threat model shifts, a phase gets re-cut — **re-run that session** (for example,
+*"Run STEP-1.5: Scaling & Performance"*).
 It re-interviews you, **revises the existing architecture doc in place, and records the
 change in that doc's Version Log** (and a new ADR if the decision is significant — the old
 ADR is superseded, not edited). Re-running is the normal way the living docs stay true as
@@ -504,12 +507,14 @@ Quick resolver:
 
 Resolve the next action top-down against the index — the first rule that matches wins:
 
-1. **STEP-1 has a `Planned` / `In progress` substep?** → run the lowest-numbered open one:
-   *"run session N.M"* in a fresh chat. Skip any substep marked `N/A` or `Deferred`. A substep with a
+1. **STEP-1 has a `Planned` / `In progress` substep?** → run the lowest-numbered open one
+   in a fresh chat using `Run STEP-1.N: <Session label from the index>`; the label is
+   optional but preferred because it gives the chat/task a clearer title. Skip any substep marked `N/A` or `Deferred`. A substep with a
    **letter suffix** (e.g. `1.6a`, `1.7a`) is a **conditional session** the kickoff slotted
-   in — invoke it **by name** (*"run the identity-auth session"* / *"run the native-app
-   session"* / *"run the privacy session"* or *"run the privacy-compliance session"*), since
-   its template file is named by topic, not by number (see §4).
+   in — use `Run STEP-1.Xa: <Conditional session label>` plus the invocation **by name**
+   (*"run the identity-auth session"* / *"run the native-app session"* / *"run the privacy
+   session"* or *"run the privacy-compliance session"*), since its template file is named by
+   topic, not by number (see §4).
 2. **All STEP-1 design sessions done but the Cross-Cutting Review is still open?** → run the
    substep whose Session label is **Cross-Cutting Review**.
 3. **Cross-Cutting Review done and STEP-1 complete, but only the STEP-1 row exists?** →

--- a/Code/{{PROJECT}}-docs/architecture/README.md
+++ b/Code/{{PROJECT}}-docs/architecture/README.md
@@ -6,7 +6,7 @@ are point-in-time). See `METHOD.md` §3 and §6.
 
 Most of these are produced by the **architecture sessions** during STEP-1
 (`../templates/architecture-sessions/`). To create or revise one, run its session
-(e.g. *"run session 1.5"*).
+(e.g. *"Run STEP-1.5: Scaling & Performance"*).
 
 ## Conventions
 - Filenames: `NN-kebab-title.md`, numbered in the order the sessions produce them.

--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -173,11 +173,11 @@ elif [ -n "$lowsub" ]; then                                 # §10.1 / §10.2
     elif printf '%s' "$lowsub_se" | grep -qiE 'privacy|compliance|data governance'; then
       cond_example="run the privacy session"
     fi
-    next="run the conditional session for substep ${lowsub} — \"${lowsub_se}\"; invoke it BY NAME (e.g. \"${cond_example}\"), not by number."
+    next="Run STEP-${lowsub}: ${lowsub_se} — invoke it BY NAME (e.g. \"${cond_example}\"), not by number."
   elif printf '%s' "$lowsub_se" | grep -qiE 'cross.?cutting'; then
-    next="run session ${lowsub} — the Cross-Cutting Review."
+    next="Run STEP-${lowsub}: Cross-Cutting Review."
   else
-    next="run session ${lowsub}  (${lowsub_se})."
+    next="Run STEP-${lowsub}: ${lowsub_se}."
   fi
 elif [ "$total_sub" -gt 0 ] && [ "$done_sub" -lt "$total_sub" ]; then
   where="Architecture (STEP-1) has ${done_sub}/${total_sub} substeps final, but no runnable open substep could be resolved."
@@ -191,7 +191,7 @@ elif [ "$have_impl" -eq 0 ]; then                           # §10.3 (or STEP-1 
     next="run the planning session — it outlines the Phase-1 implementation STEPs."
   else
     where="Architecture (STEP-1) not yet run."
-    next="run session 1.1 — start the architecture STEP."
+    next="Run STEP-1.1: System Overview, Requirements & Non-Goals — start the architecture STEP."
   fi
 elif [ -n "$inprog" ]; then                                 # §10.6
   where="Building — ${inprog} (${inprog_ti}) is In progress."

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
@@ -1,6 +1,8 @@
 # {{PROJECT}} — System Overview, Requirements & Non-Goals (Session 1.1)
 
-> **How to run:** Tell your agent *"run session 1.1"* (or *"read and run this file"*).
+> **How to run:** Tell your agent *"STEP-1.1"* or *"session 1.1"*; a leading *"Run"* and
+> `: System Overview, Requirements & Non-Goals` are optional (but the label helps chat titles).
+> You can also say *"read and run this file"*.
 > It interviews you one decision at a time, then writes
 > the System Overview, Requirements & Non-Goals architecture doc and updates
 > `prompts/STEP-index.md`.
@@ -97,8 +99,10 @@ regulated data), and **native app** (if there's a mobile or desktop app). The Ph
 and the index confirm which sessions are in play.
 
 Then point them at the next action: the lowest open STEP-1 substep in the index. Tell the
-user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+user to **start a fresh chat** and run that substep with a descriptive first message. For a
+numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.2: Phasing & Roadmap`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/02-phasing-roadmap.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/02-phasing-roadmap.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Phasing & Roadmap (Session 1.2)
 
-> **How to run:** Tell your agent *"run session 1.2"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.2"* or *"session 1.2"*; a leading *"Run"* and
+> `: Phasing & Roadmap` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Phasing & Roadmap architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md` and the System Overview, Requirements & Non-Goals architecture doc
 > (`architecture/*-system-overview.md`) first.
@@ -67,8 +68,10 @@ substep 1.2 done.
 
 ## Next
 Once 1.2 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.3: Architecture Overview & Component Boundaries`). For a lettered conditional
+session, use `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from
+that conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Architecture Overview & Component Boundaries (Session 1.3)
 
-> **How to run:** Tell your agent *"run session 1.3"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.3"* or *"session 1.3"*; a leading *"Run"* and
+> `: Architecture Overview & Component Boundaries` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Architecture Overview architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md`, the System Overview, Requirements & Non-Goals architecture doc
 > (`architecture/*-system-overview.md`), and
@@ -83,9 +84,11 @@ System row.
 
 ## Next
 Once 1.3 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). This session may have
-marked the UI / Design System row `N/A` or added a Native-app row, so trust the index. See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.4: Data Model, Ownership & Retention`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. This session may have marked the UI / Design System row `N/A` or
+added a Native-app row, so trust the index. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Data Model, Ownership & Retention (Session 1.4)
 
-> **How to run:** Tell your agent *"run session 1.4"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.4"* or *"session 1.4"*; a leading *"Run"* and
+> `: Data Model, Ownership & Retention` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Data Model architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md`, the System Overview, Requirements & Non-Goals architecture doc
 > (`architecture/*-system-overview.md`), and
@@ -68,8 +69,10 @@ the **Version Log**. Update `prompts/STEP-index.md`: mark 1.4 done.
 
 ## Next
 Once 1.4 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.5: Scaling & Performance`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Scaling & Performance (Session 1.5)
 
-> **How to run:** Tell your agent *"run session 1.5"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.5"* or *"session 1.5"*; a leading *"Run"* and
+> `: Scaling & Performance` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Scaling & Performance architecture doc and updates
 > `prompts/STEP-index.md`.
 > Reads `overview.md`, the Phasing & Roadmap architecture doc (`architecture/*-phasing-roadmap.md`),
@@ -71,8 +72,10 @@ Fill the **Decision Summary** (the "Forecloses" column is the point of this doc)
 
 ## Next
 Once 1.5 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.6: Security & Threat Model`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Security & Threat Model (Session 1.6)
 
-> **How to run:** Tell your agent *"run session 1.6"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.6"* or *"session 1.6"*; a leading *"Run"* and
+> `: Security & Threat Model` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Security & Threat Model architecture doc
 > (`architecture/06-security-threat-model.md`) and updates `prompts/STEP-index.md`.
 > Reads `overview.md`, the Architecture Overview architecture doc (`architecture/*-architecture-overview.md`),
@@ -97,8 +98,10 @@ register, PLAN, or notes/scope text.
 
 ## Next
 Once 1.6 is marked `Done` or `Deferred`, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.7: UI / Design System`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — UI / Design System (Session 1.7)
 
-> **How to run:** Tell your agent *"run session 1.7"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.7"* or *"session 1.7"*; a leading *"Run"* and
+> `: UI / Design System` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes `architecture/07-ui-design-system.md` and updates `prompts/STEP-index.md`.
 > Reads `overview.md` and the Architecture Overview architecture doc (`architecture/*-architecture-overview.md`)
 > for the client-surfaces answer first — plus any
@@ -91,8 +92,10 @@ Fill the **Decision Summary**, record **Open Questions**, start the **Version Lo
 
 ## Next
 Once 1.7 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.8: Infrastructure & Deployment`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Infrastructure & Deployment (Session 1.8)
 
-> **How to run:** Tell your agent *"run session 1.8"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.8"* or *"session 1.8"*; a leading *"Run"* and
+> `: Infrastructure & Deployment` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Infrastructure & Deployment architecture doc and updates
 > `prompts/STEP-index.md`. Reads `overview.md`, the Architecture Overview architecture doc
 > (`architecture/*-architecture-overview.md`), the Scaling & Performance architecture doc
@@ -93,8 +94,10 @@ provider/lock-in and availability/RPO-RTO decisions as ADRs if significant. Upda
 
 ## Next
 Once 1.8 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.9: Environments`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Environments (Session 1.9)
 
-> **How to run:** Tell your agent *"run session 1.9"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.9"* or *"session 1.9"*; a leading *"Run"* and
+> `: Environments` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Environments architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md` and the Infrastructure & Deployment architecture doc
 > (`architecture/*-infrastructure-deployment.md`) first.
@@ -66,8 +67,10 @@ Fill the **Decision Summary**, record **Open Questions**, start the **Version Lo
 
 ## Next
 Once 1.9 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.10: Observability`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Observability (Session 1.10)
 
-> **How to run:** Tell your agent *"run session 1.10"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.10"* or *"session 1.10"*; a leading *"Run"* and
+> `: Observability` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Observability architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md`, the Architecture Overview architecture doc (`architecture/*-architecture-overview.md`),
 > and the Scaling & Performance architecture doc (`architecture/*-scaling-performance.md`) first
@@ -67,8 +68,10 @@ Fill the **Decision Summary**, record **Open Questions**, start the **Version Lo
 
 ## Next
 Once 1.10 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.11: Interface Contracts`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-interface-contracts.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-interface-contracts.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} - Interface Contracts (Session 1.11)
 
-> **How to run:** Tell your agent *"run session 1.11"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.11"* or *"session 1.11"*; a leading *"Run"* and
+> `: Interface Contracts` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Interface Contracts architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md`, the Architecture Overview architecture doc (`architecture/*-architecture-overview.md`),
 > the Data Model architecture doc (`architecture/*-data-model.md`), the Security & Threat Model architecture doc
@@ -103,8 +104,10 @@ Fill the **Decision Summary**, record **Open Questions**, start the **Version Lo
 
 ## Next
 Once 1.11 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` section 10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.12: Test Strategy`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` section 10.
 
-**Begin now - in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user - in the one or two sentences from **What this session does** above - what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply - nothing more.
+**Begin now - in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user - in the one or two sentences from **What this session does** above - what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply - nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Test Strategy (Session 1.12)
 
-> **How to run:** Tell your agent *"run session 1.12"*. It interviews you one decision at a
+> **How to run:** Tell your agent *"STEP-1.12"* or *"session 1.12"*; a leading *"Run"* and
+> `: Test Strategy` are optional (but the label helps chat titles). It interviews you one decision at a
 > time, then writes the Test Strategy architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md`, the Architecture Overview architecture doc (`architecture/*-architecture-overview.md`),
 > the Data Model architecture doc (`architecture/*-data-model.md`), the Environments architecture doc
@@ -117,8 +118,10 @@ Fill the **Decision Summary**, record **Open Questions**, start the **Version Lo
 
 ## Next
 Once 1.12 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.13: Glossary`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session N.M" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.
+**Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read `overview.md` (and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the recorded experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/13-glossary.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/13-glossary.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Glossary (Session 1.13)
 
-> **How to run:** Tell your agent *"run session 1.13"*. It works through the project's terms
+> **How to run:** Tell your agent *"STEP-1.13"* or *"session 1.13"*; a leading *"Run"* and
+> `: Glossary` are optional (but the label helps chat titles). It works through the project's terms
 > with you, then writes the Glossary architecture doc and updates `prompts/STEP-index.md`.
 > Reads `overview.md` and **all** the architecture docs produced so far.
 > **Calibrate to experience.** Check the **Experience level** in `overview.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (`METHOD.md` §4.)
@@ -61,13 +62,16 @@ Log**; record any unresolved naming questions in **Open Questions**. Update
 
 ## Next
 Once 1.13 is marked done, the next action is the lowest open STEP-1 substep in the index. Tell
-the user to **start a fresh chat** and run that substep (for a numbered core session, *"run
-session N.M"*; for a lettered conditional session, invoke it by name). See the next-action
-resolver in `METHOD.md` §10.
+the user to **start a fresh chat** and run that substep with a descriptive first message. For
+a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for example,
+`Run STEP-1.14: Cross-Cutting Review`). For a lettered conditional session, use
+`Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
+conditional's template. See the next-action resolver in `METHOD.md` §10.
 
-**Begin now — in this same reply.** "run session 1.13" is your go-ahead, not a request for
-acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to
-start. Read `overview.md` and all the architecture docs silently. Then, in this one reply:
+**Begin now — in this same reply.** "STEP-1.13" or "session 1.13", with or without a leading
+"Run" and with or without ": Glossary", is your go-ahead, not a request for acknowledgement:
+don't say "ready when you are", don't recap this file, don't ask whether to start. Read
+`overview.md` and all the architecture docs silently. Then, in this one reply:
 **(1)** tell the user — in the one or two sentences from **What this session does** above —
 what you're about to do (plain language); then **(2)** immediately present the first batch of
 terms you've gathered (with proposed plain-language definitions) for them to confirm or

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/14-cross-cutting-review.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/14-cross-cutting-review.md
@@ -1,6 +1,7 @@
 # {{PROJECT}} — Cross-Cutting Review (Session 1.14)
 
-> **How to run:** Tell your agent *"run session 1.14"*. This is the closing pass of the
+> **How to run:** Tell your agent *"STEP-1.14"* or *"session 1.14"*; a leading *"Run"* and
+> `: Cross-Cutting Review` are optional (but the label helps chat titles). This is the closing pass of the
 > architecture STEP. Unlike the other sessions it's a **review**, not an interview — it
 > reads everything produced in STEP-1 and checks it hangs together, then fixes what doesn't.
 > Reads **all** of `architecture/*`, `adr/*`, and
@@ -54,8 +55,10 @@ between "we have a pile of docs" and "we have a coherent architecture."
    to start a fresh chat and use the exact invocation from that conditional's template.
    **Stop the review here.** After the conditional session is complete, the next action is to
    run this Cross-Cutting Review again **from the beginning**, because the new doc may change
-   any cross-cutting finding. Do not mark 1.14 or STEP-1 `Done` until every discovered
-   conditional is resolved.
+   any cross-cutting finding. Use a descriptive first message when telling the user to run
+   the conditional, e.g. `Run STEP-1.Xa: <Conditional session label>` plus the invocation by
+   name from that conditional's template. Do not mark 1.14 or STEP-1 `Done` until every
+   discovered conditional is resolved.
 2. **Consistency.** Do the docs agree? Common conflicts: the data model vs. the API/flows
    in the Architecture Overview architecture doc; scaling assumptions vs. the chosen infrastructure; the
    backup/RPO and availability target vs. the data model's loss-tolerance decisions;
@@ -92,10 +95,11 @@ between "we have a pile of docs" and "we have a coherent architecture."
 Once the review is clean, the architecture STEP is done — mark the STEP-1 row `Done` and archive
 it to `prompts/001-mvp/step-0001/` (`prompts/README.md`). The next action is to move into
 building: **start a fresh chat** and run the **implementation planning session**
-(`templates/planning-session.md`, *"run the planning session"*) — it outlines the Phase-1
+(`templates/planning-session.md`, *"Run planning session: Phase-1 implementation roadmap"*) — it outlines the Phase-1
 implementation STEPs. See the next-action resolver (`METHOD.md` §10).
 
-**Begin now — in this same reply.** "run session 1.14" is your go-ahead, not a request for
+**Begin now — in this same reply.** "STEP-1.14" or "session 1.14", with or without a leading
+"Run" and with or without ": Cross-Cutting Review", is your go-ahead, not a request for
 acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to
 start. Read all the STEP-1 architecture docs and ADRs, every `conditional-*.md` template,
 the STEP-1 PLAN, and `prompts/STEP-index.md` silently. Run the conditional-session gate

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ production software, get review from an experienced engineer.
    asks — you don't have to pre-write anything.
 
    From there the agent proposes a roadmap and starts the architecture STEP; you work
-   through the architecture sessions one at a time (*"run session 1.1"*), then move into
+   through the architecture sessions one at a time
+   (*"Run STEP-1.1: System Overview, Requirements & Non-Goals"*), then move into
    building. On any later session, the same **"Read AGENTS.md and follow it"** resumes where
    you left off (it reads the roadmap in `prompts/STEP-index.md`) rather than re-running the
    kickoff.

--- a/brand/site/index.html
+++ b/brand/site/index.html
@@ -317,7 +317,7 @@
         <h3>Aspects covered</h3>
         <ul class="session-list">
           <li><span class="idx">1</span>What the product should and should not do</li>
-          <li><span class="idx">2</span>What belongs in the first version</li>
+          <li><span class="idx">2</span>Project phases</li>
           <li><span class="idx">3</span>Major parts of the system and their boundaries</li>
           <li><span class="idx">4</span>Important data, ownership, and retention</li>
           <li><span class="idx">5</span>Expected scale and performance needs</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -317,7 +317,7 @@
         <h3>Aspects covered</h3>
         <ul class="session-list">
           <li><span class="idx">1</span>What the product should and should not do</li>
-          <li><span class="idx">2</span>What belongs in the first version</li>
+          <li><span class="idx">2</span>Project phases</li>
           <li><span class="idx">3</span>Major parts of the system and their boundaries</li>
           <li><span class="idx">4</span>Important data, ownership, and retention</li>
           <li><span class="idx">5</span>Expected scale and performance needs</li>


### PR DESCRIPTION
## Summary
- Document short and labeled STEP-1 session invocation forms across scaffold guidance
- Update architecture session templates to accept STEP-1.N and session N.M with optional labels
- Update status output to suggest clearer session titles

## Tests
- ./Code/{{PROJECT}}-docs/scripts/check.sh
- ./tests/status-conditional-priority.sh
- ./tests/doctor-dispatcher.sh
- ./tests/links.sh
- ./tests/init-trunk-branch.sh
- ./tests/init-adr-authority.sh
- ./tests/init-mono-origin-reuse.sh
- ./tests/init-license-validation.sh
- ./tests/site-publish.sh