### PR TITLE
Decouple architecture-doc metadata (Version/Status/Coverage); retire the MVP maturity rung

### DIFF
--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -366,12 +366,29 @@ to mandate the output.
 
 ## 6. Versioning architecture docs
 
-Each architecture doc carries:
-- **`Version:`** — `major.minor.patch`. Bump *patch* for fixes/clarifications, *minor*
-  for added sections/decisions, *major* for a maturity era change.
-- **`Status:`** — the maturity era: **Draft** (`v0.x`, pre-MVP, shape unstable) →
-  **MVP** (`v1.x`, describes what's built) → **Stable** (`v2.x`, ready for outside
-  consumers).
+Each architecture doc carries three independent header facts — an identity **number**, a
+maturity **status**, and (optionally) a **coverage** note — plus a change log:
+- **`Version:`** — identity / number, `major.minor.patch`. Bump *patch* for
+  fixes/clarifications, *minor* for added sections/decisions, *major* for a **breaking
+  architectural change** (a decision that supersedes a prior one). The number is **decoupled
+  from maturity**: `major` no longer marks a maturity "era," so a project already on its own
+  house convention (a calendar date, a `v16`-style line) may keep it — the lifecycle lives in
+  `Status`, not in the digits.
+- **`Status:`** — the doc's **maturity lifecycle**, the authoritative *"is this doc the current
+  agreed truth?"* signal, independent of the number: **Draft** (not yet — `v0.x`, pre-release,
+  shape still unstable) → **Current** (yes — the live, agreed description you can depend on) →
+  **Deprecated** (no longer — the doc is retired). A doc is deprecated either because a newer doc
+  supersedes it or because the thing it described was removed (a server, a feature); either way it is
+  kept for history, not deleted, with a short note on why — and a pointer to its replacement when there
+  is one. A project may rename the rungs, but only to *settledness synonyms* (e.g.
+  WIP / Reviewed / Locked) — never a scope word (MVP) or a release-stage word (Beta / GA), which
+  are different axes. A **`Deprecated` doc is excluded from the check-in's doc-drift and
+  deferred-coverage sweeps** (`runbooks/check-in.md`): it is listed as retired for the record,
+  not reconciled against current code or backfilled.
+- **`Coverage:`** *(optional)* — how completely the doc describes its area. Omit it (or `full`)
+  when the doc fully covers the area; mark a deliberately fat or partial area `deferred` (or
+  `enumerated to depth N`) so the gap is recorded rather than mistaken for drift. Every check-in
+  resurfaces a `Coverage: deferred` doc for an explicit disposition (`runbooks/check-in.md`).
 - A **Version Log** table at the bottom: one row per change (version, date, STEP, what).
 
 ADRs are *not* versioned this way — they're dated, carry a Status (Accepted / Superseded /

--- a/Code/{{PROJECT}}-docs/architecture/README.md
+++ b/Code/{{PROJECT}}-docs/architecture/README.md
@@ -10,7 +10,7 @@ Most of these are produced by the **architecture sessions** during STEP-1
 
 ## Conventions
 - Filenames: `NN-kebab-title.md`, numbered in the order the sessions produce them.
-- Every doc carries: `Version` (major.minor.patch), `Status` (Draft → MVP → Stable),
+- Every doc carries: `Version` (major.minor.patch), `Status` (Draft → Current → Deprecated),
   `Last updated`, `Audience`, a **Decision Summary**, **Open Questions**, and a
   **Version Log**. Use `../templates/architecture-doc-template.md`.
 

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -36,8 +36,11 @@ it fixes docs, files bugs, and proves the tests pass.
 > contract drift. Fix anything it flags, then do the judgment-based review below (which a
 > script can't: does the doc still describe what the system actually *does*?).
 
-For each `architecture/NN-*.md`, compare the doc against the system as it actually is now —
-in both directions, because they catch different problems:
+For each **non-`Deprecated`** `architecture/NN-*.md`, compare the doc against the system as it
+actually is now — in both directions, because they catch different problems (a `Status:
+Deprecated` doc is **listed as retired** in the index reconciliation below, but **not** reconciled
+against current code or backfilled — it is kept for history, not swept as live;
+`METHOD.md` §6):
 
 - **Docs vs. code** — the doc claims something the code no longer does (stale doc).
   → **Fix the doc** and bump its Version Log (`METHOD.md` §6); if a real decision was made in

--- a/Code/{{PROJECT}}-docs/templates/architecture-doc-template.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-doc-template.md
@@ -1,7 +1,10 @@
 # Doc {{NN}} — {{TITLE}}
 
 **Version:** v0.1.0
-**Status:** Draft        <!-- Draft (v0.x) → MVP (v1.x) → Stable (v2.x); see METHOD.md §6 -->
+**Status:** Draft        <!-- Draft → Current → Deprecated; see METHOD.md §6 -->
+<!-- Optional — add a **Coverage:** line only for a deliberately fat or partial area:
+     omit (or `full`) = fully described; `deferred` / `enumerated to depth N` records a chunk
+     intentionally not yet enumerated (resurfaced at each check-in). See METHOD.md §6. -->
 **Last updated:** {{DATE}} ({{STEP}})
 **Audience:** {{who should read this}}
 


### PR DESCRIPTION
## What this does

Architecture docs carried three distinct concepts overloaded onto two header fields. This splits them into three independent facts and retires "MVP" as a doc-maturity label.

| Field | Now means |
|---|---|
| `Version:` | Identity number. `major` = a **breaking architectural change** (decoupled from maturity); a project may keep its own house version scheme (e.g. calendar or `v16`-style). |
| `Status:` | Maturity lifecycle, redefined **Draft → Current → Deprecated** in pure doc-trust terms — *"is this doc the current agreed truth?"*. Renamable only to settledness synonyms (WIP / Reviewed / Locked) — never a scope word (MVP) or a release-stage word (Beta/GA). |
| `Coverage:` | **New, optional** completeness note: omit/`full`, `deferred`, or `enumerated to depth N`. |

The periodic check-in's Part-1 doc-drift sweep now **skips `Status: Deprecated` docs** — they're listed as retired for the record, not reconciled against current code or backfilled.

## Files changed
- **`METHOD.md` §6** — the three-field definition; `major` reworded to a breaking change; the ladder redefined; the `Deprecated`-excluded-from-sweeps note.
- **`templates/architecture-doc-template.md`** — Status-comment ladder updated to `Draft → Current → Deprecated`; the optional `Coverage:` field documented (kept *off* the default header, so a stamped greenfield doc is unchanged); the four required header fields untouched.
- **`architecture/README.md`** — the conventions line's ladder updated.
- **`runbooks/check-in.md`** — Part-1 doc-drift sweep reconciles only non-`Deprecated` docs.

## Deliberately not changed
- **`scripts/check.sh`** — already value-agnostic (checks only the *presence* of `Version`/`Status`; never reads `Coverage`). Confirmed, no edit.
- The architecture-session templates' "start the Version Log at v0.1.0" instruction (greenfield-correct).

## Greenfield impact
Output is identical apart from **one deliberate, opt-outable default shift**: a doc maturing past `Draft` now defaults to `Current` instead of `MVP`.

## Acceptance
- `check.sh` green — 0 fails, 2 expected "not initialized" warnings, exit 0.
- Fixture architecture docs pass the frontmatter check with an arbitrary `Version: 16.2.0` + `Status: Current`, with `Status: Deprecated`, and with a settledness-synonym `Status: Reviewed` — none carrying a `Coverage:` line.
- Hub-wide `grep MVP`: no file defines a maturity rung as "MVP"; remaining hits are Phase-1-name / release-stage uses owned by later items.

---

First in a series generalizing the base method; **merges into `generalize-base-method`, not `main`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
