### PR TITLE
Update README and website copy for the 1.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ your-project/                    ← workspace shell (per-machine, not a repo)
         ├── METHOD.md            ← the methodology — read this
         ├── BOOTSTRAP-PROMPT.md  ← the kickoff prompt
         ├── overview.md          ← your project brief (you create this)
+        ├── inputs/              ← documents you provide (specs, designs, research) — sessions read these
         ├── templates/           ← architecture docs, sessions, ADRs, STEP plans, READMEs
         ├── architecture/  adr/  coding-standards/  registries/  runbooks/
         └── scripts/             ← setup-workspace.sh (onboard a new developer's machine)
@@ -367,6 +368,9 @@ snippets. In short, Throughstone creates a project documentation hub under
 `Code/{{PROJECT}}-docs/` and a sibling `prompts/` history repo. The core files include:
 
 - `overview.md` — the project brief.
+- `inputs/` — a drop point for documents you already have (product specs, prior
+  architecture/design docs, UI mockups, research); the kickoff and architecture sessions read
+  and build on them.
 - `METHOD.md` and `AGENTS.md` — the process and agent instructions.
 - `prompts/STEP-index.md` — the roadmap of planned work.
 - `architecture/` — living architecture documents.
@@ -429,13 +433,18 @@ docs, ADRs, scoped STEPs, tests, and a roadmap instead of a mystery pile of gene
 
 ### Can I use this with an existing project?
 
-In theory it could work, but Throughstone was not designed or tested for that yet. We plan to
-add better support for existing projects in the future.
+Increasingly, yes. Throughstone began greenfield-first, and the 1.7 release removed the
+assumptions that got in the way of existing code: planning now scaffolds only repos that
+aren't already registered, plans against what's already built instead of rebuilding from
+scratch, targets the first unfinished phase rather than always Phase 1, and can register a
+repo that already lives outside the workspace. You can also drop your current design docs into
+`inputs/` and have the architecture sessions build on them.
 
-In the meantime, you could try creating the documentation and following the STEP process
-manually. If you do, first make sure your code is saved in a git repo so you can revert
-changes. Second, tell the LLM that you want to use Throughstone on an existing project and
-that it should take the process step by step manually, without deleting existing code.
+It is not yet a one-click import — there's no wizard that ingests an existing codebase for you.
+The practical path: run setup, create architecture docs and a roadmap for what you already have
+(leaning on `inputs/`), then adopt the STEP process going forward. Keep your code in git so
+changes are reversible, and tell the agent it's working on an existing project and must not
+delete or rewrite existing code without review.
 
 ### Can I change decisions later?
 

--- a/brand/site/index.html
+++ b/brand/site/index.html
@@ -233,7 +233,7 @@
     </div>
     <div class="flow">
       <div class="flow-step"><div class="num">01</div><h3>Initialize</h3><p>Run the setup wizard once. It stamps the project name, license posture, repo layout, docs hub, prompts repo, and agent pointers.</p></div>
-      <div class="flow-step"><div class="num">02</div><h3>Kick off</h3><p>Tell the agent to read AGENTS.md. It interviews you, records the project brief, and prepares STEP-1 for architecture.</p></div>
+      <div class="flow-step"><div class="num">02</div><h3>Kick off</h3><p>Tell the agent to read AGENTS.md. It interviews you, records the project brief, and prepares STEP-1 for architecture. Bring existing specs, designs, or research and it builds on them.</p></div>
       <div class="flow-step"><div class="num">03</div><h3>Design first</h3><p>Architecture sessions capture scope, data, security, interfaces, testing, deployment, ADRs, and the cross-cutting review before app code starts.</p></div>
       <div class="flow-step"><div class="num">04</div><h3>Build in STEPs</h3><p>The planning session turns the locked architecture into implementation STEPs, each with substep prompts, verification, review, and archival.</p></div>
     </div>
@@ -350,7 +350,7 @@
       <p>The scaffold includes runbooks and registers for the maintenance work that often gets skipped until production exposes it.</p>
     </div>
     <div class="ops-grid">
-      <div class="op-card"><h3>Check-ins</h3><p>Every 10-20 STEPs, reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
+      <div class="op-card"><h3>Check-ins</h3><p>On a cadence you set (about every 20 STEPs), reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
       <div class="op-card"><h3>Release and rollback</h3><p>Prepare the rollback path before deploy, verify during a watch window, and make the return lever explicit.</p></div>
       <div class="op-card"><h3>Incidents</h3><p>Stabilize first, then run root-cause analysis, search for similar bugs, fix, harden, and write the postmortem.</p></div>
       <div class="op-card"><h3>Dependencies</h3><p>Vet packages before adding them and audit installed dependencies for vulnerabilities, licenses, and provenance.</p></div>
@@ -381,7 +381,7 @@
       <p>Throughstone is intentionally more structured than a blank chat. That is the point, and also the tradeoff.</p>
     </div>
     <div class="fit-grid">
-      <div class="fit-card"><h3>Good fit</h3><p>Products, internal tools, serious open-source projects, and AI-assisted builds where architecture, scaling, tests, security, future changes, or team handoff matter.</p></div>
+      <div class="fit-card"><h3>Good fit</h3><p>New projects or existing codebases you're bringing under control: products, internal tools, serious open-source projects, and AI-assisted builds where architecture, scaling, tests, security, future changes, or team handoff matter.</p></div>
       <div class="fit-card"><h3>Probably overkill</h3><p>Throwaway demos, quick scripts, school assignments, and prototypes you do not expect to maintain. For those, the process may cost more than it saves.</p></div>
       <div class="fit-card"><h3>Still needs experienced review</h3><p>Throughstone reduces project risk, but it does not make AI agents reliable by default. Production software still needs experienced review, especially around security, data, payments, and compliance.</p></div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -233,7 +233,7 @@
     </div>
     <div class="flow">
       <div class="flow-step"><div class="num">01</div><h3>Initialize</h3><p>Run the setup wizard once. It stamps the project name, license posture, repo layout, docs hub, prompts repo, and agent pointers.</p></div>
-      <div class="flow-step"><div class="num">02</div><h3>Kick off</h3><p>Tell the agent to read AGENTS.md. It interviews you, records the project brief, and prepares STEP-1 for architecture.</p></div>
+      <div class="flow-step"><div class="num">02</div><h3>Kick off</h3><p>Tell the agent to read AGENTS.md. It interviews you, records the project brief, and prepares STEP-1 for architecture. Bring existing specs, designs, or research and it builds on them.</p></div>
       <div class="flow-step"><div class="num">03</div><h3>Design first</h3><p>Architecture sessions capture scope, data, security, interfaces, testing, deployment, ADRs, and the cross-cutting review before app code starts.</p></div>
       <div class="flow-step"><div class="num">04</div><h3>Build in STEPs</h3><p>The planning session turns the locked architecture into implementation STEPs, each with substep prompts, verification, review, and archival.</p></div>
     </div>
@@ -350,7 +350,7 @@
       <p>The scaffold includes runbooks and registers for the maintenance work that often gets skipped until production exposes it.</p>
     </div>
     <div class="ops-grid">
-      <div class="op-card"><h3>Check-ins</h3><p>Every 10-20 STEPs, reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
+      <div class="op-card"><h3>Check-ins</h3><p>On a cadence you set (about every 20 STEPs), reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
       <div class="op-card"><h3>Release and rollback</h3><p>Prepare the rollback path before deploy, verify during a watch window, and make the return lever explicit.</p></div>
       <div class="op-card"><h3>Incidents</h3><p>Stabilize first, then run root-cause analysis, search for similar bugs, fix, harden, and write the postmortem.</p></div>
       <div class="op-card"><h3>Dependencies</h3><p>Vet packages before adding them and audit installed dependencies for vulnerabilities, licenses, and provenance.</p></div>
@@ -381,7 +381,7 @@
       <p>Throughstone is intentionally more structured than a blank chat. That is the point, and also the tradeoff.</p>
     </div>
     <div class="fit-grid">
-      <div class="fit-card"><h3>Good fit</h3><p>Products, internal tools, serious open-source projects, and AI-assisted builds where architecture, scaling, tests, security, future changes, or team handoff matter.</p></div>
+      <div class="fit-card"><h3>Good fit</h3><p>New projects or existing codebases you're bringing under control: products, internal tools, serious open-source projects, and AI-assisted builds where architecture, scaling, tests, security, future changes, or team handoff matter.</p></div>
       <div class="fit-card"><h3>Probably overkill</h3><p>Throwaway demos, quick scripts, school assignments, and prototypes you do not expect to maintain. For those, the process may cost more than it saves.</p></div>
       <div class="fit-card"><h3>Still needs experienced review</h3><p>Throughstone reduces project risk, but it does not make AI agents reliable by default. Production software still needs experienced review, especially around security, data, payments, and compliance.</p></div>
     </div>


### PR DESCRIPTION
Copy-only updates for the 1.7 release, for review before we tag `v1.7.0`. Two clean commits: README, then website. No method or tooling changes.

## README
- Rewrite the "Can I use this with an existing project?" FAQ for 1.7's existing-code support: planning scaffolds only repos that aren't already registered, plans against what already exists, targets the first unfinished phase, and can register a repo that lives outside the workspace; existing design docs can be dropped into `inputs/`. Kept measured — explicitly **not** a one-click importer.
- List the `inputs/` folder in "What documents does Throughstone create?"
- Add `inputs/` to the docs-hub layout tree.

## Website
Edited the canonical `brand/site/index.html` and republished to `docs/` with `brand/publish-site.sh` (both committed together to keep the publish contract in sync — `docs/index.html` is generated, not hand-edited).
- **Check-ins** card: cadence is project-selectable (about every 20 STEPs), not a fixed 10–20 window.
- **Kick off** step: mention bringing existing specs, designs, or research.
- **Good fit** card: explicitly welcome existing codebases, not just new projects.

## Verification
- `bash tests/links.sh` → PASS
- `bash tests/site-publish.sh` → PASS (`brand/site/` and `docs/` in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
