### PR TITLE
Establish the pre-answer-sheet convention for adoption harvest

### DIFF
--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -297,6 +297,12 @@ project already built with Throughstone produces no recon map and needs to do no
 template and the `reports/README.md` addition if you want them available for adopting another
 codebase later; otherwise there is no action.
 
+**Pre-answer-sheet convention.** A new `templates/retcon-preanswer-sheet.md` ships, and `init.sh`
+now scaffolds an `Upcoming Prompts/retcon/` scratch folder when it adopts an existing codebase — the
+home for the transient per-session sheets the harvest writes. Both are **adoption-only and
+greenfield-inert**: an existing project generated no such folder and needs none. Pull the new
+template if you may adopt another codebase later; otherwise there is no action.
+
 ## 3. Manual Mode
 
 This guide works today even without updater tooling, a project manifest, or an upstream update

--- a/Code/{{PROJECT}}-docs/templates/retcon-preanswer-sheet.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-preanswer-sheet.md
@@ -1,0 +1,39 @@
+# {{PROJECT}} — Pre-answer sheet: {{N.N — session name}}
+
+**Session:** `{{templates/architecture-sessions/NN-....md}}`   <!-- the in-scope session this sheet harvests -->
+**Harvested:** {{YYYY-MM-DD}}
+**Sources read:** {{the confirmed recon map + which per-asset docs / inputs / code paths}}
+**Status:** {{Harvested → Confirmed}}   <!-- Harvested when the answers are drafted from reality;
+                                            Confirmed once the confirm pass has walked every row. -->
+
+<!-- WHAT THIS IS. A pre-answer sheet is retcon's per-session hand-off: instead of interviewing a
+     session cold, the harvest DRAFTS an answer to each of that session's decisions FROM REALITY
+     (the confirmed recon map, the per-asset docs, and the running code), and the confirm pass then
+     walks every decision with the user. One sheet per in-scope architecture session, keyed to that
+     session's decision list — NOT a pre-written draft of the doc (a draft doc anchors the user and
+     forces provenance into the final doc).
+
+     IT EVOLVES. Seed the rows from the session template's decision list, but treat the sheet as a
+     living working doc, not a fixed form: add rows as harvest and confirm surface decisions the
+     template never enumerated (a real system raises questions no generic list foresaw), and split or
+     reword rows as the picture sharpens. Unlike the recon map (frozen once confirmed), a pre-answer
+     sheet keeps changing right up until its clean `architecture/` doc is written — then it is discarded.
+
+     TWO MOVES:
+     1. HARVEST (agent; human-free except the cost escalation): read the session file as REFERENCE
+        DATA — never trigger its interview — and fill Decision / Drafted answer / Provenance /
+        Confidence for every decision the session makes. An answer may draw on more than one source
+        (code and a doc, or several files) — list every source in Provenance, not just the strongest.
+     2. CONFIRM (with the user): walk each row proportionate to confidence × consequence — a
+        from-code answer gets a fast "right?", a low-confidence or load-bearing one a real
+        discussion — and record the outcome in Confirm. Then write the clean `architecture/` doc at
+        the chosen Version/Status: confirmed → plain fact; deferred → `Coverage: deferred` + a
+        `registries/risks.yml` row.
+
+     TRANSIENT. Provenance and confidence live ONLY here — they never leak into the clean doc. The
+     sheet is scratch in `Upcoming Prompts/retcon/`; it is discarded when STEP-1 lands (not archived
+     as project history). Driven by RETCON-PROMPT.md's per-session harvest→confirm. -->
+
+| # | Decision (from the session's decision list) | Drafted answer (from reality) | Provenance | Confidence | Confirm |
+|---|---------------------------------------------|-------------------------------|------------|------------|---------|
+| 1 | {{decision}} | {{answer drafted from reality}} | {{one or more — from-code `path`, from-doc (which + trust), from-memory (user), inferred, unknown}} | {{high / med / low}} | {{confirmed as-is / corrected: … / deferred → Coverage + risks.yml}} |

--- a/init.sh
+++ b/init.sh
@@ -827,6 +827,23 @@ if [ "$MODE" = "existing" ]; then
   else
     echo "  retcon: WARNING — stub STEP-1 PLAN template missing; RETCON-PROMPT.md will create the PLAN." >&2
   fi
+  # Scaffold the pre-answer-sheet scratch folder. RETCON-PROMPT.md's per-session harvest (Stage 3)
+  # drops one transient sheet per in-scope session here; seeding it now gives that a home and makes
+  # the AGENTS.md marker-loss fallback signal reliable from adoption start.
+  mkdir -p "$ROOT/Upcoming Prompts/retcon"
+  cat > "$ROOT/Upcoming Prompts/retcon/README.md" <<'RETCON_SCRATCH_README'
+# Retcon scratch — pre-answer sheets
+
+Transient working folder for **retcon adoption** (see `RETCON-PROMPT.md`). During the per-session
+harvest, each in-scope architecture session gets a **pre-answer sheet** here — one drafted answer per
+decision, with provenance tags — which the confirm pass consumes before the clean `architecture/`
+doc is written. Start each sheet from your docs hub's `templates/retcon-preanswer-sheet.md`.
+
+Scratch, not project history: these sheets are not committed, and they are discarded when STEP-1
+lands. Their presence here (alongside the in-flight STEP-1 PLAN) is also how a fresh agent detects a
+retcon in progress if the `PROJECT-STATUS` marker is ever lost.
+RETCON_SCRATCH_README
+  echo "  retcon: scaffolded pre-answer-sheet scratch (Upcoming Prompts/retcon/)"
 fi
 
 # --- 6. Initialise repo(s) --------------------------------------------------

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -86,6 +86,11 @@ run_existing_case() {
   grep -Eq '\*\*Date:\*\* [0-9]{4}-[0-9]{2}-[0-9]{2}' "$plan" \
     || { echo "FAIL: $name stub PLAN date not stamped" >&2; return 1; }
 
+  # 2b. Pre-answer-sheet scratch folder scaffolded (a home for Stage-3 sheets + a marker-loss signal).
+  [ -d "$work/Upcoming Prompts/retcon" ] \
+    || { echo "FAIL: $name did not scaffold Upcoming Prompts/retcon/" >&2; return 1; }
+  assert_file_contains "$work/Upcoming Prompts/retcon/README.md" "pre-answer sheet"
+
   # 3. STEP index stays byte-identical to the greenfield seed (slug-substituted).
   diff <(sed "s/{{PROJECT}}/$name/g" "$docs/templates/step-index-seed.md") \
        "$work/prompts/STEP-index.md" >/dev/null \
@@ -154,6 +159,10 @@ run_new_case() {
   assert_file_contains "$work/Code/$name-docs/overview.md" "PROJECT-STATUS: not-started"
   if ls "$work/Upcoming Prompts/"*STEP-1-PLAN.md >/dev/null 2>&1; then
     echo "FAIL: $name (new mode) unexpectedly seeded a STEP-1 PLAN" >&2
+    return 1
+  fi
+  if [ -d "$work/Upcoming Prompts/retcon" ]; then
+    echo "FAIL: $name (new mode) scaffolded the retcon scratch folder — would misrecover as retcon" >&2
     return 1
   fi
   assert_file_contains "$TMP_ROOT/$name.out" "interview you, propose a roadmap"


### PR DESCRIPTION
Establishes the **pre-answer-sheet convention** — the per-session hand-off retcon's harvest→confirm wrapper uses (the mechanics themselves land later). Scaffolds now, exercised when the wrapper's second half arrives.

### Template: `templates/retcon-preanswer-sheet.md`
Instead of interviewing a session cold, the harvest **drafts an answer to each of that session's decisions from reality** (the confirmed recon map, per-asset docs, running code), each row tagged with **provenance** and **confidence**; the confirm pass then walks every decision with the user before the clean `architecture/` doc is written. The convention is baked into the template:
- **One sheet per in-scope session**, keyed to that session's decision list — *not* a pre-written draft doc (which would anchor the user and force provenance into the final doc).
- **Transient** — provenance and confidence live *only* on the sheet, never leaking into the clean doc; discarded when STEP-1 lands.

### Scaffold: `Upcoming Prompts/retcon/`
`init.sh` (existing-codebase adoption only) now creates the scratch folder with a short README. This gives the per-session sheets a home and makes the `AGENTS.md` marker-loss fallback signal reliable from adoption start. Greenfield never creates it.

### Tests
`tests/init-retcon-mode.sh` now asserts the folder is **present under adoption** and **absent under greenfield** (so greenfield can't be misrecovered as a retcon).

### Migration
Adds a bullet under the accumulating `### 2.0 migration` section: template + scaffold are **adoption-only and greenfield-inert**, no action on upgrade.

Full local suite passes (the one unrelated failure is a pre-existing untracked `marketing/` folder at the workspace root, not part of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
