### PR TITLE
Clarify STEP planning command semantics

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -95,6 +95,22 @@ saying **"run the planning session"** — read
 `Code/{{PROJECT}}-docs/templates/planning-session.md` and follow it: it turns the locked
 architecture into the Phase-1 implementation STEPs.
 
+## Implementation STEPs  (how to start one)
+For implementation STEPs (`STEP-2` and later), a whole-STEP command such as **"run STEP 6"**,
+**"run STEP-6"**, **"start STEP 6"**, **"kick off STEP 6"**, or **"do STEP 6"** means:
+plan that STEP, then stop for user approval.
+
+For a `Planned` implementation STEP, confirm the scope, author the STEP PLAN and any substep
+prompts using `prompts/README.md` ("Recipe: adding a new STEP"), update
+`prompts/STEP-index.md`, then present the plan and ask for approval before running any
+substep. **Do not interpret a whole-STEP command as permission to execute the substeps you just
+created.** Execution starts only when the user explicitly says **"run substep N.M"** (or gives
+an equally specific substep command).
+
+For an `In progress` implementation STEP, open its PLAN in `Upcoming Prompts/`, identify the
+lowest open substep, and wait for the user's explicit substep command unless the current
+message already names that substep. Never run multiple substeps from a whole-STEP command.
+
 ## Repos & workspace layout
 This is a **multi-repo** project. The workspace root is **not** a repo — it's a per-machine
 shell. (Mono-repo-for-now is the exception — then the root *is* the single repo and the

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -315,6 +315,12 @@ frozen**: while executing the substeps, decisions made in an earlier substep oft
 what a later substep should do. Update the affected substep prompts (and the PLAN) as you
 go — the prompts should reflect the current intent, not the original guess.
 
+Authoring a STEP is a planning action, not execution approval. If the user's command names a
+whole implementation STEP (`run STEP N`, `start STEP N`, `kick off STEP N`, or similar),
+write or revise the PLAN and substep prompts, present them, and wait. Actual work begins only
+after an explicit substep command (or, for a thin conditional follow-up STEP, an explicit
+by-name conditional-session invocation).
+
 Treat STEP planning as an interactive discussion, not a silent document-generation task.
 Before writing the PLAN, confirm the scope with the user and ask for clarification when
 requirements, sequencing, dependencies, or ownership are unclear. When the user needs to
@@ -512,9 +518,9 @@ Quick resolver:
 | STEP-1 has an open design substep | Run the lowest-numbered open session |
 | STEP-1 design is done, Cross-Cutting Review open | Run Cross-Cutting Review |
 | STEP-1 complete and no implementation STEPs exist yet | Run the planning session |
-| Conditional-session follow-up STEP planned and none in progress | Start that conditional follow-up |
-| Planned implementation STEPs exist and none in progress | Start the lowest-numbered planned STEP |
-| A STEP is in progress | Open its PLAN and run the lowest open substep |
+| Conditional-session follow-up STEP planned and none in progress | Plan that conditional follow-up, then wait for approval |
+| Planned implementation STEPs exist and none in progress | Plan the lowest-numbered planned STEP, then wait for approval |
+| A STEP is in progress | Open its PLAN, identify the lowest open substep, and wait for an explicit substep command |
 | Check-in cadence is due | Propose a Check-in STEP |
 | Phase is complete | Do milestone doc review, then plan the next phase |
 
@@ -533,13 +539,19 @@ Resolve the next action top-down against the index — the first rule that match
 3. **Cross-Cutting Review done and STEP-1 complete, but only the STEP-1 row exists?** →
    *"run the planning session"* — it outlines the Phase-1 implementation STEPs (§2).
 4. **A `Conditional session: …` follow-up STEP is `Planned`, and no STEP is `In progress`?**
-   → start the lowest-numbered such follow-up before returning to implementation. Author its
-   thin one-substep PLAN as described in §4 and invoke the conditional by name.
-5. **Implementation STEPs outlined (`Planned`) but none `In progress`?** → start the
-   lowest-numbered `Planned` STEP: author its PLAN + substep prompts (`prompts/README.md` →
-   "Recipe: adding a new STEP"), in a fresh chat.
-6. **A STEP is `In progress`?** → open its PLAN in `Upcoming Prompts/` and run its lowest
-   open substep: *"run substep N.M"*. When the last substep is done, run the STEP's review,
+   → plan the lowest-numbered such follow-up before returning to implementation. Author its
+   thin one-substep PLAN as described in §4, record the conditional's by-name invocation, then
+   stop for approval. Run the conditional only when the user explicitly invokes it by name.
+5. **Implementation STEPs outlined (`Planned`) but none `In progress`?** → plan the
+   lowest-numbered `Planned` STEP: in a fresh chat, confirm scope, author its PLAN + substep
+   prompts (`prompts/README.md` → "Recipe: adding a new STEP"), update the index, then stop
+   for user approval. A whole-STEP command such as *"run STEP 6"*, *"run STEP-6"*,
+   *"start STEP 6"*, or *"kick off STEP 6"* means **plan the STEP and wait**; it is not
+   approval to execute the substeps you just created.
+6. **A STEP is `In progress`?** → open its PLAN in `Upcoming Prompts/` and run only the
+   explicitly requested substep: *"run substep N.M"*. If the user says only *"run STEP N"*,
+   identify the lowest open substep and wait for that explicit substep command. When the last
+   substep is done, run the STEP's review,
    then archive it (§5) and mark it `Done`.
 7. **~10–20 STEPs since the last check-in?** → propose a **Check-in STEP** at the next
    sensible breakpoint (§5; `runbooks/check-in.md`).

--- a/Code/{{PROJECT}}-docs/ONBOARDING.md
+++ b/Code/{{PROJECT}}-docs/ONBOARDING.md
@@ -114,7 +114,7 @@ Before editing code or durable docs:
    STEP touches.
 5. Update only your STEP row in `prompts/STEP-index.md` to `In progress` when you start, and
    push that small status change to the shared trunk.
-6. Work from the STEP PLAN in `Upcoming Prompts/`, running the lowest open substep first.
+6. After the STEP PLAN is approved, work from it by running the lowest open substep first.
 7. Edit shared tables narrowly: your own STEP row, your own ADR/registry row, or the row the
    STEP explicitly owns. Do not re-sort or reformat shared tables as drive-by cleanup.
 8. When complete, update the STEP review state, archive the PLAN and substep prompts from

--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -196,16 +196,16 @@ elif [ "$have_impl" -eq 0 ]; then                           # §10.3 (or STEP-1 
 elif [ -n "$inprog" ]; then                                 # §10.6
   where="Building — ${inprog} (${inprog_ti}) is In progress."
   if printf '%s' "$inprog_ti" | grep -qiE '^conditional session:'; then
-    next="open ${inprog}'s thin PLAN in \"Upcoming Prompts/\" and invoke its conditional template BY NAME. Then run its architecture-consistency review, archive it, and mark ${inprog} Done."
+    next="open ${inprog}'s thin PLAN in \"Upcoming Prompts/\", identify its conditional template invocation BY NAME, and wait for that explicit by-name command. Then run its architecture-consistency review, archive it, and mark ${inprog} Done."
   else
-    next="open ${inprog}'s PLAN in \"Upcoming Prompts/\" and run its lowest open substep (\"run substep N.M\"). When the last is done: review, archive to prompts/, mark ${inprog} Done."
+    next="open ${inprog}'s PLAN in \"Upcoming Prompts/\", identify its lowest open substep, and wait for an explicit substep command (\"run substep N.M\"). When the last is done: review, archive to prompts/, mark ${inprog} Done."
   fi
 elif [ -n "$lowplanned_cond" ]; then                        # §10.4
   where="Architecture follow-up required — ${lowplanned_cond} (${lowplanned_cond_ti}) is Planned."
-  next="start ${lowplanned_cond} before ordinary implementation work — author its thin one-substep PLAN pointing to the matching conditional-*.md template, record the exact by-name invocation and output-doc number, then run it in a fresh chat."
+  next="plan ${lowplanned_cond} before ordinary implementation work — author its thin one-substep PLAN pointing to the matching conditional-*.md template, record the exact by-name invocation and output-doc number, then stop for approval before invoking it."
 elif [ -n "$lowplanned" ]; then                             # §10.5
   where="Building — no STEP In progress; next up is ${lowplanned} (${lowplanned_ti})."
-  next="start ${lowplanned} — confirm scope, then author its PLAN + substep prompts (prompts/README.md recipe) in a fresh chat."
+  next="plan ${lowplanned} — confirm scope, author its PLAN + substep prompts (prompts/README.md recipe) in a fresh chat, then stop for approval before running any substep."
 elif [ "$all_final" -eq 1 ]; then                           # §10.8
   where="Every STEP in the index is final (Done, Deferred, or Abandoned)."
   next="phase looks complete — it's a milestone: prompt release notes (templates/release-notes-template.md if yes) + user-facing doc updates (METHOD §5), then open the next phase and run the planning session for it."

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -120,14 +120,16 @@ detailed test plan belongs in the STEP PLAN when that STEP starts.
     for duplicate numbers, and push again.
 - **Then stop.** Don't create any PLAN or substep-prompt files. When the user is ready to
   build, they start the first STEP — and *that* is when its PLAN and substep prompts get
-  authored, per `prompts/README.md`. Re-run this session if the outline needs revising as the
+  authored, per `prompts/README.md`. Starting that STEP still stops after planning; substeps
+  run only after explicit approval. Re-run this session if the outline needs revising as the
   project learns.
 
 ## Next
 The outline **is** the deliverable — author no PLANs here. Once the rows are in
 `prompts/STEP-index.md`, tell the user the next action: **start a fresh chat** and start the
 lowest-numbered `Planned` implementation STEP, authoring its PLAN + substep prompts via
-`prompts/README.md` ("Recipe: adding a new STEP"). See the next-action resolver
+`prompts/README.md` ("Recipe: adding a new STEP"), then stopping for approval before any
+substep runs. See the next-action resolver
 (`METHOD.md` §10).
 
 Start by reading the Phasing & Roadmap architecture doc (`architecture/*-phasing-roadmap.md`), the Architecture Overview architecture doc

--- a/Code/{{PROJECT}}-docs/templates/step-index-seed.md
+++ b/Code/{{PROJECT}}-docs/templates/step-index-seed.md
@@ -32,7 +32,8 @@ worked, and completed.
      add them by hand: after STEP-1's review passes, run the planning session
      (templates/planning-session.md) and it outlines all the Phase-1 implementation STEPs
      here (a couple of sentences each), in dependency order after STEP-1. Each STEP's detailed
-     PLAN and substeps are written later, when you start that STEP. Example row shape:
+     PLAN and substeps are written later, when you start that STEP. Starting a STEP means
+     planning it and stopping for approval before any substep runs. Example row shape:
      | STEP-2 | Scaffold repos & skeleton | | Planned | `{{PROJECT}}-api` | … | -->
 
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -53,7 +53,8 @@ Cross-Cutting Review passes, run the **implementation planning session**
 reads the locked architecture and **outlines all the Phase-1 implementation STEPs** into
 `STEP-index.md` — a short (2–3 sentence) scope each, in dependency order. It stops there: no
 PLANs, no substep prompts. From then on you build the STEPs one at a time, authoring each
-STEP's PLAN + substep prompts with the recipe below **when you start that STEP**.
+STEP's PLAN + substep prompts with the recipe below **when you start that STEP**. Starting a
+STEP means planning it, then stopping for approval before any substep runs.
 
 The outline also interleaves a **Check-in STEP** every ~10–20 STEPs — a full STEP that runs
 `Code/{{PROJECT}}-docs/runbooks/check-in.md` (reconcile docs vs. code both ways, re-check
@@ -87,6 +88,14 @@ teammate will need later.
 > clarification whenever the work is ambiguous, and when a decision is needed offer
 > appropriate options with brief pros and cons rather than forcing the user to start from a
 > blank page.
+> A whole-STEP command such as **"run STEP 6"**, **"run STEP-6"**, **"start STEP 6"**,
+> **"kick off STEP 6"**, or **"do STEP 6"** means **write or revise this STEP plan and its
+> substep prompts, then stop for approval**. It is not permission to execute the substeps.
+> For thin STEPs (Check-in, Incident, late conditional-session follow-up, or an explicit
+> Security Baseline/Review/Audit STEP), write the thin PLAN and record the runbook/session
+> substeps instead of authoring normal substep prompts; still stop for approval before running
+> the runbook or session.
+> Substep execution requires an explicit substep command such as **"run substep 6.1"**.
 > Read the saved **Communication style** in root `.throughstone/local-user.md` and use it as
 > the default verbosity. If the file or value is missing, ask the two local-profile
 > questions from `Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md` Stage 0, create/update the file,
@@ -140,7 +149,10 @@ teammate will need later.
    invocation plus the assigned output-doc number; don't duplicate the session into a new
    prompt. Give its index row the title `Conditional session: <topic>` so the resolver runs
    it before ordinary planned implementation work.)*
-5. **Update `prompts/STEP-index.md`**: set the STEP's status and list its substeps.
+5. **Update `prompts/STEP-index.md`**: set the STEP's status and list its substeps. Then
+   present the PLAN and substep list to the user and **stop for approval** before running any
+   substep. Do not continue from planning into execution unless the user explicitly asks for a
+   specific substep, e.g. `run substep N.1`.
 6. **On completion:** run the STEP's review — your team's standard **PR / code review** (the
    method doesn't redefine it), plus the doc-drift check — then **gather the STEP's files
    (PLAN + any substep prompts + review) from `Upcoming Prompts/` into a new `step-NNNN/` folder**

--- a/tests/status-conditional-priority.sh
+++ b/tests/status-conditional-priority.sh
@@ -68,7 +68,7 @@ write_index "$index" \
 | STEP-12 | Conditional session: AI feature | | In progress | | Fixture |'
 output="$(run_status "$index")"
 assert_contains "$output" \
-  'invoke its conditional template BY NAME'
+  'identify its conditional template invocation BY NAME'
 
 # With no conditional follow-up in the index, the resolver should select ordinary planned work.
 write_index "$index" \
@@ -77,5 +77,7 @@ write_index "$index" \
 output="$(run_status "$index")"
 assert_contains "$output" \
   'Building — no STEP In progress; next up is STEP-2 (Ordinary implementation).'
+assert_contains "$output" \
+  'then stop for approval before running any substep'
 
 echo "status.sh conditional priority: PASS"


### PR DESCRIPTION
## Summary

- Clarifies that numbered whole-STEP commands such as `run STEP 6`, `start STEP 6`, or `kick off STEP 6` mean to author or revise the STEP plan and then stop for approval.
- Preserves existing execution paths for STEP-1 architecture sessions, explicit substep commands, and named runbook/session invocations.
- Updates the status resolver, onboarding guidance, planning templates, and regression coverage so generated projects inherit the behavior.

## Why

A user command intended to kick off STEP planning was interpreted as permission to create the substeps, run all of them, and complete the STEP. The process docs now draw a clearer boundary between planning a numbered STEP and executing specific substeps.

## Validation

- `bash tests/status-conditional-priority.sh`
- `bash Code/{{PROJECT}}-docs/scripts/check.sh`

`check.sh` passes with expected warnings for the uninitialized scaffold state: no `prompts/STEP-index.md` yet.