### PR TITLE
Name the retcon inventory substeps inv-1..inv-5 (was i1..i5)

### DIFF
--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -60,16 +60,16 @@ the way — not a pretty description a mature team already knows.
 
 | # | Title | Produces | Status |
 |---|-------|----------|--------|
-| i1 | Intake | Depth dial set; rough repo/doc/resource locations, the project's lifecycle stage, and any house version convention recorded (RETCON-PROMPT.md Stage 1). | Planned |
-| i2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces); each existing doc classified with a trust level. | Planned |
-| i3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
-| i4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
-| i5 | Upgrade this PLAN | Mark i1–i4 `Done`; **append** (never rewrite) the per-asset substeps + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table. | Planned |
+| inv-1 | Intake | Depth dial set; rough repo/doc/resource locations, the project's lifecycle stage, and any house version convention recorded (RETCON-PROMPT.md Stage 1). | Planned |
+| inv-2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces); each existing doc classified with a trust level. | Planned |
+| inv-3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
+| inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
+| inv-5 | Upgrade this PLAN | Mark inv-1–inv-4 `Done`; **append** (never rewrite) the per-asset substeps + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table. | Planned |
 
 <!-- ═══════════════════════════════════════════════════════════════════════════════
      Everything ABOVE is the seed init.sh dropped. Once the inventory is CONFIRMED
-     (substep i4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
-     the above. It marks i1–i5 Done and APPENDS, below this line:
+     (substep inv-4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
+     the above. It marks inv-1–inv-5 Done and APPENDS, below this line:
        • the per-asset substeps — one per repo/doc-set/resource, free-form units, each
          documenting one asset so nothing is lost (a repo is not a 1.N session);
        • the in-scope architecture sessions 1.1–1.14 (the harvest→confirm wrapper);
@@ -96,10 +96,10 @@ the way — not a pretty description a mature team already knows.
   `registries/risks.yml` with a revisit trigger; the check-in re-surfaces them.
 
 ## Definition of done (inventory phase)
-- [ ] i1–i4 complete: intake recorded, everything inventoried, the recon map drafted and
+- [ ] inv-1–inv-4 complete: intake recorded, everything inventoried, the recon map drafted and
       **confirmed by the user**.
-- [ ] i5 complete: this PLAN upgraded by addition — per-asset substeps + the in-scope 1.1–1.14
-      sessions + the `Conditional sessions considered` table appended; i1–i5 marked `Done`.
+- [ ] inv-5 complete: this PLAN upgraded by addition — per-asset substeps + the in-scope 1.1–1.14
+      sessions + the `Conditional sessions considered` table appended; inv-1–inv-5 marked `Done`.
 - [ ] Next action is the lowest open **appended** substep (the per-session harvest→confirm wrapper).
       The overall STEP-1 baseline lands later, after the Cross-Cutting Review (see the retcon
       baseline note above).

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -76,8 +76,8 @@ run_existing_case() {
   # 2. Stub STEP-1 PLAN seeded at the greenfield in-flight path, fully resolved.
   [ -f "$plan" ] || { echo "FAIL: $name did not seed $plan" >&2; return 1; }
   assert_file_contains "$plan" "Retcon baseline"
-  assert_file_contains "$plan" "| i1 |"          # the lowest open inventory substep
-  assert_file_contains "$plan" "| i5 |"
+  assert_file_contains "$plan" "| inv-1 |"          # the lowest open inventory substep
+  assert_file_contains "$plan" "| inv-5 |"
   if grep -Eq '\{\{(PROJECT|DATE)\}\}' "$plan"; then
     echo "FAIL: $name stub PLAN has unresolved placeholders" >&2
     grep -nE '\{\{(PROJECT|DATE)\}\}' "$plan" >&2


### PR DESCRIPTION
Renames the stub STEP-1 PLAN's inventory substeps from `i1`–`i5` to `inv-1`–`inv-5`.

**Why:** the `inv-` prefix is self-documenting ("inventory") and reads unambiguously beside the `1.1`–`1.14` architecture sessions once the PLAN is upgraded by addition — `i1` sitting next to `1.1` was easy to misread. The labels are free-form and are **not** parsed by `status.sh`, so this is wording only; behaviour is unchanged.

**Scope (12 insertions / 12 deletions):**
- `templates/retcon-step-1-plan-stub.md` — the substep table labels, plus the matching references in the Definition of Done and the upgrade-by-addition comment.
- `tests/init-retcon-mode.sh` — the two assertions that key on the lowest / last inventory substep (`| inv-1 |`, `| inv-5 |`).

Base is `retcon-front-door`; squash-merge after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
