### PR TITLE
Record release/launch stage as a project fact, distinct from Phase-1 scope

### DIFF
--- a/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/BOOTSTRAP-PROMPT.md
@@ -84,6 +84,18 @@ Propose:
   `prompts/STEP-index.md` (replacing the `{{PHASE_1_NAME}}` placeholder `init.sh` left there),
   and its kebab-case form later names the `001-<phase-name>/` archive folder created when
   STEP-1 is archived (so a POC archives to `001-poc/`, a full v1 to `001-v1/`).
+- **The release stage** — a *separate axis* from the milestone above. How widely and to whom
+  this first release ships (pre-launch → internal alpha → closed/invite-only beta → public
+  beta → GA): an **engineering calibration input** — how much robustness and polish the
+  architecture owes its audience — **not** the marketing launch plan. Ask it leading with the
+  recommendation: *"Where does the first release land — internal/pre-launch, a closed beta, or
+  public?"* Most new builds genuinely **start pre-launch**, so recommend that as the default; a
+  closed beta or a public launch are also valid, so don't assume. Record the answer on the
+  optional **"Release stage / launch target"** line in `Code/{{PROJECT}}-docs/overview.md` (a
+  short prose descriptor — e.g. `internal alpha`, `closed beta — ~50 invited users`,
+  `public GA`). It stays **independent** of the Phase-1 scope name above and of any doc
+  `Status`; the architecture sessions calibrate their *breadth* defaults to it, while *rigor*
+  stays keyed to what's at stake (`METHOD.md` §4).
 - The **Phase plan** — what Phase 1 (your chosen first milestone) includes and, deliberately,
   excludes; a rough sketch of later phases for things being deferred. (This is a sketch to
   align on direction; the Phasing & Roadmap session formalizes the phase plan.)

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -284,8 +284,25 @@ interesting trade-off, not the basics.
 
 > *Observability (Session 1.10):*
 > - **L1:** "How will you *know* the app is healthy once people use it? The trap: it breaks, and the only signal is angry users — and even then you can't tell why. The fix is leaving yourself a trail of breadcrumbs to answer 'what happened?'. For v1 I'd suggest just good logs plus an alert if the site goes down. Enough to start?"
-> - **L2:** "Observability — how you'll see what the system is doing in production; the failure mode is 'users told us it broke and we can't tell why.' Logs (what happened), metrics (is it healthy), alerts (tell me when it's not). For an MVP I'd default to structured logs + an error/uptime alert and add dashboards later. Start there?"
-> - **L3:** "Observability — logs/metrics/traces and alerting. SLOs now or later? I'd default to structured logging + error tracking + an uptime alert for the MVP and defer tracing/SLOs unless you're latency-sensitive."
+> - **L2:** "Observability — how you'll see what the system is doing in production; the failure mode is 'users told us it broke and we can't tell why.' Logs (what happened), metrics (is it healthy), alerts (tell me when it's not). For a first release I'd default to structured logs + an error/uptime alert and add dashboards later. Start there?"
+> - **L3:** "Observability — logs/metrics/traces and alerting. SLOs now or later? I'd default to structured logging + error tracking + an uptime alert for a first release and defer tracing/SLOs unless you're latency-sensitive."
+
+### Calibrating defaults to the project's facts
+Experience level (above) changes *how* a session asks; the project's own recorded facts change
+*what* it recommends. A session's default is **never** keyed to an assumed "MVP" — it reads the
+facts the brief and earlier sessions captured, and it **splits breadth from rigor**:
+
+- **Breadth** — how big and how public the system is (a modular monolith vs. microservices, one
+  locale vs. many, the fewest environments that are safe) — tracks the **release stage and
+  load** (`overview.md`'s *Release stage / launch target* and *Scale & shape*). An earlier,
+  narrower launch justifies a simpler default here.
+- **Rigor** — security controls, privacy process, availability — tracks **what's at stake**: the
+  blast radius and data sensitivity (`overview.md`'s *Sensitive data & risk*). An early release
+  stage is **never** a license to lower rigor on a high-stakes system: a closed beta that handles
+  health data or payments still owes its users real protection.
+
+So "for a first release" is a *breadth* default, set by stage and load — not a reason to thin out
+rigor, which the session keys to blast radius instead.
 
 ## 5. The prompt lifecycle
 

--- a/Code/{{PROJECT}}-docs/ONBOARDING.md
+++ b/Code/{{PROJECT}}-docs/ONBOARDING.md
@@ -23,7 +23,7 @@ Some early projects are **mono-repo-for-now**:
 - There is one repo.
 - `AGENTS.md`, `CLAUDE.md`, and `doctor.sh` are committed in that repo.
 - `setup-workspace.sh` is not needed. Clone the repo, open it, and continue at
-  [Read the project state](#3-read-the-project-state).
+  [Read the project state](#4-read-the-project-state).
 
 ## 2. Set up a multi-repo workspace
 

--- a/Code/{{PROJECT}}-docs/registries/risks.yml
+++ b/Code/{{PROJECT}}-docs/registries/risks.yml
@@ -50,7 +50,7 @@ risks: []
 #     source: "architecture/06-security-threat-model.md"
 #     description: "Public endpoints launch without per-user rate limiting; details live in refs."
 #     impact: "Possible availability degradation from noisy clients or automated attacks."
-#     mitigation: "Framework-level request limits plus uptime alerting for MVP."
+#     mitigation: "Framework-level request limits plus uptime alerting for the initial launch."
 #     revisit_trigger: "Before public beta or before accepting untrusted user traffic."
 #     refs:
 #       - "architecture/06-security-threat-model.md#threats--mitigations"

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
@@ -30,8 +30,8 @@ UI / Design System session and the conditional Native-app session apply.
 
 ## How this session works
 - One decision at a time; sketch a simple diagram when it clarifies; **wait** for answers.
-- Recommend a default (for most MVPs: a **modular monolith**, not microservices) and say
-  what it forecloses.
+- Recommend a default (for most first releases: a **modular monolith**, not microservices) and
+  say what it forecloses.
 - Keep it high-level — responsibilities and boundaries, not class-level detail.
 
 ## Decisions to make (in order)

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
@@ -30,8 +30,8 @@ now prevents painful migrations and compliance surprises later.
 
 ## How this session works
 - One decision at a time; sketch the entities and relationships; **wait** for answers.
-- Recommend sensible defaults (e.g. surrogate UUID keys, a single relational DB for an
-  MVP) and flag what they foreclose.
+- Recommend sensible defaults (e.g. surrogate UUID keys, a single relational DB for a first
+  release) and flag what they foreclose.
 - Watch for hidden PII — push on anything that touches personal data.
 
 ## Decisions to make (in order)
@@ -41,8 +41,8 @@ now prevents painful migrations and compliance surprises later.
 2. **Ownership / source of truth.** For each entity, which component owns it (is the
    authoritative source). Critical once more than one component reads/writes it.
 3. **Storage choice(s).** Relational vs. document vs. key-value vs. blob — and whether it's
-   one shared database or one per component. Default: one relational DB for an MVP unless
-   there's a reason. Flag lock-in / scaling implications for the Scaling & Performance
+   one shared database or one per component. Default: one relational DB for a first release
+   unless there's a reason. Flag lock-in / scaling implications for the Scaling & Performance
    session.
 4. **Identifiers.** Surrogate keys (UUID/auto-increment) vs. natural keys; ID format and
    whether IDs are exposed publicly.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
@@ -26,16 +26,16 @@ bottleneck/scaling decisions, caching and async plans, load-test inputs, and don
 mitigations.
 
 ## Why this session matters
-The goal here is **not** to build for scale you don't have — it's to make sure the MVP,
-built for a handful of users, doesn't quietly *block* the scale you'll want later. The
+The goal here is **not** to build for scale you don't have — it's to make sure a first release,
+sized for your launch-stage load, doesn't quietly *block* the scale you'll want later. The
 classic trap: a shortcut that's invisible at 5 users (in-memory state, one big sync
 request, a single database doing everything) and a rewrite at 5,000. We decide which
 shortcuts are fine and which to avoid cheaply now.
 
 ## How this session works
 - One decision at a time; **wait** for answers.
-- For each decision, recommend the **simplest thing that works for the MVP**, then state
-  explicitly whether it forecloses future scaling and the cheapest way to avoid that.
+- For each decision, recommend the **simplest thing that works for your launch-stage load**,
+  then state explicitly whether it forecloses future scaling and the cheapest way to avoid that.
 - Use real numbers from the user, not guesses.
 
 ## Decisions to make (in order)
@@ -48,7 +48,7 @@ shortcuts are fine and which to avoid cheaply now.
 4. **First bottleneck.** Under growth, what breaks first — the database, a single process,
    a third-party rate limit? Be specific; it's where future effort goes.
 5. **Scaling strategy.** Vertical (bigger box) vs. horizontal (more boxes); what can scale
-   independently. For an MVP, vertical is often fine — *if* the design stays
+   independently. At your launch-stage load, vertical is often fine — *if* the design stays
    horizontally-scalable when needed.
 6. **Caching & async.** Where caching helps (and how it's invalidated); what heavy work
    can move to a queue/background job instead of blocking a request.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
@@ -27,15 +27,15 @@ mitigations.
 
 ## Why this session matters
 The goal here is **not** to build for scale you don't have — it's to make sure a first release,
-sized for your launch-stage load, doesn't quietly *block* the scale you'll want later. The
+sized for the load it actually has, doesn't quietly *block* the scale you'll want later. The
 classic trap: a shortcut that's invisible at 5 users (in-memory state, one big sync
 request, a single database doing everything) and a rewrite at 5,000. We decide which
 shortcuts are fine and which to avoid cheaply now.
 
 ## How this session works
 - One decision at a time; **wait** for answers.
-- For each decision, recommend the **simplest thing that works for your launch-stage load**,
-  then state explicitly whether it forecloses future scaling and the cheapest way to avoid that.
+- For each decision, recommend the **simplest thing that works for a first release**, then state
+  explicitly whether it forecloses future scaling and the cheapest way to avoid that.
 - Use real numbers from the user, not guesses.
 
 ## Decisions to make (in order)
@@ -48,7 +48,7 @@ shortcuts are fine and which to avoid cheaply now.
 4. **First bottleneck.** Under growth, what breaks first — the database, a single process,
    a third-party rate limit? Be specific; it's where future effort goes.
 5. **Scaling strategy.** Vertical (bigger box) vs. horizontal (more boxes); what can scale
-   independently. At your launch-stage load, vertical is often fine — *if* the design stays
+   independently. For a first release, vertical is often fine — *if* the design stays
    horizontally-scalable when needed.
 6. **Caching & async.** Where caching helps (and how it's invalidated); what heavy work
    can move to a queue/background job instead of blocking a request.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
@@ -26,14 +26,15 @@ dependency-risk posture, and web-risk posture.
 ## Why this session matters
 "We're too small to be a target" is the most common — and most wrong — security
 assumption. Anything on the public internet gets probed automatically; attackers don't
-check your user count first. You don't need a fortress for an MVP, but you do need to know
-your **assets, your boundaries, and the threats you're choosing to accept**. This session
+check your user count first. You don't need a fortress for a *low* blast radius, but you do for
+a high one — either way, know your **assets, your boundaries, and the threats you're choosing to
+accept**. This session
 can end in a *deliberate, recorded* deferral — but deferral must be a decision, not an
 oversight.
 
 ## How this session works
 - One decision at a time; **wait** for answers.
-- For each threat, recommend a **minimum viable mitigation** for the MVP and note the
+- For each threat, recommend a **mitigation matched to its blast radius** and note that
   **blast radius** if it's skipped.
 - Keep it concrete to *this* system — use the assets and boundaries from the
   Architecture Overview architecture doc and the Data Model architecture doc.
@@ -68,7 +69,7 @@ oversight.
    dependency vulnerabilities. What's handled by the framework vs. needs attention? (The
    dependency/supply-chain posture you set here is operationalized in
    `runbooks/dependency-supply-chain.md` — vetting new deps and auditing them on a cadence.)
-7. **Mitigate now vs. defer.** For each significant threat: mitigate in the MVP, or defer?
+7. **Mitigate now vs. defer.** For each significant threat: mitigate now, or defer?
    For every deferral, record the blast radius and **what triggers revisiting** (e.g.
    "before we accept real user data / payments / go public"). Add each accepted deferral to
    `registries/risks.yml`, or update the existing row if this session revisits it.
@@ -81,7 +82,7 @@ Write `architecture/06-security-threat-model.md` — the Security & Threat Model
 doc (use `templates/architecture-doc-template.md`). Body:
 - **Assets**
 - **Trust boundaries** (diagram or list)
-- **Threats → mitigations** table — threat | boundary | MVP mitigation | deferred / blast radius
+- **Threats → mitigations** table — threat | boundary | mitigation | deferred / blast radius
 - **AuthN/AuthZ posture**, **secrets & data protection**, **web-risk posture**
 
 Fill the **Decision Summary**, record **Open Questions**, start the **Version Log**. Capture

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
@@ -99,7 +99,7 @@ patterns branch from there.
     right-to-left support. *Localization (l10n)* is **which languages/locales you actually
     ship** now. The trap is foreclosure: shipping English-only is fine, but *hardcoding*
     English everywhere is the expensive mistake — retrofitting i18n later means touching every
-    screen. MVP default: ship one locale, but route user-facing text through a strings layer
+    screen. First-release default: ship one locale, but route user-facing text through a strings layer
     from day one so adding a language later is a translation job, not a rewrite. Decide RTL
     in or out deliberately.
 13. **Motion & transitions**; **data visualization** (if charts).

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
@@ -39,7 +39,7 @@ how a small outage becomes permanent data loss.
 ## How this session works
 - One decision at a time; **wait** for answers.
 - Recommend the **lowest-operational-burden option that fits** (often a managed PaaS or
-  containers on a managed platform for an MVP), and flag cost and lock-in tradeoffs.
+  containers on a managed platform for a first release), and flag cost and lock-in tradeoffs.
 - Tie back to the Scaling & Performance and Security & Threat Model architecture docs where relevant.
 
 ## Decisions to make (in order)
@@ -49,8 +49,8 @@ how a small outage becomes permanent data loss.
    functions vs. managed app platform vs. plain VMs. Default to the simplest that meets the
    scaling needs from the Scaling & Performance architecture doc.
 3. **Build & deploy pipeline.** How code becomes a running version: CI builds, artifacts,
-   and how a deploy is triggered (and rolled back). Manual is OK for an MVP if it's written
-   down and repeatable — the optional `runbooks/release-deploy.md` checklist is where that
+   and how a deploy is triggered (and rolled back). Manual is OK for a first release if it's
+   written down and repeatable — the optional `runbooks/release-deploy.md` checklist is where that
    procedure lives operationally; this decision designs what it executes.
 4. **Infrastructure as code.** Terraform / Pulumi / provider tooling / none. How infra is
    provisioned reproducibly — even a single script beats clicking in a console.
@@ -63,8 +63,9 @@ how a small outage becomes permanent data loss.
    database, a third-party API). Name the **single points of failure** (this is the
    *availability* angle; the Scaling & Performance architecture doc named them for *load*) and pick an
    **availability target**: is a
-   few hours of downtime fine, or must this stay up? For an MVP, a single region with a fast
-   redeploy is often the right call — the point is to choose it knowingly, not by default.
+   few hours of downtime fine, or must this stay up? For a modest availability target, a single
+   region with a fast redeploy is often the right call — the point is to choose it knowingly, not
+   by default.
    Where it's cheap, prefer **graceful degradation** (read-only mode, a cached response, a
    clear "try again shortly") over a hard crash when a dependency is unavailable.
 8. **Backups & disaster recovery.** What's backed up, how often, and how long backups are

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
@@ -29,15 +29,15 @@ code is promoted** gives you a safe path to production.
 
 ## How this session works
 - One decision at a time; **wait** for answers.
-- Recommend the **fewest environments that give you safety** for the MVP (often local +
+- Recommend the **fewest environments that give you safety** for your launch stage (often local +
   one staging + prod), and flag what each adds in cost/maintenance.
 
 ## Decisions to make (in order)
 1. **Which environments.** Local/dev, CI (for automated tests), staging/pre-prod,
-   production. Which do you actually need for the MVP, and what is each *for*?
+   production. Which do you actually need for your launch stage, and what is each *for*?
 2. **Sandbox / demo environment?** Do you need a separate sandbox — for trying the product
    without real data, for demos, or for external integrators to test against? (Often *not*
-   needed at MVP; decide consciously.)
+   needed at a first release; decide consciously.)
 3. **Config & secrets per environment.** How configuration differs per environment
    (environment variables / config files — never secrets in code) and where each environment's
    secrets come from

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
@@ -29,12 +29,12 @@ code is promoted** gives you a safe path to production.
 
 ## How this session works
 - One decision at a time; **wait** for answers.
-- Recommend the **fewest environments that give you safety** for your launch stage (often local +
+- Recommend the **fewest environments that give you safety** for a first release (often local +
   one staging + prod), and flag what each adds in cost/maintenance.
 
 ## Decisions to make (in order)
 1. **Which environments.** Local/dev, CI (for automated tests), staging/pre-prod,
-   production. Which do you actually need for your launch stage, and what is each *for*?
+   production. Which do you actually need for a first release, and what is each *for*?
 2. **Sandbox / demo environment?** Do you need a separate sandbox — for trying the product
    without real data, for demos, or for external integrators to test against? (Often *not*
    needed at a first release; decide consciously.)

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
@@ -32,7 +32,7 @@ to measure, and what to alert on** now means you can actually operate the thing.
 
 ## How this session works
 - One decision at a time; **wait** for answers.
-- Recommend a **lightweight default** for the MVP (structured logs + a few key metrics +
+- Recommend a **lightweight default** for a first release (structured logs + a few key metrics +
   health checks + error tracking) and scale up only where the system warrants it.
 - Be explicit about what must **not** be logged (secrets, PII).
 

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
@@ -47,7 +47,8 @@ Threat Model session.
 
 ## Decisions to make (in order)
 1. **Authentication methods.** Password, OAuth/social, SSO/SAML/OIDC, passwordless/magic
-   link, MFA. Which for the MVP, which later.
+   link, MFA. Which now, which later — keyed to what you're protecting (the threats and data
+   sensitivity), not the launch stage.
 2. **Identity provider — build vs. buy.** Managed (Auth0, Cognito, Clerk, Firebase,
    Keycloak self-host) vs. roll-your-own. Default: **buy**, unless there's a strong reason.
    Record the decision (an ADR).

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
@@ -48,7 +48,7 @@ Threat Model session.
 ## Decisions to make (in order)
 1. **Authentication methods.** Password, OAuth/social, SSO/SAML/OIDC, passwordless/magic
    link, MFA. Which now, which later — keyed to what you're protecting (the threats and data
-   sensitivity), not the launch stage.
+   sensitivity), not the release stage.
 2. **Identity provider — build vs. buy.** Managed (Auth0, Cognito, Clerk, Firebase,
    Keycloak self-host) vs. roll-your-own. Default: **buy**, unless there's a strong reason.
    Record the decision (an ADR).

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
@@ -75,7 +75,7 @@ deletion/export requests **now** keeps compliance a design property rather than 
    This sharpens the retention answer from the Data Model architecture doc with the legal *must-delete* angle.
 6. **Data-subject rights.** How you'll satisfy access, export/portability, correction, and
    deletion ("right to be forgotten") requests — as an *operational process*, not a promise.
-   Manual is fine for an MVP **if it's written down** and someone owns it.
+   Manual is fine at low volume and low sensitivity **if it's written down** and someone owns it.
 7. **Data residency & sub-processors.** Where data physically lives (residency/sovereignty
    constraints) and which third parties (analytics, hosting, payment, email, AI APIs) receive
    personal data — your sub-processors — plus a transfer mechanism if data crosses borders.
@@ -83,7 +83,7 @@ deletion/export requests **now** keeps compliance a design property rather than 
 8. **Governance & accountability.** Who owns privacy, where the record-of-processing / data
    map lives and stays current, your **breach-notification** obligations (who you must notify
    and how fast), and the plan for a public **privacy policy** (and a DPA where required).
-   Lightweight for an MVP — but assigned to a name, not left ownerless.
+   Lightweight at low volume and low sensitivity — but assigned to a name, not left ownerless.
 
 ## Output
 Write `architecture/NN-privacy-compliance.md` (use `templates/architecture-doc-template.md`; NN per

--- a/Code/{{PROJECT}}-docs/templates/overview-template.md
+++ b/Code/{{PROJECT}}-docs/templates/overview-template.md
@@ -39,6 +39,14 @@
 <!-- Roughly how many users / requests / records at launch? In a year? Is it a web app,
      a mobile/desktop app, an API/service, a CLI, or several? Who hosts it? -->
 
+## Release stage / launch target
+<!-- Optional. How widely and to whom this first release ships — pre-launch / internal
+     alpha / closed (invite-only) beta / public beta / GA. An engineering calibration input
+     (how much robustness and polish the architecture owes its audience), not a marketing
+     plan, and distinct from the Phase-1 milestone's scope name. A short prose descriptor:
+     e.g. "internal alpha", "closed beta — ~50 invited users", "public GA". Leave blank if
+     you're unsure — most new builds start pre-launch. -->
+
 ## Constraints & must-haves
 <!-- Regulatory or compliance needs, budget, timeline, team size & skills, languages or
      platforms you're committed to, systems you must integrate with or can't change. -->

--- a/Code/{{PROJECT}}-docs/templates/phase-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/phase-readme-template.md
@@ -9,6 +9,6 @@ here. STEP numbers are global (they don't reset per phase).
 
 | STEP | Title | Substeps | Archived |
 |------|-------|----------|----------|
-| [STEP-1](step-0001/) | Architecture | 13 | {{DATE}} |
+| [STEP-1](step-0001/) | Architecture | 14 | {{DATE}} |
 
 <!-- Add a row when a STEP's folder is moved into this phase on completion. -->


### PR DESCRIPTION
Gives the method a first-class, **recorded** notion of *release / launch stage* — how widely and to whom the system ships (pre-launch → internal → closed / public beta → GA) — as a third axis kept distinct from Phase-1 **scope** (MVP / POC / v1) and doc **maturity** (Draft / Current / Deprecated). Previously this axis was proxied by "MVP" scattered through the architecture-session bodies, which reads wrong for any build whose first release isn't an early-and-small MVP, and is actively wrong for a mature, already-shipped system.

Part of the Group A base refactors (generalizing the method ahead of the retcon adoption path).

## Record the fact
- `templates/overview-template.md` gains an optional **Release stage / launch target** line near *Scale & shape*; `check.sh` never reads it.
- `BOOTSTRAP-PROMPT.md` Stage 1 asks it, leading with a pre-launch default — the same recommend-a-default, one-question shape as the phase-name question.

## Calibrate sessions to it
- `METHOD.md` §4 gains a note splitting **breadth** (how big / how public → the recorded stage + load) from **rigor** (security, privacy, availability → blast radius / data sensitivity). An early stage is never a license to lower rigor on a high-stakes system. The §4 Observability worked examples are reworded off "MVP."
- Sessions `03`, `04`, `05`, `07`, `08`, `09`, `10` reword their breadth defaults to the recorded stage + load; rigor sessions `06` and `conditional-privacy-compliance` rekey onto blast radius / data volume + sensitivity; `conditional-identity-auth` keys onto what's being protected; `registries/risks.yml`'s example row drops "for MVP."

## Notes
- Additive and opt-outable: same recommendations if the user takes the default, and the three axes stay independent. **No `status.sh` / `check.sh` / STEP-grammar change.**
- `check.sh` is green (0 fails); a `grep MVP` over `templates/architecture-sessions/` now returns only the Phase-1-name uses in `02` and `14`.
- Also folds in two small deferred doc fixes queued to land with the next change: `ONBOARDING.md` (mono-repo anchor `#3` → `#4`) and `templates/phase-readme-template.md` (STEP-1 substep count `13` → `14`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
