### PR TITLE
Add a throughstone field to the repo inventory

### DIFF
--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -272,6 +272,24 @@ rules apply unchanged.
   touched or moved; they simply start `Live` in the ledger, and any retirement to `inputs/archive/`
   happens only when you decide it at a check-in.
 
+### 2.0 migration
+
+**Upgrading to 2.0?** 2.0 adds **existing-codebase adoption** — a new project can be stood up by
+reverse-engineering a running system instead of interviewing it from scratch. Most of it is new
+machinery a project already built with Throughstone never touches; this section collects the few
+things an existing project picks up on upgrade, added as each 2.0 change lands. Nothing here rewrites
+project files, and all of it is greenfield-inert.
+
+**`throughstone:` field on repo rows.** `registries/repos.yml` gains a per-row `throughstone:` field
+recording how the method relates to each repo — value `managed` today, with `external` reserved for a
+later partial-adoption feature. It is inert (nothing reads it yet), and a **missing value is read as
+`managed`**, so an un-upgraded inventory keeps working unchanged. To make your rows explicit — and
+ready for a future `external` — add `throughstone: managed` to each existing repo entry. That is a
+**safe additive edit**: it inserts one field and changes no existing data. `registries/repos.yml` is
+project state (a registry, like `inputs/inputs-index.md`), so this is **review-required and never
+auto-overwritten** — updater tooling adds the line to each row for your review rather than replacing
+the file. Pull the updated `registries/repos.yml` header (which documents the field) alongside it.
+
 ## 3. Manual Mode
 
 This guide works today even without updater tooling, a project manifest, or an upstream update

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -19,22 +19,37 @@
 # Teams: give each repo a `remote:` field (any cloneable git URL). scripts/setup-workspace.sh clones from
 # it, and the STEP-number reservation in runbooks/collaboration.md relies on a shared remote
 # for prompts/ + this docs hub. Solo with no remotes, it's optional.
+#
+# `throughstone:` (per row) records how the method relates to a repo. Every repo the method
+# maintains carries `managed`; a later version adds `external` for a repo that is only referenced,
+# not maintained (partial adoption). The field is inert today — nothing reads it yet — and
+# forward-compatible: it is written now so that future distinction is expressible without reshaping
+# the inventory. Both front doors write it the same way — a repo greenfield stands up and a repo
+# adopted from an existing codebase are both `managed` — so the two produce identical rows. For
+# compatibility with inventories written before this field existed, a missing value is read as
+# `managed`. (This per-row token is unrelated to the top-level `throughstone:` key in
+# `.throughstone/manifest.yml`, which versions the method itself — different file and scope, no
+# collision.)
 
 repos:
   - name: "{{PROJECT}}-docs"
     location: "Code/{{PROJECT}}-docs/"
     type: docs            # docs | service | library | app | infra | tests
+    throughstone: managed
     description: "Documentation hub: architecture, ADRs, standards, registries."
 
   - name: "prompts"
     location: "prompts/"
     type: docs
+    throughstone: managed
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
   # Service / app / library repos get added here as the architecture names them and they
-  # are stamped from templates/repo-readme-template.md. Example:
+  # are stamped from templates/repo-readme-template.md. Give each new repo `throughstone: managed`
+  # like the rows above. Example:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service
+  #   throughstone: managed
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
   #   description: "..."


### PR DESCRIPTION
Adds a per-repo `throughstone:` field to `registries/repos.yml`, recording how the method relates to each repo.

- **Value today:** `managed` — the method maintains this repo. Every repo the method maintains carries it.
- **Inert:** nothing reads the field yet.
- **Forward-compatible:** a later version can add `external` for a repo that is only referenced, not maintained (partial adoption). Writing `managed` now lets that distinction be expressed later without reshaping the inventory.
- **Symmetric front doors:** greenfield and existing-codebase adoption both write `managed`, so the two produce identical rows — the inventory doesn't encode which front door created it.
- **Back-compat:** a missing value is read as `managed`, so inventories written before this field still resolve correctly.

The header also notes this per-row token is unrelated to the top-level `throughstone:` key in `.throughstone/manifest.yml` (which versions the method) — different file and scope, no collision.

### Migration
Starts a **2.0 migration** section in `UPDATING-THROUGHSTONE.md`. Its first entry tells an upgrading project to backfill `throughstone: managed` onto existing repo rows — a **safe additive edit** (inserts one field, changes no existing data), **review-required and never auto-overwritten** because `repos.yml` is project state. So legacy inventories pick up the field on upgrade rather than leaning on the `absent = managed` default forever. (The section is accumulated on the branch as further 2.0 parts land.)

### Scope
The two seed rows (`{{PROJECT}}-docs`, `prompts`) gain the field, the repo-add guidance + commented example show it, and the header documents it. No `init.sh` or test change is needed — `record_registry_remote` matches only live `- name:` rows and inserts `remote:` after `type:`. `links` and the four `repos.yml`-touching init tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
