### PR TITLE
Fix five frictions found running the adoption resolver end-to-end

### DIFF
--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -32,9 +32,9 @@ The work runs in stages, each a set of PLAN substeps:
 - **Stage 1 — Intake** (`inv-1`) — frame the adoption. Below.
 - **Stage 2 — Map + plan** (`inv-2`…`inv-5`, then the per-asset substeps) — scan and inventory, draft
   the recon map, the user confirms it, upgrade this PLAN by addition, then document each asset. Below.
-- **Stage 3 — Harvest→confirm** the architecture sessions (`1.1`–`1.14`), then the Cross-Cutting
-  Review and land. *Forthcoming in the next build increment; until it lands, Stages 1–2 are the
-  resolvable work.*
+- **Stage 3 — Harvest→confirm** the architecture sessions `1.1`–`1.13`, then the Cross-Cutting
+  Review (`1.14`) and land. *Forthcoming in the next build increment; until it lands, Stages 1–2 are
+  the resolvable work.*
 
 When the baseline lands (after the Cross-Cutting Review), STEP-1 becomes an ordinary `Done` row marked
 **RETCON**, `PROJECT-STATUS` flips to `kickoff-complete`, and from that instant this is ordinary
@@ -147,16 +147,17 @@ what is above**:
   This is a **tracker, not a second catalog** — no Location/Notes column: the descriptive detail
   (location, role, notes) stays in the recon map's frozen Inventory, and the deliverable each substep
   produces lands in `repos.yml` / the repo README / the recon-map detail (see below), never in the cell.
-- **The in-scope architecture sessions `1.1`–`1.14`** — the STEP-1 substep mirror; these run the
-  harvest→confirm wrapper (Stage 3).
+- **The in-scope architecture sessions `1.1`–`1.14`** — the STEP-1 substep mirror. `1.1`–`1.13` run
+  the harvest→confirm wrapper (Stage 3); `1.14` is the Cross-Cutting Review + land, not a harvest.
 - **The `Conditional sessions considered` table** — seed it the way greenfield does (see the
   Conditional-sessions note in `templates/step-index-seed.md`), but from **code-visible surfaces**: a
   client/mobile surface → `conditional-native-app`, any authentication → `conditional-identity-auth`,
   PII → `conditional-privacy-compliance`. Seed now; refine as sessions harvest.
 
-**Seed `registries/risks.yml` from the confirmed map.** Give each genuinely-risky item in the map's
-**Confidence & Unknowns** / **Coverage & Confidence** sections a `risks.yml` row with a revisit
-trigger, so the check-in re-surfaces it. During adoption the risk lives in `risks.yml` **only** — do
+**Seed `registries/risks.yml` from the confirmed map.** Give each genuinely-risky item the map
+surfaces — in **Confidence & Unknowns**, **Coverage & Confidence**, **Tests & CI** (e.g. no tests or
+an empty CI gate on a shipped system), or anywhere else — a `risks.yml` row with a revisit trigger,
+so the check-in re-surfaces it. During adoption the risk lives in `risks.yml` **only** — do
 **not** add a `Planned` backfill STEP to `prompts/STEP-index.md`; the index stays at its greenfield
 seed until the baseline lands (see *How this prompt works*), when a deferred area becomes ordinary
 forward work like any other risk.
@@ -177,9 +178,13 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   point-in-time, the code wins on conflict) and write the Throughstone-shaped doc as a **pointer**
   where that fits. Architecture-grade docs get *lifted* into `architecture/` by their owning session
   later — that wiring is Stage 3; here, just land and classify them.
-- **Per resource** — feed the session that will own it, recording enough for its harvest to pick up:
-  data stores → `1.4`, infrastructure → `1.8`, environments → `1.9`, observability → `1.10`,
-  interface contracts → `1.11`.
+- **Per resource** — every non-repo, non-doc asset the inventory found gets a substep, feeding the
+  session that will own it (record enough for its harvest to pick up): data stores → `1.4`, services /
+  endpoints / interface surfaces → `1.11`, external integrations → `1.11`, infrastructure / deploy
+  surfaces / CI → `1.8`, environments → `1.9`, observability → `1.10`. **When in doubt, give it its
+  own substep** — a human can merge or dismiss one that turns out not to matter, but a resource with
+  no substep is easily forgotten. Group many-of-a-kind (e.g. 40 endpoints) into one substep to stay
+  legible; never silently drop a kind.
 
 When the per-asset substeps are done, the lowest open substep is the first architecture session
 (`1.1`) — **Stage 3, the per-session harvest→confirm wrapper** (RETCON-PROMPT's second half).

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -66,15 +66,38 @@ the way — not a pretty description a mature team already knows.
 | inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
 | inv-5 | Upgrade this PLAN | Mark inv-1–inv-5 `Done` (this row included); **append** (never rewrite) the per-asset substeps (`asset-N` id + Status) + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table; seed `registries/risks.yml` from the confirmed map's unknowns/coverage. | Planned |
 
+### Intake results (inv-1)
+<!-- WHAT THIS IS. The record of the four framing answers RETCON-PROMPT.md's Stage 1 (Intake)
+     collects before any scanning. Stage 1 fills these in place (replacing the {{placeholders}});
+     Stage 2 reads them — the locations tell it where to scan, the version convention tells it how to
+     stamp each doc's Version, and the depth posture is its default when it meets a fat payload.
+
+     Leave the placeholders until inv-1 runs. Two of the four are ALSO written to their permanent
+     homes — release stage to overview.md, the depth posture to the recon map's Coverage & Confidence
+     section — but they are echoed here so Stage 2 reads one working note instead of three files. This
+     block is the only free-text the agent adds above the marker; everything else above is init.sh's
+     seed, and the upgrade (inv-5) only appends below the marker. -->
+- **Locations:** {{repos / docs / resources — rough paths, URLs, hosts; and who can answer questions
+  about each}}
+- **Lifecycle / release stage:** {{pre-launch / shipped / mature — a short prose descriptor, e.g.
+  "public GA" or "internal alpha, ~20 users"; also written to `overview.md`}}
+- **House version convention:** {{the scheme docs should respect — calendar / product-line / semantic
+  / none; note per-repo if the repos differ}}
+- **Depth-dial posture:** {{the default for how hard to push fat payloads — Full (enumerate & confirm
+  everything) or economical when payloads are enormous; refined per fat payload in Stage 2/3, with the
+  human escalation as the real control}}
+
 <!-- ═══════════════════════════════════════════════════════════════════════════════
      Everything ABOVE is the seed init.sh dropped. Once the inventory is CONFIRMED
      (substep inv-4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
-     the above. It marks inv-1–inv-5 Done and APPENDS, below this line:
+     the above (the only in-place fill-ins there are Stage 1's Intake-results values and
+     flipping a substep's Status to Done). It marks inv-1–inv-5 Done and APPENDS, below this line:
        • the per-asset substeps — one row per repo/doc-set/resource in their own
          `# | Asset | Kind | Status` table (`asset-N` ids; same Status tracking as the inv-N
          table above), each documenting one asset so nothing is lost (a repo is not a 1.N
          session); resolve the lowest-open `asset-N` before 1.1;
-       • the in-scope architecture sessions 1.1–1.14 (the harvest→confirm wrapper);
+       • the in-scope architecture sessions 1.1–1.14 (1.1–1.13 harvest→confirm; 1.14 is the
+         Cross-Cutting Review + land, not a harvest);
        • the `Conditional sessions considered` table — seeded from code-visible surfaces
          (client surfaces, PII, auth) and refined as sessions harvest, exactly as
          greenfield seeds-then-refines it;
@@ -90,7 +113,7 @@ the way — not a pretty description a mature team already knows.
   local-profile questions from `BOOTSTRAP-PROMPT.md` Stage 0, create it, and continue. Don't copy
   either value into this PLAN.
 - **STEP-1 is docs-only — no application code.** Retcon may create Markdown and scaffolding
-  (a {{PROJECT}} README per adopted repo, `registries/` rows, `architecture/` docs), but never
+  (a Throughstone-shaped README per adopted repo, `registries/` rows, `architecture/` docs), but never
   rewrites the user's codebase. It adopts the existing one.
 - **Detect-then-confirm.** Propose an inventory; let the user correct it. Existing repos are
   registered **in place** by their real `location` (not relocated).


### PR DESCRIPTION
Fixes five friction points found by running the existing-codebase adoption resolver end-to-end against a real 2-repo fixture (mobile app + backend) — the map+plan stage had never actually executed before, only shipped as prose.

## Fixes

1. **Session range** — the harvest→confirm wrapper is `1.1`–`1.13`; `1.14` is the Cross-Cutting Review + land, not a harvest. The prose said "harvest `1.1`–`1.14`, then the Cross-Cutting Review," double-counting `1.14`.

2. **Intake results have a home** — Stage 1 records four things (locations, lifecycle, version convention, depth posture) "in the PLAN," but the stub had no slot for them. Added a labeled placeholder section with a detailed description — what each field is, how Stage 1 fills it and Stage 2 reads it, and why it persists (two of the four are echoed from their permanent homes so Stage 2 reads one note, not three files). The marker comment now names the sanctioned in-place fill-ins so it doesn't read as violating "never rewrite above."

3. **Per-asset "resource" broadened** — now explicitly covers services/endpoints, integrations, and CI/deploy (each mapped to its owning session), with a rule: when unsure, give an asset its own substep — a human can merge or dismiss one, but a dropped asset gets forgotten. Group many-of-a-kind to stay legible.

4. **`risks.yml` seeding** — now also reads the recon map's Tests & CI section (e.g. no tests or an empty CI gate on a shipped system), not only Confidence & Unknowns / Coverage & Confidence.

5. **Grammar** — reword "a `{{PROJECT}}` README" to "a Throughstone-shaped README" — article-safe once the slug is substituted, and more accurate (it is the Throughstone README shape stamped into each repo).

## Files
- `Code/{{PROJECT}}-docs/RETCON-PROMPT.md`
- `Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md`

## Verification
- `tests/links.sh`, `tests/init-retcon-mode.sh` — PASS
- Fresh `init.sh --mode=existing` generation with the updated stub: placeholder section renders and substitutes; generated project passes `check.sh` (0/0) and `links.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
