### PR TITLE
Retcon: verification-review fixes for the adoption resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ a project stood up from scratch behaves exactly as before.
   `PROJECT-STATUS: retcon`, seeds the greenfield-identical STEP index, and drops a stub **STEP-1 PLAN**
   whose substeps are the inventory work. `scripts/status.sh` and `AGENTS.md` recognize the `retcon`
   status and route a fresh agent to a new **`RETCON-PROMPT.md`** resolver, which reverse-engineers the
-  architecture baseline from the running code (inventory → recon map → per-session harvest, each decision
-  confirmed with you) instead of interviewing it from scratch — landing at a `Done STEP-1` baseline
-  equivalent to a greenfield one, from which the ordinary forward flow continues. **Default mode is
-  `new`**; a project stood up from scratch never enters this path and is unchanged.
+  architecture baseline from the running code instead of interviewing it from scratch — running the
+  intake, inventorying every repo/doc/resource, drafting a recon map you confirm, and writing the real
+  STEP-1 plan. The per-session harvest→confirm and the land at a `Done STEP-1` baseline (equivalent to a
+  greenfield one, from which the ordinary forward flow continues) arrive in the remaining 2.0
+  increments. **Default mode is `new`**; a project stood up from scratch never enters this path and is
+  unchanged.
 - **`throughstone:` field on repo rows** (`registries/repos.yml`) — records how the method relates to
   each repo (`managed` today; `external` reserved for a later partial-adoption feature). Inert
   (nothing reads it yet) and read as `managed` when absent, so existing inventories are unaffected.
@@ -33,7 +35,7 @@ a project stood up from scratch behaves exactly as before.
   `reports/README.md`) — the point-in-time "birth certificate" an adoption produces at STEP-1:
   inventory, stack per repo, services, data stores, integrations, existing-docs classification,
   tests/CI, and a Coverage & Confidence ledger. The user confirms it before anything is built on it,
-  and it is frozen afterward. A greenfield project never produces one.
+  and its confirmed inventory is frozen afterward. A greenfield project never produces one.
 - **Pre-answer-sheet convention** (`templates/retcon-preanswer-sheet.md`) — the per-session working
   sheet an adoption's harvest writes: a drafted answer to each session decision, read from the running
   code and provenance-tagged, confirmed with the user before the clean `architecture/` doc is written.

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -89,6 +89,11 @@ with or without the session label (preferred with the label, e.g.
 interview the user one decision at a time, then write the output architecture doc and update
 `prompts/STEP-index.md`. No copy-paste, no special commands.
 
+> **Adoption exception:** if `overview.md` reads `PROJECT-STATUS: retcon`, do **not** cold-interview a
+> session here — the project is adopting an existing codebase. Follow `RETCON-PROMPT.md` instead; it
+> reads the session files as reference data to harvest from the running code, never by triggering
+> their interview.
+
 **"STEP-1.N", "Run STEP-1.N: <session label>", "session N.M", and "Run session N.M:
 <session label>" are all the user's go-ahead — begin in that same reply.** Don't
 acknowledge, summarize the file, restate the plan, or ask whether to start (no "Ready when

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -147,12 +147,14 @@ The confirmed map now fixes both the asset list and which sessions apply. Edit
 `Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md`: **append at the END of the PLAN (after Definition of
 done) — never rewrite the seed above.** Do the appends *first*, then mark `inv-5` **Done** last, as
 the completion flag. If a
-resumed agent finds `inv-5` still open, the upgrade was interrupted — re-run it **idempotently**:
-append only the blocks (asset table, `1.1`–`1.14` sessions, conditional table, `risks.yml` rows) not
-already present — and for the asset table, reconcile **row by row** against the frozen recon-map
-Inventory: append an `asset-N` row for **every** Inventory asset that lacks one (an earlier run may
-have written the table header and some rows but not all). Then mark `inv-5` **Done**. (`inv-1`…`inv-4`
-are already `Done` from as-you-go marking.) The appends:
+resumed agent finds `inv-5` still open, the upgrade was interrupted — re-run it **idempotently**,
+reconciling each block **row by row** rather than treating a present table header as a complete block
+(an earlier run may have written a header and some rows but not all): append an `asset-N` row for
+**every** frozen recon-map Inventory asset that lacks one; append any missing **session** row so the
+table holds the full fixed `1.1`–`1.14` set (a dropped tail would silently skip the Cross-Cutting
+Review); append any missing **conditional** row from the seeded set; and add any `risks.yml` row not
+already present. Then mark `inv-5` **Done**. (`inv-1`…`inv-4` are already `Done` from as-you-go
+marking.) The appends:
 
 - **Per-asset substeps** — the confirmed **Inventory** (from the recon map) projected into work
   units: one **row per asset**, tracked in their own appended table (its own columns — not
@@ -209,8 +211,9 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   record a short per-repo note (stack, entry points, role) in that README — its living home, which the
   owning `architecture/` docs deepen later (never back into the frozen recon map). Register repos
   **in place** by their real location; never relocate the user's code.
-- **Per doc-set** — copy the found source docs into `inputs/` and add an `inputs/inputs-index.md` row
-  (`Live`) for each, per the base inputs lifecycle (point-in-time; the code wins on conflict). Their
+- **Per doc-set** — copy the found source docs into `inputs/` and add each one's
+  `inputs/inputs-index.md` row(s) (`Live`), per the base inputs lifecycle (point-in-time; the code
+  wins on conflict). Their
   classification and trust already live in the frozen recon map — don't restate them. That is the
   whole Stage-2 deliverable for a doc-set: **land and record, nothing more.** Architecture-grade docs
   (a finished design doc, a protocol/API spec) get *lifted* into `architecture/` later by their owning

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -126,8 +126,9 @@ and fill every section from the scan: inventory, stack per repo, entry points/se
 integrations, existing-docs classification + trust, tests/CI, and the confidence/unknowns. Stamp the
 front matter too — **Reviewed commit(s)** (the `repo@sha` state this map describes) and **Depth dial**
 — so the snapshot is pinned to an exact point in time. Set the **Coverage & Confidence** section from
-intake — the depth-dial posture and any areas you are already choosing to bound. Leave `Status: Draft`.
-Mark `inv-3` **Done** once the draft is written.
+intake — the depth-dial posture and any areas you are already choosing to bound. Write the **Summary**
+last — a few sentences on what the system is, the shape of the inventory, and the biggest unknowns.
+Leave `Status: Draft`. Mark `inv-3` **Done** once the draft is written.
 
 ### `inv-4` — Confirm the recon map  ▸ checkpoint
 **Detect, then confirm.** Present the draft and let the user correct it — this is the one hard gate,
@@ -165,8 +166,17 @@ marking.) The appends:
   (location, role, notes) stays in the recon map's frozen Inventory, and the deliverable each substep
   produces lands in its living home — `repos.yml`, the repo README, or an `architecture/` / `inputs/`
   doc (see below) — never in the cell.
-- **The in-scope architecture sessions `1.1`–`1.14`** — the STEP-1 substep mirror. `1.1`–`1.13` run
-  the harvest→confirm wrapper (Stage 3); `1.14` is the Cross-Cutting Review + land, not a harvest.
+- **The in-scope architecture sessions `1.1`–`1.14`** — the STEP-1 substep mirror, in their own
+  appended table with the **same `Planned` · `In progress` · `Done` Status convention** as the
+  `inv-N` and `asset-N` tables, so a resumed agent resolves the lowest-open session across a chat
+  boundary. Session progress lives **here in the PLAN**: during adoption `prompts/STEP-index.md` is
+  held at its greenfield seed (see the risks.yml paragraph below), so it cannot track which session is
+  done. `1.1`–`1.13` run the harvest→confirm wrapper (Stage 3); `1.14` is the Cross-Cutting Review +
+  land, not a harvest.
+
+  | Substep | Session | Status |
+  |---------|---------|--------|
+  | `1.1` | {{session name}} | Planned |
 - **The `Conditional sessions considered` table** — mirror the `Conditional sessions considered`
   table greenfield authors from `templates/step-plan-template.md` (its columns and its seeded rows),
   but decide each row from **code-visible surfaces**: a client/mobile surface →
@@ -184,8 +194,9 @@ seed until the baseline lands (see *How this prompt works*), when a deferred are
 forward work like any other risk.
 
 **Resolution order.** Resolve the **lowest-open `asset-N`** per-asset substep first; only when every
-`asset-N` is `Done` does the lowest open substep become the first architecture session (`1.1`, Stage
-3). So the next action now is the first per-asset substep, `asset-1`.
+`asset-N` is `Done` does the lowest open substep become the first architecture session — the
+**lowest-open `1.N`** (Status ≠ `Done`), starting at `1.1` (Stage 3). So the next action now is the
+first per-asset substep, `asset-1`.
 
 ### The per-asset substeps (depth)
 Resolve each in turn — the **lowest-open `asset-N`** (Status ≠ `Done`); mark its row `Done` once the

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -149,8 +149,10 @@ done) — never rewrite the seed above.** Do the appends *first*, then mark `inv
 the completion flag. If a
 resumed agent finds `inv-5` still open, the upgrade was interrupted — re-run it **idempotently**:
 append only the blocks (asset table, `1.1`–`1.14` sessions, conditional table, `risks.yml` rows) not
-already present, then mark `inv-5` **Done**. (`inv-1`…`inv-4` are already `Done` from as-you-go
-marking.) The appends:
+already present — and for the asset table, reconcile **row by row** against the frozen recon-map
+Inventory: append an `asset-N` row for **every** Inventory asset that lacks one (an earlier run may
+have written the table header and some rows but not all). Then mark `inv-5` **Done**. (`inv-1`…`inv-4`
+are already `Done` from as-you-go marking.) The appends:
 
 - **Per-asset substeps** — the confirmed **Inventory** (from the recon map) projected into work
   units: one **row per asset**, tracked in their own appended table (its own columns — not
@@ -207,10 +209,12 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   record a short per-repo note (stack, entry points, role) in that README — its living home, which the
   owning `architecture/` docs deepen later (never back into the frozen recon map). Register repos
   **in place** by their real location; never relocate the user's code.
-- **Per doc-set** — save found source docs into `inputs/` (they ride the base inputs lifecycle:
-  point-in-time, the code wins on conflict) and write the Throughstone-shaped doc as a **pointer**
-  where that fits. Architecture-grade docs get *lifted* into `architecture/` by their owning session
-  later — that wiring is Stage 3; here, just land and classify them.
+- **Per doc-set** — copy the found source docs into `inputs/` and add an `inputs/inputs-index.md` row
+  (`Live`) for each, per the base inputs lifecycle (point-in-time; the code wins on conflict). Their
+  classification and trust already live in the frozen recon map — don't restate them. That is the
+  whole Stage-2 deliverable for a doc-set: **land and record, nothing more.** Architecture-grade docs
+  (a finished design doc, a protocol/API spec) get *lifted* into `architecture/` later by their owning
+  session — that wiring is Stage 3, not here.
 - **Per resource** — every non-repo, non-doc asset the inventory found gets a substep, feeding the
   session that will own it (record enough for its harvest to pick up): data stores → `1.4`; API /
   interface surfaces (HTTP/RPC endpoints, published contracts) → `1.11`; other runnable surfaces
@@ -226,3 +230,11 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
 When the per-asset substeps are done, the lowest open substep is the first architecture session
 (`1.1`) — **Stage 3, the per-session harvest→confirm wrapper** (RETCON-PROMPT's second half).
 *Forthcoming in the next build increment; until it lands, Stage 2 is the resolvable work.*
+
+> **When you reach `1.1` and Stage 3 is not present in this prompt, STOP.** Report that the inventory
+> baseline (Stages 1–2) is complete and the harvest→confirm sessions are pending a future build
+> increment, then wait. **Do NOT** run the architecture sessions from
+> `templates/architecture-sessions/` — those are the greenfield **cold-interview** files, and running
+> one against an adopted codebase would interview the architecture from scratch, exactly what retcon
+> exists to avoid. (When Stage 3 lands it will drive `1.1`–`1.13` as a harvest that reads those files
+> as reference data, never by triggering their interview.)

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -25,7 +25,9 @@ Retcon runs like greenfield: the next action is always derivable from disk. Ther
 PLAN-driven resolver** — this prompt — reading the in-flight **STEP-1 PLAN** at
 `Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md` (a stub `init.sh` seeded; its substeps are the
 inventory work). **Resolve the lowest open substep** and do it — that is your next action, mid-inventory
-included, in a fresh chat or a resumed one.
+included, in a fresh chat or a resumed one. **Mark each substep `Done` in the PLAN the moment its work
+completes, before resolving the next** — that as-you-go marking is what makes "the lowest open substep"
+land on the right next action after any interruption.
 
 The work runs in stages, each a set of PLAN substeps:
 
@@ -97,10 +99,13 @@ each concrete depth call in the recon map's Coverage & Confidence section.
 > per doc, from how settled the harvested reality is (a confirmed as-built doc is typically
 > **`Current`**, whether or not the product has shipped).
 
-**Record + advance.** Write the release-stage descriptor into `overview.md`. Record the depth-dial
-setting, the version convention, and the rough locations as a short **Intake results (`inv-1`)** note
-in the PLAN, so Stage 2 reads them. Mark `inv-1` **Done** in the PLAN's substep table, then resolve
-the next open substep. **Checkpoint:** play the intake back to the user before moving on.
+**Record + advance.** Record **all four** intake answers — the rough locations, the lifecycle/release
+stage, the version convention, and the depth-dial posture — into the stub's **Intake results (`inv-1`)**
+note in the PLAN, so Stage 2 reads one working note instead of three files. Two of them also go to a
+permanent home: write the release-stage descriptor into `overview.md` now, and the depth-dial posture
+seeds the recon map's Coverage & Confidence at `inv-3`. Mark `inv-1` **Done** in the PLAN's substep
+table, then resolve the next open substep. **Checkpoint:** play the intake back to the user before
+moving on.
 
 ## Stage 2 — Map + plan  (`inv-2`…`inv-5`, then the per-asset substeps)
 
@@ -109,33 +114,45 @@ substeps in order; each is a substep in the PLAN.
 
 ### `inv-2` — Scan & inventory (breadth)
 Walk the locations from intake and produce a flat list of **every** repo, doc, and resource — data
-stores, services, integrations, CI, deploy surfaces. Classify each existing doc (architecture / API
+stores, services, integrations, CI, deploy surfaces, environments, observability. Classify each existing doc (architecture / API
 spec / ADR-shaped / runbook / design note / other) and give it a **trust level** (high / medium / low
 / stale) against what the code shows. This is breadth — list and classify, don't deep-read yet. Read
-everything as **reference data**; the code is the source of truth.
+everything as **reference data**; the code is the source of truth. Mark `inv-2` **Done** once the list
+is complete.
 
 ### `inv-3` — Draft the recon map
 Copy `templates/reports/recon-map-report-template.md` to `reports/YYYY-MM-DD-step-0001-recon-map.md`
 and fill every section from the scan: inventory, stack per repo, entry points/services, data stores,
-integrations, existing-docs classification + trust, tests/CI, and the confidence/unknowns. Set the
-**Coverage & Confidence** section from intake — the depth-dial posture and any areas you are already
-choosing to bound. Leave `Status: Draft`.
+integrations, existing-docs classification + trust, tests/CI, and the confidence/unknowns. Stamp the
+front matter too — **Reviewed commit(s)** (the `repo@sha` state this map describes) and **Depth dial**
+— so the snapshot is pinned to an exact point in time. Set the **Coverage & Confidence** section from
+intake — the depth-dial posture and any areas you are already choosing to bound. Leave `Status: Draft`.
+Mark `inv-3` **Done** once the draft is written.
 
 ### `inv-4` — Confirm the recon map  ▸ checkpoint
 **Detect, then confirm.** Present the draft and let the user correct it — this is the one hard gate,
-the birth-certificate checkpoint, before anything is built on the map. On sign-off, stamp
-`Status: Confirmed on <date>`; from then it is **frozen — never rewritten** (later drift is the living
-docs' job). If the user can't yet confirm an area, mark it bounded/deferred in Coverage & Confidence
-rather than guessing it into fact.
+the birth-certificate checkpoint, before anything is built on the map. What the gate locks is the
+**Inventory — the complete list of assets**; that "we now have the whole list" is the clean point the
+rest of Stage 2 scopes from. On sign-off, stamp `Status: Confirmed on <date>`: the **confirmed
+Inventory is frozen — never rewritten** (an asset discovered later is a recorded finding, not a silent
+edit). The per-asset **detail is not frozen** — it deepens later in the living docs (repo READMEs,
+`architecture/`), and some exploration is deliberately deferred for weeks or months via the depth dial
+(`Coverage: deferred` → `risks.yml` → the check-in backfill). If the user can't yet confirm an area,
+mark it bounded/deferred in Coverage & Confidence rather than guessing it into fact. Once the map is
+confirmed and frozen, mark `inv-4` **Done**.
 
 ### `inv-5` — Upgrade this PLAN by addition
 The confirmed map now fixes both the asset list and which sessions apply. Edit
-`Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md`: mark `inv-1`…`inv-5` **Done** (this substep included,
-so a resumed agent doesn't re-run the upgrade), and **below the upgrade marker append — never rewrite
-what is above**:
+`Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md`: **append at the END of the PLAN (after Definition of
+done) — never rewrite the seed above.** Do the appends *first*, then mark `inv-5` **Done** last, as
+the completion flag. If a
+resumed agent finds `inv-5` still open, the upgrade was interrupted — re-run it **idempotently**:
+append only the blocks (asset table, `1.1`–`1.14` sessions, conditional table, `risks.yml` rows) not
+already present, then mark `inv-5` **Done**. (`inv-1`…`inv-4` are already `Done` from as-you-go
+marking.) The appends:
 
 - **Per-asset substeps** — the confirmed **Inventory** (from the recon map) projected into work
-  units: one **row per asset**, tracked in their own table below the marker (its own columns — not
+  units: one **row per asset**, tracked in their own appended table (its own columns — not
   the `inv-N` table's — but the same `Planned` · `In progress` · `Done` Status convention, so a
   resumed agent can tell which are left). Number them `asset-1`, `asset-2`, … in discovery order — one
   per **repo**, one per **doc-set** (related docs grouped), one per **resource**:
@@ -144,15 +161,19 @@ what is above**:
   |---|-------|------|--------|
   | `asset-1` | {{name}} | repo / doc-set / resource | Planned |
 
-  This is a **tracker, not a second catalog** — no Location/Notes column: the descriptive detail
+  This is a **tracker, not a second catalog** — no Location/Notes column: the breadth detail
   (location, role, notes) stays in the recon map's frozen Inventory, and the deliverable each substep
-  produces lands in `repos.yml` / the repo README / the recon-map detail (see below), never in the cell.
+  produces lands in its living home — `repos.yml`, the repo README, or an `architecture/` / `inputs/`
+  doc (see below) — never in the cell.
 - **The in-scope architecture sessions `1.1`–`1.14`** — the STEP-1 substep mirror. `1.1`–`1.13` run
   the harvest→confirm wrapper (Stage 3); `1.14` is the Cross-Cutting Review + land, not a harvest.
-- **The `Conditional sessions considered` table** — seed it the way greenfield does (see the
-  Conditional-sessions note in `templates/step-index-seed.md`), but from **code-visible surfaces**: a
-  client/mobile surface → `conditional-native-app`, any authentication → `conditional-identity-auth`,
-  PII → `conditional-privacy-compliance`. Seed now; refine as sessions harvest.
+- **The `Conditional sessions considered` table** — mirror the `Conditional sessions considered`
+  table greenfield authors from `templates/step-plan-template.md` (its columns and its seeded rows),
+  but decide each row from **code-visible surfaces**: a client/mobile surface →
+  `conditional-native-app`, any authentication → `conditional-identity-auth`, PII →
+  `conditional-privacy-compliance`. Seed now; refine as sessions harvest. (If an included conditional
+  later earns a lettered `1.Xa` STEP-index row + doc number, follow the Conditional-sessions note in
+  `templates/step-index-seed.md` for that.)
 
 **Seed `registries/risks.yml` from the confirmed map.** Give each genuinely-risky item the map
 surfaces — in **Confidence & Unknowns**, **Coverage & Confidence**, **Tests & CI** (e.g. no tests or
@@ -172,19 +193,24 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
 
 - **Per repo** — register it in `registries/repos.yml` (a row: real `location`, `type`, and
   `throughstone: managed`), stamp a Throughstone README from `templates/repo-readme-template.md`, and
-  record a short per-repo note (stack, entry points, role) in the recon map's detail. Register repos
+  record a short per-repo note (stack, entry points, role) in that README — its living home, which the
+  owning `architecture/` docs deepen later (never back into the frozen recon map). Register repos
   **in place** by their real location; never relocate the user's code.
 - **Per doc-set** — save found source docs into `inputs/` (they ride the base inputs lifecycle:
   point-in-time, the code wins on conflict) and write the Throughstone-shaped doc as a **pointer**
   where that fits. Architecture-grade docs get *lifted* into `architecture/` by their owning session
   later — that wiring is Stage 3; here, just land and classify them.
 - **Per resource** — every non-repo, non-doc asset the inventory found gets a substep, feeding the
-  session that will own it (record enough for its harvest to pick up): data stores → `1.4`, services /
-  endpoints / interface surfaces → `1.11`, external integrations → `1.11`, infrastructure / deploy
-  surfaces / CI → `1.8`, environments → `1.9`, observability → `1.10`. **When in doubt, give it its
-  own substep** — a human can merge or dismiss one that turns out not to matter, but a resource with
-  no substep is easily forgotten. Group many-of-a-kind (e.g. 40 endpoints) into one substep to stay
-  legible; never silently drop a kind.
+  session that will own it (record enough for its harvest to pick up): data stores → `1.4`; API /
+  interface surfaces (HTTP/RPC endpoints, published contracts) → `1.11`; other runnable surfaces
+  (workers, cron jobs, CLIs, functions) → `1.3`; external integrations → `1.11`; infrastructure /
+  deploy surfaces / CI-CD pipeline → `1.8`; CI test gates (suites/coverage that block merge) → `1.12`;
+  environments → `1.9`; observability → `1.10`. Routing names a **primary** home, not an exclusive one
+  — a resource may feed more than one session (an endpoint informs both `1.3` and `1.11`); the substep
+  just records it where its harvest will look first. **When in doubt, give it its own substep** — a
+  human can merge or dismiss one that turns out not to matter, but a resource with no substep is easily
+  forgotten. Group many-of-a-kind (e.g. 40 endpoints) into one substep to stay legible; never silently
+  drop a kind.
 
 When the per-asset substeps are done, the lowest open substep is the first architecture session
 (`1.1`) — **Stage 3, the per-session harvest→confirm wrapper** (RETCON-PROMPT's second half).

--- a/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
@@ -20,8 +20,11 @@
         then confirm — propose the inventory and let the user fix it. Editing is expected here, and
         ONLY here: while it is Draft.
      2. ONCE CONFIRMED IT IS FROZEN — never rewritten (confirmation seals it, and stamps the date).
-        Later reality-drift is the living docs' job (architecture/, registries/), not an edit to this
-        snapshot.
+        What confirmation locks is the INVENTORY — the complete list of assets — the clean point the
+        rest of Stage 2 is scoped from; a later-discovered asset is a recorded finding, not a silent
+        edit. Per-asset DETAIL is not frozen here: it deepens in the living docs this map feeds (repo
+        READMEs, architecture/, registries/), and deferred exploration rides the depth dial. Later
+        reality-drift is the living docs' job, not an edit to this snapshot.
 
      WHAT IT FEEDS (it is a seed, not a living artifact): the confirmed map seeds `registries/repos.yml`
      (one row per repo), the thin `architecture/` docs the sessions harvest, and — from Confidence &
@@ -38,7 +41,7 @@ Every repo, doc, and resource discovered — the breadth pass. One row per asset
 
 | Asset | Kind | Location | Notes |
 |-------|------|----------|-------|
-| {{name}} | {{repo / doc / data store / service / integration / CI / deploy surface / other}} | {{path / URL / host}} | {{one line — role, ownership, anything notable}} |
+| {{name}} | {{repo / doc / data store / service / integration / CI / deploy surface / environment / observability / other}} | {{path / URL / host}} | {{one line — role, ownership, anything notable}} |
 
 ## Stack Per Repo
 
@@ -100,9 +103,10 @@ trigger; the check-in re-surfaces them.
 
 ## Coverage & Confidence
 
-The frozen, dated record of how thoroughly this run read the system — the run-level "skimmed ≠
-covered" ledger (the first of three altitudes; the others are `registries/risks.yml` and each
-doc's `Coverage` / `Status`). Never asserted-but-shallow: an area is either read or listed here as
+The frozen, dated record of **what this run mapped and what it deliberately left for later** — the
+run-level coverage ledger of covered-vs-deferred, not a thoroughness score (some reading is deferred
+by design). The first of three altitudes; the others are `registries/risks.yml` and each doc's
+`Coverage` / `Status`. Never asserted-but-shallow: an area is either mapped here or listed as
 deferred, with a plain "what's missing and why it matters."
 
 - **Depth-dial setting:** {{the fat-payload depth chosen at intake, and why}}

--- a/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
@@ -93,9 +93,10 @@ Presence and shape of the safety net per repo — not a quality verdict, just wh
 
 ## Confidence & Unknowns
 
-What is still uncertain after the breadth pass — open questions, low-confidence reads, and areas
-not yet opened. Genuinely-risky unknowns are pushed to `registries/risks.yml` with a revisit
-trigger; the check-in re-surfaces them.
+What is still uncertain after the breadth pass — open questions and low-confidence reads that need a
+**next move** (harvest, or ask the user). A *deliberate* depth-dial deferral is not an unknown: it
+goes in **Coverage & Confidence** below, not here. Genuinely-risky unknowns are pushed to
+`registries/risks.yml` with a revisit trigger; the check-in re-surfaces them.
 
 | Unknown / low-confidence area | Why it matters | Confidence | Next move |
 |-------------------------------|----------------|------------|-----------|

--- a/Code/{{PROJECT}}-docs/templates/retcon-preanswer-sheet.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-preanswer-sheet.md
@@ -1,6 +1,6 @@
 # {{PROJECT}} — Pre-answer sheet: {{N.N — session name}}
 
-**Session:** `{{templates/architecture-sessions/NN-....md}}`   <!-- the in-scope session this sheet harvests -->
+**Session:** `{{templates/architecture-sessions/NN-....md}}`   <!-- the in-scope harvest session (1.1–1.13) this sheet covers -->
 **Harvested:** {{YYYY-MM-DD}}
 **Sources read:** {{the confirmed recon map + which per-asset docs / inputs / code paths}}
 **Status:** {{Harvested → Confirmed}}   <!-- Harvested when the answers are drafted from reality;
@@ -9,7 +9,8 @@
 <!-- WHAT THIS IS. A pre-answer sheet is retcon's per-session hand-off: instead of interviewing a
      session cold, the harvest DRAFTS an answer to each of that session's decisions FROM REALITY
      (the confirmed recon map, the per-asset docs, and the running code), and the confirm pass then
-     walks every decision with the user. One sheet per in-scope architecture session, keyed to that
+     walks every decision with the user. One sheet per in-scope harvest session (`1.1`–`1.13`; `1.14`
+     is the Cross-Cutting Review + land, not a harvest), keyed to that
      session's decision list — NOT a pre-written draft of the doc (a draft doc anchors the user and
      forces provenance into the final doc).
 
@@ -27,8 +28,9 @@
      2. CONFIRM (with the user): walk each row proportionate to confidence × consequence — a
         from-code answer gets a fast "right?", a low-confidence or load-bearing one a real
         discussion — and record the outcome in Confirm. Then write the clean `architecture/` doc at
-        the chosen Version/Status: confirmed → plain fact; deferred → `Coverage: deferred` + a
-        `registries/risks.yml` row.
+        its `Version` and `Status`. Record each decision by its Confirm outcome — independently of
+        those two doc axes: a confirmed decision as plain fact; a decision left unconfirmed as
+        `Coverage: deferred` with a `registries/risks.yml` row.
 
      TRANSIENT. Provenance and confidence live ONLY here — they never leak into the clean doc. The
      sheet is scratch in `Upcoming Prompts/retcon/`; it is discarded when STEP-1 lands (not archived

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -25,7 +25,10 @@ When adoption lands (after the Cross-Cutting Review), STEP-1 becomes an ordinary
 `prompts/STEP-index.md` marked **RETCON**, with the scope *"Retcon baseline — reverse-engineered
 from existing code; adopted {{DATE}}; forward work starts at STEP-2."* It archives greenfield-style
 into `prompts/001-<milestone>/step-0001/` (the folder name converges with greenfield), and a
-one-line provenance note goes in `overview.md` (*"Adopted via retcon on {{DATE}}"*).
+one-line provenance note goes in `overview.md` (*"Adopted via retcon on {{DATE}}"*). Landing also
+flips the STEP-index `1.1`–`1.14` architecture-session substeps to `Done` (they were held at the
+greenfield `Planned` seed while session progress lived here in the PLAN), so the landed project
+resolves like a greenfield baseline instead of re-running the sessions.
 To the resolver it is an ordinary architecture baseline needing no new logic: forward
 implementation starts at **STEP-2**, and the first forward planning session inserts a **baseline
 check-in** as STEP-2 — the full test suite this docs-only STEP-1 deliberately skips.
@@ -54,8 +57,9 @@ the way — not a pretty description a mature team already knows.
   `inputs/inputs-index.md` tracks what still holds vs. what observed reality has superseded).
 
 ## Substeps — the inventory work
-> Free-form inventory units (not the `1.1`–`1.14` session mirror, and not parsed by `status.sh` —
-> real progress lives here in the PLAN). Resolve the **lowest open** one, and mark it `Done` the moment
+> PLAN-local inventory substeps — tracked in the table below by Status, not the `1.1`–`1.14` session
+> mirror, and not parsed by `status.sh` (real progress lives here in the PLAN). Resolve the **lowest
+> open** one, and mark it `Done` the moment
 > its work completes (before resolving the next) so a resumed chat lands right. `RETCON-PROMPT.md`
 > drives each; see it for the detail.
 
@@ -65,7 +69,7 @@ the way — not a pretty description a mature team already knows.
 | inv-2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces, environments, observability); each existing doc classified with a trust level. | Planned |
 | inv-3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
 | inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
-| inv-5 | Upgrade this PLAN | **Append** (never rewrite) the per-asset substeps (`asset-N` id + Status) + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table; seed `registries/risks.yml` from the confirmed map's unknowns/coverage; then mark `inv-5` `Done` last (inv-1–inv-4 already `Done` from as-you-go marking). | Planned |
+| inv-5 | Upgrade this PLAN | **Append** (never rewrite) the per-asset substeps (`asset-N` id + Status) + the in-scope `1.1`–`1.14` sessions (`1.N` id + Status) + the `Conditional sessions considered` table; seed `registries/risks.yml` from the confirmed map's unknowns/coverage; then mark `inv-5` `Done` last (inv-1–inv-4 already `Done` from as-you-go marking). | Planned |
 
 ### Intake results (inv-1)
 <!-- WHAT THIS IS. The record of the four framing answers RETCON-PROMPT.md's Stage 1 (Intake)
@@ -98,8 +102,10 @@ the way — not a pretty description a mature team already knows.
          `# | Asset | Kind | Status` table (`asset-N` ids; same Status tracking as the inv-N
          table above), each documenting one asset so nothing is lost (a repo is not a 1.N
          session); resolve the lowest-open `asset-N` before 1.1;
-       • the in-scope architecture sessions 1.1–1.14 (1.1–1.13 harvest→confirm; 1.14 is the
-         Cross-Cutting Review + land, not a harvest);
+       • the in-scope architecture sessions 1.1–1.14 in their own table carrying the same
+         Planned/In progress/Done Status column as the inv-N/asset-N tables (session progress
+         lives here in the PLAN while STEP-index stays at its greenfield seed); 1.1–1.13
+         harvest→confirm; 1.14 is the Cross-Cutting Review + land, not a harvest;
        • the `Conditional sessions considered` table — seeded from code-visible surfaces
          (client surfaces, PII, auth) and refined as sessions harvest, exactly as
          greenfield seeds-then-refines it;
@@ -128,7 +134,7 @@ the way — not a pretty description a mature team already knows.
 - [ ] inv-1–inv-4 complete: intake recorded, everything inventoried, the recon map drafted and
       **confirmed by the user**.
 - [ ] inv-5 complete: this PLAN upgraded by addition — per-asset substeps (`asset-N` id + Status) + the
-      in-scope 1.1–1.14 sessions + the `Conditional sessions considered` table appended; `inv-5` marked
+      in-scope 1.1–1.14 sessions (`1.N` id + Status) + the `Conditional sessions considered` table appended; `inv-5` marked
       `Done` last (inv-1–inv-4 already `Done` from as-you-go marking); `registries/risks.yml` seeded
       from the confirmed map (STEP-index untouched).
 - [ ] Next action is the lowest open **appended** substep — the first per-asset substep (`asset-1`),

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -55,16 +55,17 @@ the way — not a pretty description a mature team already knows.
 
 ## Substeps — the inventory work
 > Free-form inventory units (not the `1.1`–`1.14` session mirror, and not parsed by `status.sh` —
-> real progress lives here in the PLAN). Resolve the **lowest open** one. `RETCON-PROMPT.md` drives
-> each; see it for the detail.
+> real progress lives here in the PLAN). Resolve the **lowest open** one, and mark it `Done` the moment
+> its work completes (before resolving the next) so a resumed chat lands right. `RETCON-PROMPT.md`
+> drives each; see it for the detail.
 
 | # | Title | Produces | Status |
 |---|-------|----------|--------|
 | inv-1 | Intake | Depth dial set; rough repo/doc/resource locations, the project's lifecycle stage, and any house version convention recorded (RETCON-PROMPT.md Stage 1). | Planned |
-| inv-2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces); each existing doc classified with a trust level. | Planned |
+| inv-2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces, environments, observability); each existing doc classified with a trust level. | Planned |
 | inv-3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
 | inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
-| inv-5 | Upgrade this PLAN | Mark inv-1–inv-5 `Done` (this row included); **append** (never rewrite) the per-asset substeps (`asset-N` id + Status) + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table; seed `registries/risks.yml` from the confirmed map's unknowns/coverage. | Planned |
+| inv-5 | Upgrade this PLAN | **Append** (never rewrite) the per-asset substeps (`asset-N` id + Status) + the in-scope `1.1`–`1.14` sessions + the `Conditional sessions considered` table; seed `registries/risks.yml` from the confirmed map's unknowns/coverage; then mark `inv-5` `Done` last (inv-1–inv-4 already `Done` from as-you-go marking). | Planned |
 
 ### Intake results (inv-1)
 <!-- WHAT THIS IS. The record of the four framing answers RETCON-PROMPT.md's Stage 1 (Intake)
@@ -75,8 +76,8 @@ the way — not a pretty description a mature team already knows.
      Leave the placeholders until inv-1 runs. Two of the four are ALSO written to their permanent
      homes — release stage to overview.md, the depth posture to the recon map's Coverage & Confidence
      section — but they are echoed here so Stage 2 reads one working note instead of three files. This
-     block is the only free-text the agent adds above the marker; everything else above is init.sh's
-     seed, and the upgrade (inv-5) only appends below the marker. -->
+     block is the only free-text the agent fills in the seed; everything else here is init.sh's
+     seed, and the upgrade (inv-5) only appends at the end of the PLAN (after Definition of done). -->
 - **Locations:** {{repos / docs / resources — rough paths, URLs, hosts; and who can answer questions
   about each}}
 - **Lifecycle / release stage:** {{pre-launch / shipped / mature — a short prose descriptor, e.g.
@@ -88,10 +89,11 @@ the way — not a pretty description a mature team already knows.
   human escalation as the real control}}
 
 <!-- ═══════════════════════════════════════════════════════════════════════════════
-     Everything ABOVE is the seed init.sh dropped. Once the inventory is CONFIRMED
-     (substep inv-4), RETCON-PROMPT.md UPGRADES this PLAN BY ADDITION — it does not rewrite
-     the above (the only in-place fill-ins there are Stage 1's Intake-results values and
-     flipping a substep's Status to Done). It marks inv-1–inv-5 Done and APPENDS, below this line:
+     Everything in this stub — substeps, Intake results, Ground rules, Definition of done — is
+     the seed init.sh dropped. Once the inventory is CONFIRMED (substep inv-4), RETCON-PROMPT.md
+     UPGRADES this PLAN BY ADDITION — it does not rewrite any of it (the only in-place fill-ins are
+     Stage 1's Intake-results values and flipping a substep's Status to Done — done as each substep
+     completes, inv-5 marked last). It APPENDS, at the END of this PLAN (after Definition of done):
        • the per-asset substeps — one row per repo/doc-set/resource in their own
          `# | Asset | Kind | Status` table (`asset-N` ids; same Status tracking as the inv-N
          table above), each documenting one asset so nothing is lost (a repo is not a 1.N
@@ -126,8 +128,9 @@ the way — not a pretty description a mature team already knows.
 - [ ] inv-1–inv-4 complete: intake recorded, everything inventoried, the recon map drafted and
       **confirmed by the user**.
 - [ ] inv-5 complete: this PLAN upgraded by addition — per-asset substeps (`asset-N` id + Status) + the
-      in-scope 1.1–1.14 sessions + the `Conditional sessions considered` table appended; inv-1–inv-5
-      marked `Done`; `registries/risks.yml` seeded from the confirmed map (STEP-index untouched).
-- [ ] Next action is the lowest open **appended** substep (the per-session harvest→confirm wrapper).
-      The overall STEP-1 baseline lands later, after the Cross-Cutting Review (see the retcon
-      baseline note above).
+      in-scope 1.1–1.14 sessions + the `Conditional sessions considered` table appended; `inv-5` marked
+      `Done` last (inv-1–inv-4 already `Done` from as-you-go marking); `registries/risks.yml` seeded
+      from the confirmed map (STEP-index untouched).
+- [ ] Next action is the lowest open **appended** substep — the first per-asset substep (`asset-1`),
+      then the `1.1`–`1.13` harvest→confirm sessions. The overall STEP-1 baseline lands later, after
+      the Cross-Cutting Review (see the retcon baseline note above).

--- a/init.sh
+++ b/init.sh
@@ -792,6 +792,13 @@ fi
 if [ ! -f "$DOCS/overview.md" ]; then
   cp "$DOCS/templates/overview-template.md" "$DOCS/overview.md"
   echo "  created $DOCS/overview.md (fill it in)"
+  # The seeded PROJECT-STATUS marker is what AGENTS.md/status.sh route on — and the literal that
+  # retcon's §5c flips. If the template's marker text ever drifts, that routing silently breaks
+  # (and §5c's substitution would no-op), so verify the seed took before anything depends on it.
+  grep -q '<!-- PROJECT-STATUS: not-started -->' "$DOCS/overview.md" || {
+    echo "init.sh: overview.md is missing the seeded '<!-- PROJECT-STATUS: not-started -->' marker" >&2
+    echo "        (overview-template.md may have drifted). Aborting before the project ships mis-routed." >&2
+    exit 1; }
 fi
 
 # --- 5b. Seed the STEP index ------------------------------------------------
@@ -814,6 +821,15 @@ fi
 if [ "$MODE" = "existing" ]; then
   # Flip the kickoff gate from the seeded `not-started` to `retcon` (see overview-template.md).
   perl -pi -e 's/<!-- PROJECT-STATUS: not-started -->/<!-- PROJECT-STATUS: retcon -->/' "$DOCS/overview.md"
+  # This flip is the single most load-bearing line in retcon: it is what routes every agent and
+  # status.sh into adoption. A silent no-op (marker text drifted, so the substitution matched
+  # nothing) would ship `not-started` and run the greenfield kickoff against existing code — so
+  # verify it took, mirroring the precondition guard on the stub-PLAN write just below.
+  grep -q '<!-- PROJECT-STATUS: retcon -->' "$DOCS/overview.md" || {
+    echo "init.sh: failed to set the retcon PROJECT-STATUS marker in overview.md" >&2
+    echo "        (overview-template.md may have drifted). Aborting so the project does not ship" >&2
+    echo "        routed to the greenfield kickoff instead of retcon adoption." >&2
+    exit 1; }
   echo "  retcon: PROJECT-STATUS set to 'retcon' (adopting an existing codebase)"
   # Seed the stub STEP-1 PLAN at the SAME in-flight path greenfield uses, so the Cross-Cutting
   # Review and later check-ins find it where they look. Its substeps are the inventory work;


### PR DESCRIPTION
## What this is

Two review passes over the existing-codebase **adoption** path (retcon) — the map + plan
resolver and the artifacts it produces. Verify-and-fix only; no new feature surface. Both
passes walked a throwaway 2-repo fixture end-to-end (`init.sh --mode=existing` → intake →
inventory → recon map → per-asset), with mid-run resume checks, and confirmed greenfield
output is unchanged.

## Commits

**`c0e4eef` — full verification review (11 refinements).** Hardened the adoption process
after reading it end to end, including `init.sh` line by line:

- Recon-map freeze scoped to the inventory **list** (the asset list is the birth
  certificate); per-asset detail lives on in the living docs, not the frozen snapshot.
- Resume-safety: inventory substeps mark `Done` as-you-go; the PLAN-upgrade step appends
  first and self-marks last, with an idempotent re-run guard.
- Added `environments` + `observability` to the scan list and the recon-map inventory kinds;
  refined per-resource → owning-session routing.
- Recon map stamps its reviewed commit(s) + depth dial (point-in-time snapshot); intake
  records all four framing answers into the PLAN's working note.
- `init.sh` marker-flip guard: the status flip that routes every agent into adoption now has
  a pre/post assertion, so template drift aborts init with a clear message instead of
  silently running the greenfield kickoff against existing code (negative drift test added).

**`8b32ef0` — second independent pass (3 fixes + a land note).**

- The STEP-1 PLAN's appended `1.1`–`1.14` architecture-session rows now carry the same
  `Planned/In progress/Done` Status column as the inventory and per-asset tables, so a
  resumed agent resolves the lowest-open session across a chat boundary (session progress
  lives in the PLAN during adoption, off the index grammar, exactly as `status.sh` documents).
- Completed the recon-map fill list (the map's Summary section was the one section the
  enumeration didn't name).
- Reworded the stub's inventory-substeps note ("free-form units" → "PLAN-local substeps
  tracked by Status").
- Documented that landing flips the index `1.1`–`1.14` substeps to `Done` alongside the
  STEP-1 row, so a landed project resolves like a greenfield baseline instead of re-running
  the sessions it just reverse-engineered.

## Verification

- Full maintainer test suite passes (11/11).
- Fresh `init.sh --mode=existing` generates a `check.sh` (0/0) + `links`-clean project that
  resolves to the first architecture session.
- Greenfield output diff-identical (`repos.yml` seed rows, empty adoption scratch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
