### PR TITLE
Document registering a repo in place by a location outside Code/*

### DIFF
--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -448,6 +448,20 @@ this method do contain the Throughstone-authored README and CI starter, so
 `scripts/apply-project-license.sh` copies `LICENSE-THROUGHSTONE` and writes a visible
 `LICENSING.md` that distinguishes retained scaffold material from project-authored code.
 
+**Where a repo lives — created as a sibling, or registered in place.** By default a repo is
+**created as a `Code/*` sibling** under the workspace root, and its `registries/repos.yml`
+`location:` is that workspace-relative sibling path — the layout `init.sh` and the scaffolding
+above assume. A repo may instead be **registered in place by its `location:`** — a path
+*outside* the `Code/*` shell (an absolute path, or any other arbitrary path) — in addition to that
+created-as-sibling default, so a repo that lives elsewhere is referenced where it sits rather than
+created under `Code/`. `location:` records wherever the repo actually is; the optional `remote:` is
+unchanged (a cloneable URL when the repo has one).
+`scripts/setup-workspace.sh` honors `location:` verbatim either way — it clones from `remote:`
+into that path when a remote is set, and otherwise leaves the repo referenced where it sits.
+Branch-per-STEP and the overlap warning (`runbooks/collaboration.md`) key on repo
+**identity** — its `repos.yml` entry, not where it lives — so an in-place repo participates in
+them exactly like a sibling. The `Code/*` sibling layout stays the default.
+
 **All durable content lives in a repo** — almost always `Code/{{PROJECT}}-docs/`. The
 workspace root holds only **per-machine** files: the pointer `CLAUDE.md` / `AGENTS.md`
 (which redirect to the canonical `Code/{{PROJECT}}-docs/AGENTS.md`) and `.claude/` config.

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -6,6 +6,13 @@
 # architecture docs before a design change. Update this whenever a repo is created. Tooling/CI
 # can read it to stay in sync. See METHOD.md §7.
 #
+# `location:` is where the repo lives — by default a `Code/*` sibling under the workspace root,
+# written workspace-root-relative (e.g. Code/{{PROJECT}}-api/). It MAY instead point OUTSIDE the
+# `Code/*` shell — an absolute path or any other arbitrary path — for a repo referenced in place
+# where it lives, rather than created as a sibling. setup-workspace.sh uses `location`
+# verbatim (clones from `remote` into it, or references it in place when there's no remote), so
+# keep `location` and `remote` distinct: a clone URL goes in `remote`, never folded into `location`.
+#
 # Mono-repo-for-now: the entries below are folders inside the single repo, not separate repos
 # yet — this inventory describes the post-split (multi-repo) target.
 #


### PR DESCRIPTION
## What

Documents that a code repo may be registered **in place** by a `registries/repos.yml` `location:`
that points **outside the `Code/*` sibling shell** — an absolute or otherwise arbitrary path — in
addition to the created-as-sibling default. A repo that lives elsewhere is referenced where it sits
rather than created under `Code/`.

## Why this is documentation-only

`scripts/setup-workspace.sh` already honors `location:` verbatim: for each repo it clones from
`remote:` into that path when a remote is present, and otherwise leaves the repo referenced where it
sits. An out-of-`Code/*` `location:` therefore already flows through unchanged — so this adds no
tooling. It states the supported layout in `METHOD.md` §7 and the `repos.yml` header convention, and
clarifies that `location:` and `remote:` stay distinct (a clone URL belongs in `remote:`, never
folded into `location:`).

## Invariants

- The `Code/*` sibling layout stays the **default**; a default (new-project) workspace is
  byte-unchanged.
- Branch-per-STEP and the overlap warning key on repo **identity**, not location, so an in-place repo
  participates unchanged.

## Verification

- `scripts/check.sh` stays green (0 fail / 2 expected "not initialized" warnings).
- Behavioral: a fixture `repos.yml` with a `location:` outside `Code/*` — one row with a `remote:`,
  one without — run through `setup-workspace.sh` confirms the out-of-`Code/*` path is used verbatim
  (cloned from the remote when present; referenced in place and left untouched when not), while the
  `Code/*` sibling default still clones as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
