### PR TITLE
Keep brought-in inputs/ docs from going stale as architecture supersedes them

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -56,7 +56,7 @@ This project follows the method in **`Code/{{PROJECT}}-docs/METHOD.md`** — rea
 - Durable docs live in `Code/{{PROJECT}}-docs/`:
   - `architecture/` — *what* the system is (versioned, living).
   - `adr/` — *why* it's that way (point-in-time decision records).
-  - `inputs/` — documents *you* provide that inform the design (specs, prior docs, UI designs); the sessions read from here.
+  - `inputs/` — point-in-time documents *you* provide that inform the design (specs, prior docs, UI designs); sessions read the live ones here (not `inputs/archive/`) and treat them as a starting point, not living truth (see the inputs rule under Ground rules).
 - The roadmap and status are in `prompts/STEP-index.md`.
 
 ## Architecture sessions  (how to run one)
@@ -70,7 +70,8 @@ interview the user one decision at a time, then write the output architecture do
 **"STEP-1.N", "Run STEP-1.N: <session label>", "session N.M", and "Run session N.M:
 <session label>" are all the user's go-ahead — begin in that same reply.** Don't
 acknowledge, summarize the file, restate the plan, or ask whether to start (no "Ready when
-you are"). Read root `.throughstone/local-user.md`, `overview.md`, anything relevant in `inputs/`, and
+you are"). Read root `.throughstone/local-user.md`, `overview.md`, anything relevant in `inputs/` (its live
+material, not `inputs/archive/`), and
 any earlier architecture docs silently, then immediately **ask the session's first question**,
 calibrated to the profile's experience level. The user types one short command and expects
 the first question back, not a confirmation prompt.
@@ -89,8 +90,8 @@ periodic check-in may also schedule a conditional later as a standalone
 exact invocation and output-doc number instead of reopening STEP-1.
 
 Each session reads what it needs from disk (`Code/{{PROJECT}}-docs/overview.md`, anything
-relevant in `Code/{{PROJECT}}-docs/inputs/`, and earlier architecture docs), so context can be
-cleared between sessions — state lives in files. If the user provides a document in chat, save
+relevant in `Code/{{PROJECT}}-docs/inputs/` excluding `inputs/archive/`, and earlier architecture
+docs), so context can be cleared between sessions — state lives in files. If the user provides a document in chat, save
 a copy into `inputs/` so later sessions and fresh chats can use it.
 
 When STEP-1 is complete (the Cross-Cutting Review passed), the user moves into building by
@@ -170,6 +171,20 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
   architecture doc (`architecture/*-architecture-overview.md`) / `registries/repos.yml`, and
   a new domain term may need the Glossary architecture doc — don't let a doc go stale (see
   `Code/{{PROJECT}}-docs/METHOD.md` §6).
+- **Inputs are point-in-time; `architecture/` is the living truth.** Treat anything in
+  `Code/{{PROJECT}}-docs/inputs/` as a *starting point*, not a current source of truth: where a
+  generated `architecture/` or `adr/` doc covers the same ground, the generated doc wins, and an
+  input's superseded parts must not be built on. `inputs/inputs-index.md` records what each input
+  still holds vs. what's been superseded; **read `inputs/` but not `inputs/archive/`** (retired
+  inputs, kept for history). When a session captures an input's content into `architecture/`, mark
+  it in that index. **Lift architecture-grade inputs — a protocol/API spec, a formal contract, a
+  finished design doc — into `architecture/` promptly** (often a whole-file copy or a light reformat
+  to match doc conventions), rather than leaving them live here with `architecture/` merely pointing
+  at them; the original stays as provenance. (Use judgment, though: some inputs are better
+  **referenced** from `architecture/` and kept here long-lived — a large external standard you only
+  partially implement is one example, not the only one.) The
+  periodic check-in reconciles the ledger and retires fully-superseded inputs
+  (`Code/{{PROJECT}}-docs/inputs/README.md`).
 - **Keep accepted risks visible.** Known, accepted risks and deferred technical debt live in
   `Code/{{PROJECT}}-docs/registries/risks.yml`. Add or update a row when security controls,
   dependency fixes, incident follow-ups, or tech debt are consciously deferred. The register is

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -176,7 +176,15 @@ architecture sessions read the relevant documents from there and build on them i
 re-deriving what you already know; hand a session a document **in chat** instead and it saves
 a copy into `inputs/` so it persists for later sessions and fresh chats. The folder is durable
 and **not STEP-1-only** — a later phase, a V2, or a check-in can drop in new inputs the same
-way. See `inputs/README.md`.
+way.
+
+These documents are **point-in-time**: a starting point, not the living source of truth. As the
+sessions capture an input's content into `architecture/` — synthesized for a PRD, or lifted as a
+near-verbatim copy for a spec or other finished doc — that generated doc becomes the truth and the
+captured parts go stale, so `inputs/` carries a small ledger (`inputs/inputs-index.md`) of what each
+input still holds vs. what's been superseded, and a fully-superseded input is retired to
+`inputs/archive/`, which sessions don't read. The periodic check-in reconciles this (§5). See
+`inputs/README.md`.
 
 ### Sessions are re-runnable
 A session isn't a one-time gate. If an assumption changes later — scaling needs grow, the

--- a/Code/{{PROJECT}}-docs/inputs/README.md
+++ b/Code/{{PROJECT}}-docs/inputs/README.md
@@ -22,12 +22,50 @@ already says. If you'd rather paste a document or point the agent at one **in ch
 agent **saves a copy here** so it persists for later sessions and fresh chats — sessions run
 in separate chats and read their inputs from disk, not from the conversation.
 
+## Lifecycle — these are point-in-time; `../architecture/` is living
+An input is a **starting point**, not a lasting source of truth. It's a snapshot of what you knew
+or were handed at one moment; the living description of the system lives in `../architecture/` (and
+the decisions behind it in `../adr/`) — **even when an architecture doc began as a copy of something
+here.** Where a generated `../architecture/` or `../adr/` doc covers the same ground as an input,
+**the generated doc wins.**
+
+Architecture-grade material belongs in `../architecture/` **promptly** — the difference between
+inputs is only *how* it gets there:
+- A **PRD, prior design doc, or research** is *synthesized*: a session reads it, makes the
+  decisions, and writes an architecture doc that interprets it. The input rarely survives verbatim,
+  and once folded in it's history (provenance, not current intent).
+- A **protocol / API spec, or another finished, authoritative doc** is often already in final form.
+  Don't leave it living here with `../architecture/` merely *pointing* at it — **lift it into
+  `../architecture/` as soon as it's in play.** That lift may be a **whole-file copy, or a light
+  reformat** to follow the doc conventions (add the `Version`/`Status` header, fit the naming). From
+  then on the architecture copy is the living version you keep true, and the original stays here as
+  provenance.
+  - *Use judgment, though:* lifting isn't always the right move — sometimes you **reference** the
+    input from `../architecture/` and keep it here, long-lived and `Live`, instead of copying it in.
+    A large external standard you don't own and only partially implement (a long RFC/ISO) is the
+    clearest example — write a compliance/interface doc that references it and keep the artifact
+    pinned by version — but it's *an* example, not the only case.
+
+Two things keep this from rotting:
+- **The index — `inputs-index.md`.** It records, per input, which parts `../architecture/` has
+  already superseded and which still hold, so a later session builds only on what's current instead
+  of re-reading a stale seed. Add a row when you drop in an input; flip it when a session captures
+  one (see that file).
+- **The archive — `inputs/archive/`.** When an input has been **fully** superseded, retire it by
+  moving it into `inputs/archive/`. **Sessions read `inputs/` but not `inputs/archive/`,** so a
+  captured seed stops reading as current intent while its file is kept for history. This is a
+  **move, never an in-place edit or a delete** — the periodic check-in (`../runbooks/check-in.md`)
+  surfaces candidates and you decide; nothing is auto-moved.
+
 ## Conventions
 - Give each file a clear, descriptive name (e.g. `payments-protocol-v2.pdf`,
   `admin-dashboard-figma-export.png`) so a session can tell what it is at a glance.
 - Subfolders are fine if you have a lot (e.g. `specs/`, `ui/`).
 - These are **your source materials, not method output** — unlike `../architecture/` (*what*
-  the system is) and `../adr/` (*why*), nothing here is versioned or rewritten by the sessions.
+  the system is) and `../adr/` (*why*), nothing here is versioned or rewritten by the sessions (a
+  superseded input is *moved* to `inputs/archive/`, never edited in place — see Lifecycle above).
+- `inputs-index.md` (the live-vs-superseded ledger) and this `README.md` are **guidance, not
+  inputs** — a session never treats them as source documents.
 - The folder is **durable and not STEP-1-only**: a later phase, a V2, or a check-in can add
   new inputs the same way.
 - Committed by default, so the whole team shares them. If a document is sensitive or very

--- a/Code/{{PROJECT}}-docs/inputs/inputs-index.md
+++ b/Code/{{PROJECT}}-docs/inputs/inputs-index.md
@@ -1,0 +1,57 @@
+# Inputs index — what still holds, what's been superseded
+
+> **What this is.** `inputs/` holds **point-in-time** source documents; `architecture/` holds the
+> **living** truth (`inputs/README.md`). This file is the ledger that keeps the two honest: it
+> records, per input, which parts an `architecture/` (or `adr/`) doc has already **superseded** and
+> which parts still **hold** — so a later session builds only on what's current instead of
+> re-reading a stale seed, and the periodic check-in can retire what's fully captured. It is the
+> same shape as the other registries (`../registries/repos.yml`, `../registries/risks.yml`,
+> `../adr/README.md`): a session updates it at the moment of change, and the check-in
+> (`../runbooks/check-in.md`) reconciles it against reality.
+>
+> **Greenfield-inert.** A new project has captured nothing yet — every row is `Live` (or the table
+> is empty), so sessions read all of `inputs/` exactly as before. The ledger only starts doing work
+> once a generated doc covers ground an input first supplied.
+>
+> This file and `README.md` are **guidance, not inputs** — a session never treats them as source
+> documents.
+
+## How to read a row
+- **Input** — the file under `inputs/`, e.g. `payments-protocol-v2.pdf` (or `specs/orders-api.md`).
+- **Part** — the smallest piece of that input the input's own structure lets you name: a section,
+  page range, or named region (`§3 Wire format`, `pp.4–6 sequence diagram`). Map as finely as the
+  document allows. Use `(whole)` when it can't be cleanly decomposed — a single diagram, an image,
+  an unstructured doc — rather than inventing sections.
+- **Status** — `Live` (still authoritative — build on it) or `Superseded` (a generated doc now owns
+  this ground — don't). An input with some rows `Live` and some `Superseded` is *partially*
+  superseded: it stays in `inputs/` and is read only for its `Live` parts. When **every** row for an
+  input is `Superseded`, it is fully captured — retire it to `inputs/archive/` (which sessions do
+  not read) and leave its rows here as the record.
+- **Covered by / note** — for a `Superseded` part, the `architecture/` doc or ADR that now owns it
+  (e.g. `architecture/11-interface-contracts`). For a `Live` part, an optional note (e.g. *external
+  protocol spec — authoritative until the protocol revises*).
+
+## When to update it
+- **On import** — a document lands in `inputs/`: add its row(s), `Live`.
+- **On capture** — a session folds an input's content into an `architecture/` doc or an ADR: in the
+  same edit, flip the captured part(s) to `Superseded` and name the covering doc. If the input is
+  itself architecture-grade — e.g. a protocol/API spec or a finished design doc — lift it into
+  `architecture/` promptly (a whole-file copy or a light reformat to match conventions) and mark it
+  here — `inputs/` is never the living home. (Use judgment, though: some inputs are better
+  **referenced** from `architecture/` and kept `Live` here — e.g. a large external standard you only
+  partially implement — one example, not the only one.)
+- **On check-in** — the inputs sweep in `../runbooks/check-in.md` reconciles this ledger against the
+  architecture docs, dispositions anything now covered, and offers to archive fully-superseded
+  inputs. Surface-and-decide — the sweep never moves or deletes a file on its own.
+
+## Index
+
+| Input | Part | Status | Covered by / note |
+|-------|------|--------|-------------------|
+<!-- Example rows — replace with your own once you add inputs:
+| payments-protocol-v2.pdf | §3 Wire format         | Superseded | architecture/11-interface-contracts |
+| payments-protocol-v2.pdf | §5 Retry / idempotency | Live       | external spec — authoritative until the protocol revises |
+| brand-moodboard.png      | (whole)                | Live       | design reference; not decomposable |
+-->
+
+_No inputs indexed yet._

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -157,6 +157,38 @@ Beyond the architecture docs, sweep four things that rot just as quietly:
   create missing source artifacts, and file follow-up STEPs for anything whose trigger has
   fired or whose severity is no longer acceptable.
 
+### Inputs sweep
+
+The `inputs/` folder holds **point-in-time** source documents (a PRD, a prior design doc, a
+protocol/API spec, UI designs); `architecture/` holds the living truth (`inputs/README.md`,
+`METHOD.md` §4). As the build captures that material into `architecture/`, an input's captured
+parts go stale — but nothing revisits `inputs/` between check-ins, so a superseded seed keeps
+reading as current intent until it's reconciled here.
+
+Read `inputs/inputs-index.md` — the ledger of which parts of which input are still `Live` vs.
+`Superseded` (`README.md` and `inputs-index.md` are guidance, not inputs). Reconcile it against the
+architecture docs, **treating only live inputs as current: `inputs/archive/` is history and is not
+swept**, the same way a `Status: Deprecated` doc is listed but not reconciled as live
+(`METHOD.md` §6):
+
+- **Drift into the index.** For each input file under `inputs/` (excluding `inputs/archive/`),
+  confirm it has row(s) in the ledger; add `Live` rows for anything imported but never recorded, and
+  flag ledger rows whose input file is gone.
+- **Newly superseded.** For each `Live` row, check whether a **`Current`** `architecture/` doc (or
+  an ADR) now covers that part. If it does, surface it and let the user disposition it: **mark
+  `Superseded`** (update the row, name the covering doc) or **keep `Live`** (still authoritative —
+  e.g. an external spec the design hasn't diverged from, or a seed not yet fully captured). If an
+  input is itself architecture-grade — a protocol/API spec, a formal contract, a finished design
+  doc — and still lives only in `inputs/`, flag it to be **lifted** into `architecture/` (often a
+  whole-file copy or a light reformat to match doc conventions), then marked `Superseded` here;
+  inputs are never the living home. (Use judgment, though — some inputs are better **referenced**
+  from `architecture/` and kept here, e.g. a large external standard you only partially implement;
+  that's one example, not the only one.)
+- **Retire the fully superseded.** When **every** row for an input is `Superseded`, offer to retire
+  it: **move the file to `inputs/archive/`** (sessions stop reading it) and leave its rows in the
+  ledger as the record. **Surface-and-decide — never auto-move or auto-delete a file;** a still-`Live`
+  input (e.g. an external contract the design still complies with) is never flagged as superseded.
+
 ### Security-review gate
 
 Nudge security deliberately, but do not turn every check-in into a full audit. Read
@@ -197,6 +229,9 @@ Write a short **check-in report** under `reports/` in the docs hub. Use
 - **Deferred coverage:** each non-`Deprecated` doc carrying `Coverage: deferred`, its recorded
   disposition (backfill now / still defer / risk-seeded), and any backfill STEP filed or existing
   one retained; a `Deprecated` such doc is noted as retired, not backfilled.
+- **Inputs:** live inputs reconciled against the architecture docs — rows newly marked `Superseded`
+  (with the covering doc), any input retired to `inputs/archive/`, and any import missing from
+  `inputs/inputs-index.md` that was added; `inputs/archive/` entries are noted as retired, not swept.
 - **Risks/debt:** `registries/risks.yml` items reviewed, closed, updated, or promoted to
   follow-up STEPs.
 - **Security review gate:** S0/S1/S2 current status, whether a review is due, and any Security

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
@@ -7,7 +7,7 @@
 > the System Overview, Requirements & Non-Goals architecture doc and updates
 > `prompts/STEP-index.md`.
 > Have `overview.md` (your 1–2 page brief) available — the session starts from it.
-> **Already have a product spec, PRD, or requirements doc?** Put it in `inputs/` (or paste it / point me at it in chat and I'll save a copy there); I'll build on it instead of re-asking what it already answers.
+> **Already have a product spec, PRD, or requirements doc?** Put it in `inputs/` (or paste it / point me at it in chat and I'll save a copy there); I'll build on it instead of re-asking what it already answers. Inputs are a point-in-time starting point: I read the live ones (not `inputs/archive/`), and where an `architecture/` doc already covers the same ground, it wins.
 > **Calibrate to the local user profile.** Check the **Experience level** in root `.throughstone/local-user.md`: at Level 1-2 (no/basic coding background) explain each question's *what* and *why* in plain language - leading with a recommended default - before asking, and skip bare jargon. If the file is missing, ask the two local-profile questions from `BOOTSTRAP-PROMPT.md` Stage 0, create it, then continue. Also check **Communication style** there and use it as the default level of detail; an explicit style request in chat overrides it for this session only. At any level, treat any confusion or request to clarify - in any words, not just those - as a cue to explain plainly, and tell the user up front they can ask. (See `METHOD.md` §4, "Calibrating to the user's experience level".)
 
 ## About {{PROJECT}}
@@ -39,8 +39,8 @@ No code in this session. The output is a Markdown doc.
 1. **One decision at a time.** Ask, show 2–4 concrete options/examples where useful, then
    **wait for the answer**. Don't assume.
 2. **Start from what's known.** Pull everything you can from `overview.md` and anything the
-   user put in `inputs/` first; ask only what's missing or ambiguous. Don't re-ask what the
-   brief or a provided document already answers.
+   user put in `inputs/` first (its live material, not `inputs/archive/`); ask only what's missing
+   or ambiguous. Don't re-ask what the brief or a provided document already answers.
 3. **Recommend, then flag the tradeoff.** Where there's a sensible default for a project at
    this stage, propose it — but say what it rules out later.
 4. **Push gently on vague answers.** "It should be fast" / "for everyone" → ask for

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
@@ -6,7 +6,7 @@
 > Reads `overview.md`, the System Overview, Requirements & Non-Goals architecture doc
 > (`architecture/*-system-overview.md`), and
 > the Phasing & Roadmap architecture doc (`architecture/*-phasing-roadmap.md`) first.
-> **Have existing architecture docs, system diagrams, or a protocol/API spec?** Put them in `inputs/` (or share them in chat and I'll save copies there); I'll design from them rather than starting cold.
+> **Have existing architecture docs, system diagrams, or a protocol/API spec?** Put them in `inputs/` (or share them in chat and I'll save copies there); I'll design from them rather than starting cold. These are point-in-time inputs: I read the live ones (not `inputs/archive/`), and where an `architecture/` doc already covers the same ground, that doc wins.
 > **Calibrate to the local user profile.** Check the **Experience level** in root `.throughstone/local-user.md`: at Level 1-2 (no/basic coding background) explain each question's *what* and *why* in plain language - leading with a recommended default - before asking, and skip bare jargon. If the file is missing, ask the two local-profile questions from `BOOTSTRAP-PROMPT.md` Stage 0, create it, then continue. Also check **Communication style** there and use it as the default level of detail; an explicit style request in chat overrides it for this session only. At any level, treat any confusion or request to clarify - in any words, not just those - as a cue to explain plainly, and tell the user up front they can ask. (See `METHOD.md` §4, "Calibrating to the user's experience level".)
 
 ## About {{PROJECT}}

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -10,8 +10,9 @@
 > Reads **all** of `architecture/*` (especially the Phasing & Roadmap architecture doc
 > `architecture/*-phasing-roadmap.md`, the Architecture Overview architecture doc
 > `architecture/*-architecture-overview.md`, and the Interface Contracts architecture doc
-> `architecture/*-interface-contracts.md`), `adr/*`, anything relevant in `inputs/` (specs or
-> prior docs you provided — e.g. a protocol spec the build must satisfy),
+> `architecture/*-interface-contracts.md`), `adr/*`, anything still live in `inputs/` (point-in-time
+> specs or prior docs you provided — e.g. a protocol spec the build must satisfy; skip
+> `inputs/archive/`, and where an `architecture/` doc already covers an input, that doc wins),
 > `prompts/STEP-index.md`, and — for multi-repo
 > projects — `registries/repos.yml`.
 > **Calibrate to the local user profile.** Check the **Experience level** in root `.throughstone/local-user.md`: at Level 1–2 (no/basic coding background) explain each question's *what* and *why* in plain language — leading with a recommended default — before asking, and skip bare jargon. If the file is missing, ask the two local-profile questions from `BOOTSTRAP-PROMPT.md` Stage 0, create it, then continue. Also check **Communication style** there and use it as the default verbosity for this planning session; an explicit style request in chat overrides it for this session only. At any level, treat any confusion or request to clarify — in any words, not just those — as a cue to explain plainly, and tell the user up front they can ask. (See `METHOD.md` §4, "Calibrating to the user's experience level".)

--- a/Code/{{PROJECT}}-docs/templates/reports/check-in-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/check-in-report-template.md
@@ -15,6 +15,7 @@
 | Repo READMEs | {{repos}} | {{none / summary}} | {{updated / follow-up}} |
 | Interface contracts | {{artifacts}} | {{none / summary}} | {{updated / follow-up}} |
 | Docstrings | {{areas}} | {{none / summary}} | {{updated / follow-up}} |
+| Inputs vs. architecture | {{inputs/inputs-index.md}} | {{none / rows superseded / retired to archive}} | {{index updated / archived / follow-up}} |
 
 ## Conditional Coverage
 

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
@@ -21,7 +21,11 @@
                                       Stage 0, create it,
                                       and calibrate explanations/questions to it
        - overview.md                — project brief
-       - inputs/                    — specs & prior docs you provided (e.g. a protocol spec to build against)
+       - inputs/                    — point-in-time specs & prior docs you provided (e.g. a
+                                      protocol spec to build against); read the live ones, not
+                                      inputs/archive/, and prefer an architecture/ doc where it
+                                      already covers the same ground (inputs/inputs-index.md tracks
+                                      what still holds vs. what's superseded)
        - architecture/README.md     — the architecture docs (what the system is)
        - adr/README.md              — the decision records (why it's that way)
        - coding-standards/README.md — the per-language standards


### PR DESCRIPTION
## Why

The `inputs/` folder — where a team drops the documents it already has (PRDs, prior design docs, protocol/API specs, UI designs) — had no lifecycle. Every architecture session and the kickoff read it and built on it as **current intent**, and nothing ever revisited it. Once a generated `architecture/` doc covered the same ground, the original document still read as "current," so a later re-run of a session could quietly build on **superseded assumptions**. This was a live problem on any project that brings in documents, independent of anything else.

## The model

Inputs are **point-in-time**; `architecture/` is the **living truth**. Where a generated `architecture/` or `adr/` doc covers the same ground as an input, the generated doc wins. Inputs differ only in how long they stay live — a PRD is captured once; a protocol spec holds until the external owner revises it or the design diverges — not in kind.

## What changed

- **Authority rule**, stated once in `inputs/README.md` and the `AGENTS.md` ground rules so every session inherits it. The system-overview, architecture-overview, substep, and planning read-points now treat inputs as a starting point and exclude `inputs/archive/`.
- **New `inputs/inputs-index.md` ledger** — records, per input, which parts an `architecture/`/`adr/` doc has superseded and which still hold, at **section granularity where the input's structure allows** and a whole-doc row where it doesn't (a diagram, an unstructured doc). Written when an input is imported and when a session captures its content.
- **`inputs/archive/`** — a fully-superseded input is *moved* here (sessions don't read it), never edited in place or deleted, mirroring how a `Deprecated` architecture doc is kept for history but not swept.
- **Check-in inputs sweep** — beside the deferred-coverage sweep: reconcile the ledger against the architecture docs, surface a newly-superseded input for a **retire/keep** decision, and never auto-move or delete. A still-live input (e.g. an external spec the design still complies with) is never flagged. A matching row was added to the check-in report template.

## Greenfield-inert

No change to `init.sh` or the kickoff. A fresh project ships an empty ledger, sessions still read `inputs/` and build on it, and there are no new prompts on a first run. The lifecycle only starts doing work once a generated doc supersedes ground an input first supplied.

## Verification

- `scripts/check.sh` — clean
- `scripts/links.sh` — clean (all scoped local links resolve, including the new file)
- Full test suite — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
