### PR TITLE
Make the planning STEP-shape milestone-relative, not build-from-scratch

### DIFF
--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -67,8 +67,8 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    you scaffolded in an earlier run is already registered) or when the project already has some of
    these repos; if `registries/repos.yml` is absent or has no code-repo rows yet (that first run,
    or a mono-repo), nothing is registered and every named repo scaffolds, exactly as before.
-   The first implementation STEP is almost always *"scaffold the repos and the skeleton"* —
-   create each new code repo from
+   When repos still need creating — a first run, the usual case — the first implementation
+   STEP is almost always *"scaffold the repos and the skeleton"*: create each new code repo from
    `templates/repo-readme-template.md`, wire up the chosen stack, CI, and the environment/secrets
    baseline from the Environments architecture doc, plus any interface contract artifact placeholders or repo-local contract files
    named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each repo as its
@@ -92,8 +92,10 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    explain itself. Confirm the repo list with the user — on a first run they're all new; note any
    that already exist (already registered with a filled-in README) so you scaffold only the new
    ones.
-2. **The implementation STEP sequence.** Propose all the Phase-1 STEPs in dependency order.
-   A typical shape:
+2. **The implementation STEP sequence.** Propose all the Phase-1 STEPs in dependency order —
+   **build or extend what this milestone needs, given what already exists.** On a first run
+   nothing is built yet, so scaffolding and the core data layer come first and you build
+   outward from there; that's the usual case, and the typical shape is:
    - **Scaffold** — repos, skeleton, CI, local run + the env/secrets baseline.
    - **Core data layer** — the data model from `architecture/*-data-model.md` made real (schema,
      migrations, access layer).
@@ -101,8 +103,10 @@ STEP's PLAN with its owner rather than silently replacing its index row.
      against the data layer and component boundaries.
    - **Integration / end-to-end** — wire the capabilities together; the launch-criteria
      path from the phase plan works end to end.
-   Adjust to the actual project. Each STEP gets a global STEP number (continuing from
-   STEP-1).
+   On a **re-run**, or a later phase whose scaffold and core data layer already exist, start
+   from what's built and plan the STEPs that **extend** it, rather than re-scaffolding or
+   rebuilding what's already there. Adjust to the actual project. Each STEP gets a
+   global STEP number (continuing from STEP-1).
 3. **Interleave check-in STEPs.** Roughly **every 10–20 STEPs**, add a **Check-in STEP**
    that runs `runbooks/check-in.md` (doc-drift reconciliation, conditional-session coverage,
    accepted-risk review, and a full test run). Place each at a sensible breakpoint — after a


### PR DESCRIPTION
## What

The implementation planning session (`templates/planning-session.md`) handed the agent a **build-from-scratch STEP shape** — scaffold → core data layer → one STEP per capability → integration, with the first implementation STEP "almost always scaffold" — written as if nothing exists yet.

The session is **re-runnable** (once per phase). On a re-run, or when planning a later phase, the scaffold and core data layer already exist, so that shape reads as *rebuild-from-scratch*. This makes the STEP shape **milestone-relative**: plan to *build or extend what this milestone needs, in dependency order, given what already exists.*

## Changes

`templates/planning-session.md`, two spots:

- **Work-item 2 (the STEP sequence):** now leads with the general "build or extend what this milestone needs" principle. The four-bullet scaffold → data → capabilities → integration sequence is kept **verbatim** as the worked example for a first run (nothing built yet); a re-run or later phase "starts from what's built and plans the STEPs that **extend** it — skip the early scaffold/data-layer STEPs and lead with the new capabilities."
- **Work-item 1 (the "first STEP is scaffold" line):** conditioned on "when repos still need creating — a first run."

## Why this is a base fix, not a retcon favor

Like #89 (A5), it keys on **observable state** (what's already built / registered), never on "was this a retcon." The build-from-scratch shape was already subtly wrong for greenfield's own re-runs and Phase-2+ planning; retcon then falls out as the extreme end of the same logic, with no retcon-gated recipe. Written greenfield-first, in A5's vocabulary — "first run", "re-run", "a later phase" — with no "adopted"/"retcon" leaking into the distributed template.

## Greenfield impact

None on a first run: nothing is built → the shape is exactly scaffold → data → capabilities → integration, a byte-identical outline. A small improvement on re-runs / later phases (won't read as rebuild-from-scratch).

## Acceptance

- `scripts/check.sh` green (0 fail, 2 expected "not initialized" warnings).
- A greenfield **first-run** planning session produces the same scaffold-first outline as before.
- A **re-run** / Phase-2 plan over an existing repo + data layer plans *extension* work rather than re-scaffolding or rebuilding.
- No `status.sh` / `check.sh` / STEP-grammar change; no retcon-specific logic introduced.
- Leaves work-item 2's `Phase-1` references untouched for A7.

---

Second of the planning-session generalization trio (A5 → **A6** → A7), per `.dev/retcon-prep-refactors.md` §A6. Merges into `generalize-base-method`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
