### PR TITLE
Graduate the method to 1.0 and finalize the 1.7 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,6 +373,7 @@ software **architecture-first** with an AI coding agent.
   mono-repo-for-now layouts; license selection and stamping.
 - **Brand assets** and the throughstone.org documentation site.
 
+[1.7.0]: https://github.com/mherschberg/Throughstone/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/mherschberg/Throughstone/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/mherschberg/Throughstone/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/mherschberg/Throughstone/compare/v1.3.0...v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ phases, re-runs, custom conventions, and existing codebases. **Two opt-outable d
   can add to it, and the implementation planning session and substep template point at it too.
 
 ### Changed
+- **Method version → 1.0** (from `0.4 (beta)`): with the base-refactor generalizations in this
+  release, the core method graduates from beta; the collaboration and scaffold-update layers keep
+  maturing.
 - **Architecture-doc metadata decoupled** into three independent header facts: **`Version`**
   (identity; `major` = a breaking architectural change, no longer a maturity "era", so a house
   version scheme is fine), **`Status`** (maturity), and optional **`Coverage`** (completeness).

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -1,6 +1,6 @@
 # The Method
 
-**Method version: 0.4 (beta)** — still early; expect refinement, especially the collaboration and scaffold-update layers.
+**Method version: 1.0** — the core method is stable; expect continued refinement, especially in the collaboration and scaffold-update layers.
 
 > Built with **Throughstone** — this file and the other scaffold files (`templates/`,
 > `runbooks/`, `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause; the full text is

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -77,6 +77,19 @@ not fail the check.
 
 ### 1.7 migration
 
+**Upgrading from 1.6? Start here.** This release rewrites no project files. Only two defaults
+shift, and only once you pull the new tooling/templates: the doc-maturity ladder and the check-in
+cadence. Fast path:
+
+1. Pull the process docs + tooling as one review-required group (`METHOD.md`,
+   `runbooks/check-in.md`, `templates/planning-session.md`, `scripts/status.sh`, `scripts/check.sh`).
+2. Want the old check-in window (DUE 10 / OVERDUE 20)? Add `<!-- CHECK-IN-CADENCE: 15 -->` to
+   `overview.md`; otherwise omit it to take the new default of 20 (DUE 15 / OVERDUE 25).
+3. Optionally reinterpret old `Status: MVP` / `Status: Stable` architecture docs as
+   `Status: Current` (no forced change; `check.sh` keeps passing either way).
+4. Create `inputs/` and copy its `README.md` if you want the bring-your-own-docs drop point.
+5. Everything else is future-only or purely behavioral — the per-area detail below covers each.
+
 The **1.7 base refactors** generalize the method — flexible Phase-1 naming, decoupled
 doc metadata, a deferred-coverage check-in sweep, a recorded release stage, and existence-aware
 repo scaffolding — so it also fits later phases, re-runs, custom conventions, and existing


### PR DESCRIPTION
Branched off `generalize-base-method` (the 1.7 release branch), so this PR isolates just the three commits below. **Merge target is `generalize-base-method`, not `main`.**

## What's here
- **Graduate the method to version 1.0** — `METHOD.md` `0.4 (beta)` → `1.0`, with a matching first "Changed" entry in the 1.7.0 changelog (mirrors how 1.6.0 recorded its bump).
- **Add the 1.7.0 compare link** — the changelog footer link every prior version had (resolves once `v1.7.0` is tagged).
- **Lead the 1.7 upgrade notes with a quick checklist** — a "start here" fast path atop the migration section; the per-area detail stays underneath, unchanged.

## Deliberately not included
- **README + website** — still propose-only per our discussion; happy to add them as more commits here if you want.
- **The changelog date** — still `Unreleased`; stamp it at `v1.7.0` tag time.

## Worth a look on review
Going `0.4 (beta)` → `1.0` meant rewriting the caveat, not just bumping the number. Current wording: *"the core method is stable; expect continued refinement, especially in the collaboration and scaffold-update layers."* Reword to taste.

## Verification
`tests/links.sh` passes; the changes are docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
