### PR TITLE
Add the retcon front door: adopt an existing codebase via init.sh

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -14,7 +14,7 @@
 ## First action — kickoff or resume?
 **Before doing anything else, decide which mode you're in** by reading the `PROJECT-STATUS`
 marker near the top of `Code/{{PROJECT}}-docs/overview.md` (the `<!-- PROJECT-STATUS: … -->`
-line). It has one of two values:
+line). It has one of three values:
 
 If `Code/{{PROJECT}}-docs/overview.md` does not exist, this is still the uninitialized
 template/download; tell the user to run `./init.sh` first, then come back with *"Read
@@ -29,7 +29,17 @@ AGENTS.md and follow it."*
   `Code/{{PROJECT}}-docs/overview.md` for review; seed it from the one-line description in
   *What is {{PROJECT}}* below). The user should not have to pre-write `overview.md` or paste a
   kickoff command. The bootstrap flips the marker to `kickoff-complete` when it finishes.
-- **`kickoff-complete` → Resume mode.** Kickoff already happened. **Do not re-run kickoff.**
+- **`retcon` → Adoption mode (existing codebase).** The project is being adopted from an
+  existing codebase, not designed from scratch. **Do not run the greenfield kickoff.** Read
+  `Code/{{PROJECT}}-docs/RETCON-PROMPT.md` and follow it: it is a single PLAN-driven resolver
+  over the in-flight **STEP-1 PLAN** (`Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md`, a stub
+  seeded by `init.sh` whose substeps are the inventory work) — resolve its **lowest open
+  substep**. Instead of interviewing the architecture cold, retcon reverse-engineers the
+  baseline *from the running code* (inventory → recon map → confirm, then harvest→confirm each
+  session). `RETCON-PROMPT.md` flips the marker to `kickoff-complete` when the baseline lands;
+  from that instant this is ordinary {{PROJECT}} and resumes from `prompts/STEP-index.md`.
+- **`kickoff-complete` → Resume mode.** Kickoff (or a completed retcon adoption) already
+  happened. **Do not re-run kickoff.**
   Pick up the next action via the next-action resolver (`METHOD.md` §10): **run
   `./doctor.sh status` (or `Code/{{PROJECT}}-docs/scripts/status.sh`)** — it resolves §10 mechanically from disk and
   prints where you are, the next action, and the check-in cadence. Read
@@ -38,8 +48,20 @@ AGENTS.md and follow it."*
   isn't available (older project, no shell), fall back to reading the index and applying §10
   yourself.
 
-(If the marker is missing entirely — an older project predating it — fall back to inferring:
-treat it as resume unless `prompts/STEP-index.md` is still the bare `init.sh` seed.)
+These aren't four stages: `not-started` and `retcon` are **two in-progress paths to the same
+`kickoff-complete` terminal**. Greenfield needs no separate "kickoff-in-progress" marker because
+its long work — the STEP-1 architecture sessions — runs *after* `kickoff-complete` under
+`status.sh`; retcon's `retcon` *is* that in-progress marker, because its equivalent work runs
+*before* the terminal, resolved from the STEP-1 PLAN by `RETCON-PROMPT.md`.
+
+(If the marker is missing entirely — an older project predating it, or marker loss/corruption
+— infer from disk. **First check for an adoption in progress:** an in-flight
+`Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md` (or an `Upcoming Prompts/retcon/` scratch folder)
+sitting over a still-bare `init.sh`-seed `prompts/STEP-index.md` means a **retcon** whose marker
+was lost — **restore `PROJECT-STATUS: retcon`** and follow `RETCON-PROMPT.md`. Both those signals
+are absent in a fresh greenfield checkout — `init.sh` writes no STEP-1 PLAN in new-project mode;
+the kickoff does. Otherwise treat it as **resume** unless `prompts/STEP-index.md` is still the
+bare `init.sh` seed, which means the greenfield kickoff never ran → **kickoff mode**.)
 
 ## What is {{PROJECT}}
 {{PROJECT_DESCRIPTION}}

--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -36,6 +36,22 @@ if [ -f "$OVERVIEW" ] && grep -q 'PROJECT-STATUS: not-started' "$OVERVIEW"; then
   exit 0
 fi
 
+# --- Retcon gate (adopting an existing codebase) ------------------------------
+# While a project is being adopted from existing code, the STEP-1 resolver is RETCON-PROMPT.md,
+# not this script: progress lives in the in-flight STEP-1 PLAN (its inventory → per-asset →
+# session substeps), which is deliberately off the STEP-index grammar. So route there and stop —
+# don't try to resolve. The terminal `Done STEP-1` baseline that retcon eventually lands needs no
+# special case here; it resolves exactly like a greenfield baseline.
+if [ -f "$OVERVIEW" ] && grep -q 'PROJECT-STATUS: retcon' "$OVERVIEW"; then
+  echo "Where you are:  adopting an existing codebase (overview.md marker: retcon)."
+  echo
+  echo "Next action:"
+  echo "  → retcon in progress — follow Code/<project>-docs/RETCON-PROMPT.md. It resolves the"
+  echo "    lowest open substep in the in-flight STEP-1 PLAN (\"Upcoming Prompts/<project>-STEP-1-PLAN.md\")."
+  echo "    Open the project and say:  \"Read AGENTS.md and follow it.\""
+  exit 0
+fi
+
 if [ ! -f "$INDEX" ]; then
   echo "Where you are:  project not initialized (no prompts/STEP-index.md)."
   echo

--- a/Code/{{PROJECT}}-docs/templates/overview-template.md
+++ b/Code/{{PROJECT}}-docs/templates/overview-template.md
@@ -1,10 +1,15 @@
 # {{PROJECT}} — Project Overview
 
 <!-- PROJECT-STATUS: not-started -->
-<!-- ^ Kickoff gate (do not delete this line). `init.sh` seeds it as "not-started". The agent
-     flips it to "kickoff-complete" at the end of the bootstrap (BOOTSTRAP-PROMPT.md). While it
-     reads "not-started", opening this project in an AI agent starts the kickoff interview
-     automatically; once "kickoff-complete", agents resume from prompts/STEP-index.md instead. -->
+<!-- ^ Kickoff gate (do not delete this line). One of three values:
+       • not-started      → `init.sh` seeds this for a new project; opening the project in an
+                            AI agent starts the kickoff interview (BOOTSTRAP-PROMPT.md).
+       • retcon           → `init.sh --mode=existing` seeds this when adopting an existing
+                            codebase; agents follow RETCON-PROMPT.md (reverse-engineer the
+                            baseline from the running code) instead of the kickoff interview.
+       • kickoff-complete → the architecture baseline exists; agents resume from
+                            prompts/STEP-index.md. Both the bootstrap and a completed retcon
+                            adoption flip the marker to this path-agnostic terminal value. -->
 
 <!-- CHECK-IN-CADENCE: 20 -->
 <!-- ^ Check-in cadence (optional): aim for a Check-in STEP about every this-many STEPs. 20 is the

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -1,0 +1,105 @@
+# {{PROJECT}} — STEP-1 PLAN: Retcon baseline (reverse-engineered architecture)
+
+**Phase:** Phase 1 — (forward milestone; named at Phasing/1.2, near the end of adoption)
+**Owner:** {{who is running this — retcon is single-owner / one-machine}}   <!-- solo: optional -->
+**Status:** In progress        <!-- adoption is underway the moment you open the agent; the STEP-1
+                                    row in prompts/STEP-index.md stays Planned (the greenfield-identical
+                                    seed) until landing — that's expected, don't "fix" it: status.sh's
+                                    retcon branch routes here and ignores the index during adoption. -->
+**Date:** {{DATE}}
+**Branch:** `step-0001-architecture`   <!-- same name in every repo this STEP touches -->
+**Repos (projection):** `{{PROJECT}}-docs`, `prompts`   <!-- STEP-1 is docs-only; adopted code repos are registered in place, not rebuilt -->
+
+> **This is a STUB that `init.sh` dropped.** It is the in-flight STEP-1 PLAN for adopting an
+> existing codebase into {{PROJECT}} (**retcon**). Its substeps are the **inventory work** only.
+> Once the inventory is confirmed, `RETCON-PROMPT.md` **upgrades this PLAN by addition** (see the
+> marker further down) — it never rewrites what is above. A single PLAN-driven resolver runs
+> throughout: resolve the lowest open substep below.
+
+## The retcon baseline (what STEP-1 produces here)
+This STEP-1 is the **reverse-engineered architecture baseline** — *descriptive* (read from the
+running code), not *prescriptive* (decided, then built). The running code is the source of truth;
+existing docs, memory, and original intent are secondary evidence that may be stale or wrong.
+
+When adoption lands (after the Cross-Cutting Review), STEP-1 becomes an ordinary **`Done`** row in
+`prompts/STEP-index.md` marked **RETCON**, with the scope *"Retcon baseline — reverse-engineered
+from existing code; adopted {{DATE}}; forward work starts at STEP-2."* It archives greenfield-style
+into `prompts/001-<milestone>/step-0001/` (the folder name converges with greenfield), and a
+one-line provenance note goes in `overview.md` (*"Adopted via retcon on {{DATE}}"*).
+To the resolver it is an ordinary architecture baseline needing no new logic: forward
+implementation starts at **STEP-2**, and the first forward planning session inserts a **baseline
+check-in** as STEP-2 — the full test suite this docs-only STEP-1 deliberately skips.
+
+## Motivation
+Bring an existing system under {{PROJECT}} so the team works the STEP method **from here on**,
+without rebuilding. The deliverables are a set of {{PROJECT}}-shaped architecture docs describing
+what already exists, plus the STEP process (index, registries) stood up so the next unit of work is
+ordinary {{PROJECT}}. The value is a clean go-forward baseline plus the gaps/drift surfaced along
+the way — not a pretty description a mature team already knows.
+
+## Decisions already locked
+- root `.throughstone/local-user.md` — read **Experience level** before user-facing questions or
+  explanations, and **Communication style** before planning discussions; keep that file as the
+  personal local source of truth for both values.
+- **Reality is the code.** The baseline documents what the code *is*. Any divergence
+  (code-internal, or code-vs-goal) is recorded as reality **plus** flagged drift/debt, settled by
+  re-reading the code — not re-decided, not blanket-logged.
+- **No fabricated history, no reconstructed ADRs.** Everything before adoption is prehistory: we do
+  not reconstruct a STEP log or dated decision records for choices made long ago. A *forward*
+  decision made **during** adoption is contemporaneous and may be a normal ADR.
+- **Do it right or defer it openly.** Every area is either fully harvested (yielding a doc as thin
+  or as detailed as the reality it describes) or explicitly `Coverage: deferred` with a plain
+  "what's missing and why it matters" warning — never shallow-but-asserted.
+- Found source docs land in `inputs/` and ride the base inputs lifecycle (point-in-time;
+  `inputs/inputs-index.md` tracks what still holds vs. what observed reality has superseded).
+
+## Substeps — the inventory work
+> Free-form inventory units (not the `1.1`–`1.14` session mirror, and not parsed by `status.sh` —
+> real progress lives here in the PLAN). Resolve the **lowest open** one. `RETCON-PROMPT.md` drives
+> each; see it for the detail.
+
+| # | Title | Produces | Status |
+|---|-------|----------|--------|
+| i1 | Intake | Depth dial set; rough repo/doc/resource locations, the project's lifecycle stage, and any house version convention recorded (RETCON-PROMPT.md Stage 1). | Planned |
+| i2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces); each existing doc classified with a trust level. | Planned |
+| i3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
+| i4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
+| i5 | Upgrade this PLAN | Mark i1–i4 `Done`; **append** (never rewrite) the per-asset substeps + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table. | Planned |
+
+<!-- ═══════════════════════════════════════════════════════════════════════════════
+     Everything ABOVE is the seed init.sh dropped. Once the inventory is CONFIRMED
+     (substep i4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
+     the above. It marks i1–i5 Done and APPENDS, below this line:
+       • the per-asset substeps — one per repo/doc-set/resource, free-form units, each
+         documenting one asset so nothing is lost (a repo is not a 1.N session);
+       • the in-scope architecture sessions 1.1–1.14 (the harvest→confirm wrapper);
+       • the `Conditional sessions considered` table — seeded from code-visible surfaces
+         (client surfaces, PII, auth) and refined as sessions harvest, exactly as
+         greenfield seeds-then-refines it.
+     That upgraded PLAN — at this same path, Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md —
+     is the STEP-1 PLAN the Cross-Cutting Review's Check 1 and every future check-in read.
+     See RETCON-PROMPT.md.
+     ═══════════════════════════════════════════════════════════════════════════════ -->
+
+## Ground rules
+- **Calibrate communication from root `.throughstone/local-user.md`.** If it's missing, ask the two
+  local-profile questions from `BOOTSTRAP-PROMPT.md` Stage 0, create it, and continue. Don't copy
+  either value into this PLAN.
+- **STEP-1 is docs-only — no application code.** Retcon may create Markdown and scaffolding
+  (a {{PROJECT}} README per adopted repo, `registries/` rows, `architecture/` docs), but never
+  rewrites the user's codebase. It adopts the existing one.
+- **Detect-then-confirm.** Propose an inventory; let the user correct it. Existing repos are
+  registered **in place** by their real `location` (not relocated).
+- **Confirm every decision** proportionate to confidence × consequence — a `from-code` answer gets
+  a fast "right?"; a low-confidence, load-bearing one gets a real discussion.
+- **Accepted risks / deferrals stay visible.** Push unknowns and `Coverage: deferred` areas to
+  `registries/risks.yml` with a revisit trigger; the check-in re-surfaces them.
+
+## Definition of done (inventory phase)
+- [ ] i1–i4 complete: intake recorded, everything inventoried, the recon map drafted and
+      **confirmed by the user**.
+- [ ] i5 complete: this PLAN upgraded by addition — per-asset substeps + the in-scope 1.1–1.14
+      sessions + the `Conditional sessions considered` table appended; i1–i5 marked `Done`.
+- [ ] Next action is the lowest open **appended** substep (the per-session harvest→confirm wrapper).
+      The overall STEP-1 baseline lands later, after the Cross-Cutting Review (see the retcon
+      baseline note above).

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -60,16 +60,16 @@ the way — not a pretty description a mature team already knows.
 
 | # | Title | Produces | Status |
 |---|-------|----------|--------|
-| i1 | Intake | Depth dial set; rough repo/doc/resource locations, the project's lifecycle stage, and any house version convention recorded (RETCON-PROMPT.md Stage 1). | Planned |
-| i2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces); each existing doc classified with a trust level. | Planned |
-| i3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
-| i4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
-| i5 | Upgrade this PLAN | Mark i1–i4 `Done`; **append** (never rewrite) the per-asset substeps + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table. | Planned |
+| inv-1 | Intake | Depth dial set; rough repo/doc/resource locations, the project's lifecycle stage, and any house version convention recorded (RETCON-PROMPT.md Stage 1). | Planned |
+| inv-2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces); each existing doc classified with a trust level. | Planned |
+| inv-3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
+| inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
+| inv-5 | Upgrade this PLAN | Mark inv-1–inv-4 `Done`; **append** (never rewrite) the per-asset substeps + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table. | Planned |
 
 <!-- ═══════════════════════════════════════════════════════════════════════════════
      Everything ABOVE is the seed init.sh dropped. Once the inventory is CONFIRMED
-     (substep i4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
-     the above. It marks i1–i5 Done and APPENDS, below this line:
+     (substep inv-4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
+     the above. It marks inv-1–inv-5 Done and APPENDS, below this line:
        • the per-asset substeps — one per repo/doc-set/resource, free-form units, each
          documenting one asset so nothing is lost (a repo is not a 1.N session);
        • the in-scope architecture sessions 1.1–1.14 (the harvest→confirm wrapper);
@@ -96,10 +96,10 @@ the way — not a pretty description a mature team already knows.
   `registries/risks.yml` with a revisit trigger; the check-in re-surfaces them.
 
 ## Definition of done (inventory phase)
-- [ ] i1–i4 complete: intake recorded, everything inventoried, the recon map drafted and
+- [ ] inv-1–inv-4 complete: intake recorded, everything inventoried, the recon map drafted and
       **confirmed by the user**.
-- [ ] i5 complete: this PLAN upgraded by addition — per-asset substeps + the in-scope 1.1–1.14
-      sessions + the `Conditional sessions considered` table appended; i1–i5 marked `Done`.
+- [ ] inv-5 complete: this PLAN upgraded by addition — per-asset substeps + the in-scope 1.1–1.14
+      sessions + the `Conditional sessions considered` table appended; inv-1–inv-5 marked `Done`.
 - [ ] Next action is the lowest open **appended** substep (the per-session harvest→confirm wrapper).
       The overall STEP-1 baseline lands later, after the Cross-Cutting Review (see the retcon
       baseline note above).

--- a/init.sh
+++ b/init.sh
@@ -154,6 +154,9 @@ set, in which case a missing required value is an error (useful for scripts/CI).
 Usage: ./init.sh [options]
 
 Options:
+  --mode=MODE           new | existing                 (default: new)
+                         "existing" adopts an existing codebase (retcon): same scaffold,
+                         but the agent reverse-engineers the baseline instead of interviewing it.
   --slug=SLUG            Project slug (lowercase kebab-case, e.g. acme-scheduler)
   --desc=TEXT           One-line description
   --license=NAME        mit | bsd-3 | apache-2.0 | private
@@ -174,7 +177,7 @@ Options:
   -y, --non-interactive Never prompt; error on any missing required value
   -h, --help            Show this help and exit
 
-Env vars (flags take precedence): INIT_SLUG, INIT_DESC, INIT_LICENSE, INIT_HOLDER,
+Env vars (flags take precedence): INIT_MODE, INIT_SLUG, INIT_DESC, INIT_LICENSE, INIT_HOLDER,
   INIT_LAYOUT, INIT_REGISTRIES, INIT_COLLAB, INIT_ADR_AUTHORITY, INIT_REMOTES,
   INIT_REMOTE_PROVIDER, INIT_OWNER, INIT_REMOTE_URL, INIT_DOCS_REMOTE,
   INIT_PROMPTS_REMOTE, INIT_VISIBILITY, INIT_TRUNK_BRANCH, INIT_NONINTERACTIVE.
@@ -185,6 +188,7 @@ USAGE
 # Every input starts as an env-supplied preset and may be overwritten by a flag below. Empty
 # means "not answered yet"; the question phase either prompts, applies a default, or errors in
 # --non-interactive mode.
+MODE_IN="${INIT_MODE:-}"
 SLUG_IN="${INIT_SLUG:-}";       DESC_IN="${INIT_DESC:-}"
 LICENSE_IN="${INIT_LICENSE:-}"; HOLDER_IN="${INIT_HOLDER:-}"
 LAYOUT_IN="${INIT_LAYOUT:-}";   REGISTRIES_IN="${INIT_REGISTRIES:-}"
@@ -198,6 +202,8 @@ NONINTERACTIVE="${INIT_NONINTERACTIVE:-0}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    --mode=*)          MODE_IN="${1#*=}" ;;
+    --mode)            MODE_IN="${2:-}"; shift ;;
     --slug=*)          SLUG_IN="${1#*=}" ;;
     --slug)            SLUG_IN="${2:-}"; shift ;;
     --desc=*)          DESC_IN="${1#*=}" ;;
@@ -262,6 +268,34 @@ say "Throughstone — setup"
 #
 # Defaults are conservative for automation: multi-repo, solo, private GitHub visibility, and
 # no remote creation unless requested.
+
+# New project vs. existing codebase. This is the one fork the installer makes: "new" is the
+# greenfield kickoff; "existing" adopts a codebase that already exists (retcon). Both set up the
+# same mechanical scaffold below — the only differences land at the end (section 5c): "existing"
+# sets PROJECT-STATUS to `retcon` and drops a stub STEP-1 PLAN, then stops so an agent can
+# reverse-engineer the baseline from the running code. It is asked, never auto-detected, because
+# repo discovery is the agent's job, not the installer's.
+if [ -n "$MODE_IN" ]; then
+  case "$(printf '%s' "$MODE_IN" | tr '[:upper:]' '[:lower:]')" in
+    new|greenfield|1)          MODE=new ;;
+    existing|retcon|adopt|2)   MODE=existing ;;
+    *) echo "init.sh: invalid --mode '$MODE_IN' (new | existing)." >&2; exit 2 ;;
+  esac
+elif [ "$NONINTERACTIVE" = "1" ]; then
+  MODE=new
+else
+  echo "Is this a new project, or are you adopting Throughstone into an existing codebase?"
+  echo "  1) New project        (greenfield — the agent interviews you to design it)"
+  echo "  2) Existing codebase  (retcon — the agent reads your code and reverse-engineers the baseline)"
+  while :; do
+    case "$(ask 'Choose 1 or 2' '1')" in
+      1) MODE=new; break ;;
+      2) MODE=existing; break ;;
+      *) echo "  -> choose 1 for a new project or 2 for an existing codebase." ;;
+    esac
+  done
+fi
+
 # Project slug — validated kebab-case whether supplied or prompted.
 SLUG="$SLUG_IN"
 if [ -n "$SLUG" ]; then
@@ -770,6 +804,31 @@ if [ ! -f "prompts/STEP-index.md" ]; then
   echo "  created prompts/STEP-index.md (seeded from template)"
 fi
 
+# --- 5c. Existing-codebase adoption (retcon) --------------------------------
+# "existing" mode reuses the whole scaffold above (the STEP index stays the greenfield-identical
+# seed — STEP-1 + 1.1–1.14, all Planned — so check.sh stays clean and status.sh's `retcon` branch
+# is the only new resolver logic). It adds just two things, then stops: flip the status marker to
+# `retcon`, and drop a stub STEP-1 PLAN whose substeps are the inventory work. All discovery — find
+# & register repos, classify docs, build the recon map, harvest the sessions — is agent-driven
+# behind RETCON-PROMPT.md, routed by the `retcon` status.
+if [ "$MODE" = "existing" ]; then
+  # Flip the kickoff gate from the seeded `not-started` to `retcon` (see overview-template.md).
+  perl -pi -e 's/<!-- PROJECT-STATUS: not-started -->/<!-- PROJECT-STATUS: retcon -->/' "$DOCS/overview.md"
+  echo "  retcon: PROJECT-STATUS set to 'retcon' (adopting an existing codebase)"
+  # Seed the stub STEP-1 PLAN at the SAME in-flight path greenfield uses, so the Cross-Cutting
+  # Review and later check-ins find it where they look. Its substeps are the inventory work;
+  # RETCON-PROMPT.md upgrades it by addition once the inventory is confirmed. {{PROJECT}} was
+  # already substituted in step 3; fill {{DATE}} with the adoption date here.
+  mkdir -p "$ROOT/Upcoming Prompts"
+  if [ -f "$DOCS/templates/retcon-step-1-plan-stub.md" ]; then
+    TODAY="$(date +%Y-%m-%d)" perl -pe 's/\Q{{DATE}}\E/$ENV{TODAY}/g' \
+      "$DOCS/templates/retcon-step-1-plan-stub.md" > "$ROOT/Upcoming Prompts/${SLUG}-STEP-1-PLAN.md"
+    echo "  retcon: seeded stub STEP-1 PLAN (Upcoming Prompts/${SLUG}-STEP-1-PLAN.md)"
+  else
+    echo "  retcon: WARNING — stub STEP-1 PLAN template missing; RETCON-PROMPT.md will create the PLAN." >&2
+  fi
+fi
+
 # --- 6. Initialise repo(s) --------------------------------------------------
 # write_gitignore DIR — write the shared baseline ignore file for each generated repo.
 # The contents are intentionally small: editor cruft, per-machine agent config, and local
@@ -977,7 +1036,30 @@ fi
 
 # --- 7. Done ----------------------------------------------------------------
 say "Done."
-cat <<EOF
+# The handoff command is identical in both modes ("Read AGENTS.md and follow it"); only what the
+# agent does next differs — greenfield kickoff interview vs. retcon adoption of existing code.
+if [ "$MODE" = "existing" ]; then
+  cat <<EOF
+
+Next step:
+  Start your AI agent (Claude Code, Codex, …) in THIS folder — set its working directory
+  here, the way you normally launch it. Then send it one message:
+
+      Read AGENTS.md and follow it.
+
+  That's the whole handoff (same command for every project, every agent). This project is set
+  up to ADOPT your existing codebase (retcon): the agent reads the retcon front door
+  (RETCON-PROMPT.md), asks a few intake questions (where your repos/docs are, how deep to go),
+  then inventories your system and reverse-engineers the architecture baseline WITH you —
+  confirming what it finds rather than interviewing from a blank page.
+
+The agent builds a recon map of what you already have, then Throughstone-shaped architecture
+docs describing it; forward work starts at STEP-2 once that baseline lands. It creates your
+local communication profile in .throughstone/local-user.md along the way.
+You can delete this init.sh now — it has done its job.
+EOF
+else
+  cat <<EOF
 
 Next step:
   Start your AI agent (Claude Code, Codex, …) in THIS folder — set its working directory
@@ -992,6 +1074,9 @@ Next step:
 
 The agent will interview you, propose a roadmap, and start the architecture STEP.
 You can delete this init.sh now — it has done its job.
+EOF
+fi
+cat <<EOF
 
 Recommended optional backup:
   You can start now; your project is saved locally with Git. For backup, sharing,

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -84,6 +84,7 @@ run_interactive_case() {
   (
     cd "$work"
     printf '%s' "$input" | ./init.sh \
+      --mode=new \
       --slug="$name" \
       --desc="License validation test" \
       --holder="Throughstone Test" \
@@ -361,6 +362,7 @@ run_public_proprietary_case() {
       GH_LOG="$gh_log" \
       GH_REMOTE_ROOT="$remote_root" \
       ./init.sh \
+        --mode=new \
         --slug="$cancel_name" \
         --desc="Public proprietary cancellation test" \
         --license=private \
@@ -559,7 +561,7 @@ grep -Fq \
 run_private_case \
   "license-private" \
   bash -c \
-  "printf '2\n' | ./init.sh --slug=license-private --desc='License validation test' --layout=multi --collab=solo --remotes=no"
+  "printf '2\n' | ./init.sh --mode=new --slug=license-private --desc='License validation test' --layout=multi --collab=solo --remotes=no"
 
 run_private_case \
   "license-private-flag" \

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -76,8 +76,8 @@ run_existing_case() {
   # 2. Stub STEP-1 PLAN seeded at the greenfield in-flight path, fully resolved.
   [ -f "$plan" ] || { echo "FAIL: $name did not seed $plan" >&2; return 1; }
   assert_file_contains "$plan" "Retcon baseline"
-  assert_file_contains "$plan" "| i1 |"          # the lowest open inventory substep
-  assert_file_contains "$plan" "| i5 |"
+  assert_file_contains "$plan" "| inv-1 |"          # the lowest open inventory substep
+  assert_file_contains "$plan" "| inv-5 |"
   if grep -Eq '\{\{(PROJECT|DATE)\}\}' "$plan"; then
     echo "FAIL: $name stub PLAN has unresolved placeholders" >&2
     grep -nE '\{\{(PROJECT|DATE)\}\}' "$plan" >&2

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for init.sh's new-vs-existing fork (retcon adoption).
+#
+# Asserts:
+#   - Existing mode sets PROJECT-STATUS: retcon, seeds the stub STEP-1 PLAN at the greenfield
+#     in-flight path, keeps the STEP index greenfield-identical, and leaves check.sh clean; a
+#     fresh agent is routed to RETCON-PROMPT.md (status.sh).
+#   - New mode (explicit and default) is unchanged: PROJECT-STATUS: not-started, no stub PLAN,
+#     the greenfield kickoff message.
+#   - An invalid --mode fails before the destructive bootstrap boundary.
+#   - Marker-loss recovery: with PROJECT-STATUS stripped mid-adoption, the two disk signals the
+#     AGENTS.md "First action" fallback keys on (an in-flight stub STEP-1 PLAN over a still-bare
+#     STEP-index seed) still hold; a marker-stripped greenfield presents neither, so it cannot be
+#     misrecovered as a retcon.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-retcon-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — build an init.sh fixture from HEAD, then overlay current worktree
+# changes so this test covers uncommitted bootstrap edits (same helper as the sibling tests).
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+# assert_file_contains FILE NEEDLE — fixed-string presence with a readable failure.
+assert_file_contains() {
+  grep -Fq "$2" "$1" || { echo "FAIL: '$2' not found in $1" >&2; return 1; }
+}
+
+# run_existing_case NAME LAYOUT — adopt an existing codebase in the given layout and assert the
+# retcon front-door state.
+run_existing_case() {
+  local name="$1" layout="$2"
+  local work="$TMP_ROOT/$name"
+  local docs="$work/Code/$name-docs"
+  local plan="$work/Upcoming Prompts/$name-STEP-1-PLAN.md"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --mode=existing \
+      --slug="$name" \
+      --desc="Adopt an existing codebase" \
+      --license=private \
+      --layout="$layout" \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  # 1. Status marker flipped to retcon.
+  assert_file_contains "$docs/overview.md" "PROJECT-STATUS: retcon"
+  ! grep -Fq "PROJECT-STATUS: not-started" "$docs/overview.md"
+
+  # 2. Stub STEP-1 PLAN seeded at the greenfield in-flight path, fully resolved.
+  [ -f "$plan" ] || { echo "FAIL: $name did not seed $plan" >&2; return 1; }
+  assert_file_contains "$plan" "Retcon baseline"
+  assert_file_contains "$plan" "| i1 |"          # the lowest open inventory substep
+  assert_file_contains "$plan" "| i5 |"
+  if grep -Eq '\{\{(PROJECT|DATE)\}\}' "$plan"; then
+    echo "FAIL: $name stub PLAN has unresolved placeholders" >&2
+    grep -nE '\{\{(PROJECT|DATE)\}\}' "$plan" >&2
+    return 1
+  fi
+  grep -Eq '\*\*Date:\*\* [0-9]{4}-[0-9]{2}-[0-9]{2}' "$plan" \
+    || { echo "FAIL: $name stub PLAN date not stamped" >&2; return 1; }
+
+  # 3. STEP index stays byte-identical to the greenfield seed (slug-substituted).
+  diff <(sed "s/{{PROJECT}}/$name/g" "$docs/templates/step-index-seed.md") \
+       "$work/prompts/STEP-index.md" >/dev/null \
+    || { echo "FAIL: $name STEP-index diverged from the greenfield seed" >&2; return 1; }
+
+  # 4. check.sh is clean (warnings allowed; a FAIL exits non-zero).
+  if ! bash "$docs/scripts/check.sh" >"$TMP_ROOT/$name-check.out" 2>&1; then
+    echo "FAIL: $name check.sh reported a hard failure" >&2
+    cat "$TMP_ROOT/$name-check.out" >&2
+    return 1
+  fi
+
+  # 5. status.sh routes a fresh agent to RETCON-PROMPT.md rather than resolving the index.
+  bash "$docs/scripts/status.sh" >"$TMP_ROOT/$name-status.out" 2>&1
+  assert_file_contains "$TMP_ROOT/$name-status.out" "marker: retcon"
+  assert_file_contains "$TMP_ROOT/$name-status.out" "RETCON-PROMPT.md"
+
+  # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
+  #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).
+  assert_file_contains "$TMP_ROOT/$name.out" "ADOPT your existing codebase"
+  ! grep -Fq "interview you, propose a roadmap" "$TMP_ROOT/$name.out"
+}
+
+# run_existing_env_case — the same fork via the INIT_MODE env var instead of the flag.
+run_existing_env_case() {
+  local name="retcon-env"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    INIT_MODE=existing ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Adopt via env var" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  assert_file_contains "$work/Code/$name-docs/overview.md" "PROJECT-STATUS: retcon"
+  [ -f "$work/Upcoming Prompts/$name-STEP-1-PLAN.md" ] \
+    || { echo "FAIL: $name (env) did not seed the stub PLAN" >&2; return 1; }
+}
+
+# run_new_case NAME EXTRA_ARGS... — greenfield must be untouched (marker, no PLAN, message).
+run_new_case() {
+  local name="$1"; shift
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="A brand-new project" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no \
+      "$@"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  assert_file_contains "$work/Code/$name-docs/overview.md" "PROJECT-STATUS: not-started"
+  if ls "$work/Upcoming Prompts/"*STEP-1-PLAN.md >/dev/null 2>&1; then
+    echo "FAIL: $name (new mode) unexpectedly seeded a STEP-1 PLAN" >&2
+    return 1
+  fi
+  assert_file_contains "$TMP_ROOT/$name.out" "interview you, propose a roadmap"
+  ! grep -Fq "ADOPT your existing codebase" "$TMP_ROOT/$name.out"
+}
+
+# run_invalid_mode_case — a bad --mode is rejected before any destructive bootstrap work.
+run_invalid_mode_case() {
+  local name="retcon-invalid"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  if (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --mode=sideways \
+      --slug="$name" \
+      --desc="Invalid mode test" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1; then
+    echo "FAIL: invalid --mode was accepted" >&2
+    return 1
+  fi
+
+  assert_file_contains "$TMP_ROOT/$name.out" "invalid --mode 'sideways'"
+  # Untouched template: the destructive boundary was never crossed.
+  [ -d "$work/Code/{{PROJECT}}-docs" ] || { echo "FAIL: template dir was mutated on invalid --mode" >&2; return 1; }
+  [ -f "$work/README.md" ] || { echo "FAIL: template files were removed on invalid --mode" >&2; return 1; }
+}
+
+# run_marker_recovery_case — simulate marker loss/corruption mid-adoption and assert that the two
+# on-disk signals the AGENTS.md "First action" fallback keys on to restore PROJECT-STATUS: retcon
+# still hold. The recovery *decision* is agent prose (AGENTS.md 57–64), so what a shell test can
+# lock is its INPUTS: an in-flight stub STEP-1 PLAN sitting over a still-bare greenfield STEP-index
+# seed. A future init.sh change that broke either signal would make the fallback misfire silently —
+# this catches it. (status.sh has no fallback by design: the agent restores the marker first.)
+run_marker_recovery_case() {
+  local name="retcon-recovery" layout="multi"
+  local work="$TMP_ROOT/$name"
+  local docs="$work/Code/$name-docs"
+  local overview="$docs/overview.md"
+  local plan="$work/Upcoming Prompts/$name-STEP-1-PLAN.md"
+  local index="$work/prompts/STEP-index.md"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --mode=existing \
+      --slug="$name" \
+      --desc="Adopt for marker-recovery test" \
+      --license=private \
+      --layout="$layout" \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  # Precondition: a healthy retcon front door (marker + stub PLAN both present).
+  assert_file_contains "$overview" "PROJECT-STATUS: retcon"
+  [ -f "$plan" ] || { echo "FAIL: $name precondition — stub PLAN not seeded" >&2; return 1; }
+
+  # Simulate the break: drop the PROJECT-STATUS marker line entirely (marker "missing/corrupted").
+  perl -ni -e 'print unless /PROJECT-STATUS:/' "$overview"
+  ! grep -q 'PROJECT-STATUS:' "$overview" \
+    || { echo "FAIL: $name could not strip the marker for the scenario" >&2; return 1; }
+
+  # Signal (a): an in-flight stub STEP-1 PLAN still sits at the greenfield in-flight path.
+  [ -f "$plan" ] || { echo "FAIL: $name recovery signal (a) — in-flight STEP-1 PLAN missing" >&2; return 1; }
+  assert_file_contains "$plan" "Retcon baseline"
+  # Signal (b): it sits over a STILL-BARE greenfield STEP-index seed (no forward progress yet).
+  diff <(sed "s/{{PROJECT}}/$name/g" "$docs/templates/step-index-seed.md") "$index" >/dev/null \
+    || { echo "FAIL: $name recovery signal (b) — STEP-index is not the bare greenfield seed" >&2; return 1; }
+}
+
+# run_marker_recovery_negative_case — the other half of the AGENTS.md truth table: a fresh
+# greenfield checkout, even with its marker stripped, presents NEITHER signal, so it can never be
+# misrecovered as a retcon. (run_new_case pins the marker-present half; this pins it under loss.)
+run_marker_recovery_negative_case() {
+  local name="green-recovery"
+  local work="$TMP_ROOT/$name"
+  local overview="$work/Code/$name-docs/overview.md"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --mode=new \
+      --slug="$name" \
+      --desc="Greenfield for marker-recovery test" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  perl -ni -e 'print unless /PROJECT-STATUS:/' "$overview"
+  # Signal (a) absent: no in-flight STEP-1 PLAN → the fallback cannot mistake greenfield for retcon.
+  if ls "$work/Upcoming Prompts/"*STEP-1-PLAN.md >/dev/null 2>&1; then
+    echo "FAIL: $name greenfield presents a STEP-1 PLAN — would be misrecovered as retcon" >&2
+    return 1
+  fi
+}
+
+run_existing_case "retcon-multi" multi
+run_existing_case "retcon-mono"  mono
+run_existing_env_case
+run_new_case "green-explicit" --mode=new
+run_new_case "green-default"
+run_invalid_mode_case
+run_marker_recovery_case
+run_marker_recovery_negative_case
+
+echo "init.sh new-vs-existing fork (retcon): PASS"


### PR DESCRIPTION
## Summary

Adds a **retcon** front door so Throughstone can be adopted into an *existing* codebase, not
only a greenfield build. `init.sh` now asks one question — new project, or existing codebase? On
**existing** it stands up the same scaffold but enters retcon adoption: an agent
reverse-engineers the architecture baseline from the running code instead of running the
greenfield kickoff interview.

This is the front door + resolver plumbing. The agent-facing wrapper (`RETCON-PROMPT.md`, which
these route to) lands in a follow-up.

## What changed

- **`init.sh`** — a `--mode` / `INIT_MODE` fork (`new` | `existing`, default `new`). On *existing*
  it reuses the whole greenfield scaffold, then flips `PROJECT-STATUS` to `retcon` and drops a stub
  STEP-1 PLAN (its substeps are the inventory work) at the greenfield in-flight path
  `Upcoming Prompts/<project>-STEP-1-PLAN.md`, then stops. The closing hand-off explains adoption.
- **`scripts/status.sh`** — a `retcon` gate that routes a fresh agent to `RETCON-PROMPT.md` rather
  than resolving the STEP index (the terminal `Done STEP-1` baseline needs no change).
- **`AGENTS.md`** — recognizes `retcon` (routes to `RETCON-PROMPT.md`) and makes the missing-marker
  fallback retcon-aware: it keys on the in-flight stub PLAN / retcon scratch (and self-heals the
  marker) instead of the now-ambiguous bare-seed heuristic.
- **`templates/overview-template.md`** — documents the three `PROJECT-STATUS` values.
- **`templates/retcon-step-1-plan-stub.md`** (new) — the stub STEP-1 PLAN `init.sh` drops, carrying
  the inventory substeps and the reverse-engineered-baseline conventions (marker + scope +
  `step-0001/` archive).
- **Tests** — `tests/init-retcon-mode.sh` (new) covers the fork both ways + an invalid mode;
  `tests/init-license-validation.sh` pre-answers the new question in its interactive cases.

## Verification

- All 10 local tests pass (`tests/init-*`, `tests/status-*`, `doctor-dispatcher`, `links`).
- `check.sh` clean; a real `init.sh --mode=existing` run yields status `retcon`, a byte-identical
  greenfield STEP index, the seeded stub PLAN, and `status.sh` routing to `RETCON-PROMPT.md`.
- **Greenfield is unchanged** (default mode `new`: `not-started`, no stub PLAN, kickoff message).

## Notes for review

- **Base is the `retcon` integration branch, not `main`** — this is one item in a larger retcon
  build that merges to `main` once, complete. Please squash-merge into `retcon`.
- `RETCON-PROMPT.md` is referenced by name here; it lands in a follow-up, so no released state
  carries a dangling reference.
- Judgment calls: existing mode reuses the full greenfield mechanical scaffold (only the status
  flip, stub PLAN, and closing message differ); the stub PLAN's own Status reads `In progress`
  while the STEP-index STEP-1 row stays `Planned` (greenfield-identical seed), which the retcon
  gate makes `status.sh` ignore during adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
