### PR TITLE
Harden the retcon resolver: substep state, resume-safety, and risk seeding

### DIFF
--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -130,11 +130,23 @@ rather than guessing it into fact.
 
 ### `inv-5` — Upgrade this PLAN by addition
 The confirmed map now fixes both the asset list and which sessions apply. Edit
-`Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md`: mark `inv-1`…`inv-4` **Done**, and **below the upgrade
-marker append — never rewrite what is above**:
+`Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md`: mark `inv-1`…`inv-5` **Done** (this substep included,
+so a resumed agent doesn't re-run the upgrade), and **below the upgrade marker append — never rewrite
+what is above**:
 
-- **Per-asset substeps** — one free-form unit per asset, so nothing is lost: one per **repo**, plus
-  one per **doc-set** and per **resource**.
+- **Per-asset substeps** — the confirmed **Inventory** (from the recon map) projected into work
+  units: one **row per asset**, tracked in their own table below the marker (its own columns — not
+  the `inv-N` table's — but the same `Planned` · `In progress` · `Done` Status convention, so a
+  resumed agent can tell which are left). Number them `asset-1`, `asset-2`, … in discovery order — one
+  per **repo**, one per **doc-set** (related docs grouped), one per **resource**:
+
+  | # | Asset | Kind | Status |
+  |---|-------|------|--------|
+  | `asset-1` | {{name}} | repo / doc-set / resource | Planned |
+
+  This is a **tracker, not a second catalog** — no Location/Notes column: the descriptive detail
+  (location, role, notes) stays in the recon map's frozen Inventory, and the deliverable each substep
+  produces lands in `repos.yml` / the repo README / the recon-map detail (see below), never in the cell.
 - **The in-scope architecture sessions `1.1`–`1.14`** — the STEP-1 substep mirror; these run the
   harvest→confirm wrapper (Stage 3).
 - **The `Conditional sessions considered` table** — seed it the way greenfield does (see the
@@ -142,10 +154,20 @@ marker append — never rewrite what is above**:
   client/mobile surface → `conditional-native-app`, any authentication → `conditional-identity-auth`,
   PII → `conditional-privacy-compliance`. Seed now; refine as sessions harvest.
 
-Then resolve the lowest open appended substep — the first per-asset substep.
+**Seed `registries/risks.yml` from the confirmed map.** Give each genuinely-risky item in the map's
+**Confidence & Unknowns** / **Coverage & Confidence** sections a `risks.yml` row with a revisit
+trigger, so the check-in re-surfaces it. During adoption the risk lives in `risks.yml` **only** — do
+**not** add a `Planned` backfill STEP to `prompts/STEP-index.md`; the index stays at its greenfield
+seed until the baseline lands (see *How this prompt works*), when a deferred area becomes ordinary
+forward work like any other risk.
+
+**Resolution order.** Resolve the **lowest-open `asset-N`** per-asset substep first; only when every
+`asset-N` is `Done` does the lowest open substep become the first architecture session (`1.1`, Stage
+3). So the next action now is the first per-asset substep, `asset-1`.
 
 ### The per-asset substeps (depth)
-Resolve each in turn (lowest open). Reading one asset at a time keeps even a 20-repo system legible.
+Resolve each in turn — the **lowest-open `asset-N`** (Status ≠ `Done`); mark its row `Done` once the
+asset is recorded. Reading one asset at a time keeps even a 20-repo system legible.
 
 - **Per repo** — register it in `registries/repos.yml` (a row: real `location`, `type`, and
   `throughstone: managed`), stamp a Throughstone README from `templates/repo-readme-template.md`, and

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -64,18 +64,22 @@ the way — not a pretty description a mature team already knows.
 | inv-2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces); each existing doc classified with a trust level. | Planned |
 | inv-3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
 | inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
-| inv-5 | Upgrade this PLAN | Mark inv-1–inv-4 `Done`; **append** (never rewrite) the per-asset substeps + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table. | Planned |
+| inv-5 | Upgrade this PLAN | Mark inv-1–inv-5 `Done` (this row included); **append** (never rewrite) the per-asset substeps (`asset-N` id + Status) + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table; seed `registries/risks.yml` from the confirmed map's unknowns/coverage. | Planned |
 
 <!-- ═══════════════════════════════════════════════════════════════════════════════
      Everything ABOVE is the seed init.sh dropped. Once the inventory is CONFIRMED
      (substep inv-4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
      the above. It marks inv-1–inv-5 Done and APPENDS, below this line:
-       • the per-asset substeps — one per repo/doc-set/resource, free-form units, each
-         documenting one asset so nothing is lost (a repo is not a 1.N session);
+       • the per-asset substeps — one row per repo/doc-set/resource in their own
+         `# | Asset | Kind | Status` table (`asset-N` ids; same Status tracking as the inv-N
+         table above), each documenting one asset so nothing is lost (a repo is not a 1.N
+         session); resolve the lowest-open `asset-N` before 1.1;
        • the in-scope architecture sessions 1.1–1.14 (the harvest→confirm wrapper);
        • the `Conditional sessions considered` table — seeded from code-visible surfaces
          (client surfaces, PII, auth) and refined as sessions harvest, exactly as
-         greenfield seeds-then-refines it.
+         greenfield seeds-then-refines it;
+       • `registries/risks.yml` rows seeded from the confirmed map's Confidence & Unknowns /
+         Coverage & Confidence (genuinely-risky items only; STEP-index stays at its seed).
      That upgraded PLAN — at this same path, Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md —
      is the STEP-1 PLAN the Cross-Cutting Review's Check 1 and every future check-in read.
      See RETCON-PROMPT.md.
@@ -98,8 +102,9 @@ the way — not a pretty description a mature team already knows.
 ## Definition of done (inventory phase)
 - [ ] inv-1–inv-4 complete: intake recorded, everything inventoried, the recon map drafted and
       **confirmed by the user**.
-- [ ] inv-5 complete: this PLAN upgraded by addition — per-asset substeps + the in-scope 1.1–1.14
-      sessions + the `Conditional sessions considered` table appended; inv-1–inv-5 marked `Done`.
+- [ ] inv-5 complete: this PLAN upgraded by addition — per-asset substeps (`asset-N` id + Status) + the
+      in-scope 1.1–1.14 sessions + the `Conditional sessions considered` table appended; inv-1–inv-5
+      marked `Done`; `registries/risks.yml` seeded from the confirmed map (STEP-index untouched).
 - [ ] Next action is the lowest open **appended** substep (the per-session harvest→confirm wrapper).
       The overall STEP-1 baseline lands later, after the Cross-Cutting Review (see the retcon
       baseline note above).


### PR DESCRIPTION
Three correctness fixes to the existing-codebase adoption resolver, found in a review of the map+plan spine before the harvest sessions build on it.

## What & why

1. **Resume-safety loop.** The PLAN-upgrade substep told the agent to mark the *earlier* substeps Done but never itself — so a resumed agent in a fresh chat would see it still open and re-run the upgrade (the one "append, never rewrite" step). It now marks itself Done too.

2. **Per-asset substeps had no progress state.** The per-asset units appended to the STEP-1 PLAN were free-form, with no id or Status — so "resolve the lowest open substep" was undefined across a chat boundary (exactly the many-repo resume case the one-asset-at-a-time design exists for). Each is now a table row with an `aN` id + Status column, mirroring the inventory substeps, plus an explicit resolution order (lowest-open `aN` before the first architecture session).

3. **Recon map → `risks.yml` seeding was asserted but never actuated.** The recon-map template promised the map's unknowns seed `registries/risks.yml`, but no step did it. The PLAN-upgrade substep now seeds `risks.yml` from the confirmed map's Confidence & Unknowns / Coverage & Confidence (genuinely-risky items only, each with a revisit trigger). Scoped deliberately: only the `risks.yml` row — the STEP index stays at its adoption seed until the baseline lands, so no `Planned` STEP is added mid-adoption. That boundary is now stated in-prose.

## Files
- `Code/{{PROJECT}}-docs/RETCON-PROMPT.md`
- `Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md`

## Verification
- `tests/links.sh` — PASS
- `tests/init-retcon-mode.sh` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
