### PR TITLE
Harden the existing-codebase adoption front door

### DIFF
--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -52,6 +52,29 @@ if [ -f "$OVERVIEW" ] && grep -q 'PROJECT-STATUS: retcon' "$OVERVIEW"; then
   exit 0
 fi
 
+# --- Missing / unrecognized marker guard --------------------------------------
+# The three recognized PROJECT-STATUS values are not-started, retcon, and kickoff-complete (see
+# overview-template.md). If overview.md exists but carries none of them, the marker was lost or
+# corrupted. Do NOT fall through and confidently resolve the index: a bare seed would misreport
+# "Run STEP-1.1", which is wrong both for a pre-kickoff greenfield (should run kickoff) and for a
+# retcon whose marker was lost (should restore the marker and follow RETCON-PROMPT.md). Say it's
+# indeterminate and point at the AGENTS.md "First action" decision, which restores the marker from
+# disk (status.sh stays a helper; the agent does the recovery).
+if [ -f "$OVERVIEW" ] \
+  && ! grep -qE 'PROJECT-STATUS: (not-started|retcon|kickoff-complete)' "$OVERVIEW"; then
+  echo "Where you are:  indeterminate — overview.md has no recognized PROJECT-STATUS marker"
+  echo "                (expected one of: not-started, retcon, kickoff-complete)."
+  echo
+  echo "Next action:"
+  echo "  → the kickoff marker is missing or corrupted. Restore it via the AGENTS.md \"First action —"
+  echo "    kickoff or resume?\" decision, which infers the mode from disk. In short: an in-flight"
+  echo "    \"Upcoming Prompts/<project>-STEP-1-PLAN.md\" (or an \"Upcoming Prompts/retcon/\" folder) over a"
+  echo "    still-bare STEP-index seed means a retcon whose marker was lost → restore \"PROJECT-STATUS:"
+  echo "    retcon\" and follow RETCON-PROMPT.md; a bare seed with no such PLAN means kickoff never ran"
+  echo "    → \"not-started\"; otherwise → \"kickoff-complete\" (resume). Then re-run status.sh."
+  exit 0
+fi
+
 if [ ! -f "$INDEX" ]; then
   echo "Where you are:  project not initialized (no prompts/STEP-index.md)."
   echo

--- a/init.sh
+++ b/init.sh
@@ -290,7 +290,12 @@ else
   while :; do
     case "$(ask 'Choose 1 or 2' '1')" in
       1) MODE=new; break ;;
-      2) MODE=existing; break ;;
+      2) MODE=existing
+         echo
+         echo "  Adopting an existing codebase: keep running this from the downloaded Throughstone"
+         echo "  folder (a fresh directory), NOT from inside your existing repo. Your code stays"
+         echo "  where it is — the agent registers your repos in place later and never rewrites them."
+         break ;;
       *) echo "  -> choose 1 for a new project or 2 for an existing codebase." ;;
     esac
   done

--- a/init.sh
+++ b/init.sh
@@ -819,30 +819,43 @@ fi
 # & register repos, classify docs, build the recon map, harvest the sessions — is agent-driven
 # behind RETCON-PROMPT.md, routed by the `retcon` status.
 if [ "$MODE" = "existing" ]; then
-  # Flip the kickoff gate from the seeded `not-started` to `retcon` (see overview-template.md).
+  # Order matters here: seed the stub STEP-1 PLAN FIRST, then flip the status marker. The `retcon`
+  # marker is a promise that the resolver (RETCON-PROMPT.md) has an in-flight PLAN to resolve —
+  # RETCON-PROMPT.md reads that PLAN as a precondition and cannot rebuild it — so the marker must
+  # never be set unless the PLAN it points at exists.
+  #
+  # Seed the stub STEP-1 PLAN at the SAME in-flight path greenfield uses, so the Cross-Cutting
+  # Review and later check-ins find it where they look. Its substeps are the inventory work;
+  # RETCON-PROMPT.md upgrades it by addition once the inventory is confirmed. {{PROJECT}} was
+  # already substituted in step 3; fill {{DATE}} with the adoption date here.
+  mkdir -p "$ROOT/Upcoming Prompts"
+  # The stub template ships with the scaffold and step 3 never removes it, so a missing one means
+  # the download is incomplete or corrupt. Abort loudly BEFORE flipping the marker rather than
+  # shipping a `retcon` project with no PLAN — that state would route every agent to
+  # RETCON-PROMPT.md and then dead-end it (nothing to resolve, and no way to regenerate the stub).
+  if [ ! -f "$DOCS/templates/retcon-step-1-plan-stub.md" ]; then
+    echo "init.sh: the retcon stub STEP-1 PLAN template is missing:" >&2
+    echo "        $DOCS/templates/retcon-step-1-plan-stub.md" >&2
+    echo "        Your scaffold download looks incomplete — re-download the Throughstone template" >&2
+    echo "        and rerun ./init.sh. (The marker was not flipped; nothing routes to retcon yet.)" >&2
+    exit 1
+  fi
+  TODAY="$(date +%Y-%m-%d)" perl -pe 's/\Q{{DATE}}\E/$ENV{TODAY}/g' \
+    "$DOCS/templates/retcon-step-1-plan-stub.md" > "$ROOT/Upcoming Prompts/${SLUG}-STEP-1-PLAN.md"
+  echo "  retcon: seeded stub STEP-1 PLAN (Upcoming Prompts/${SLUG}-STEP-1-PLAN.md)"
+  # With the PLAN in place, flip the kickoff gate from the seeded `not-started` to `retcon` (see
+  # overview-template.md). This flip is the single most load-bearing line in retcon: it is what
+  # routes every agent and status.sh into adoption. A silent no-op (marker text drifted, so the
+  # substitution matched nothing) would ship `not-started` and run the greenfield kickoff against
+  # existing code — so verify it took, mirroring the precondition guard on the seeded overview
+  # marker in §5.
   perl -pi -e 's/<!-- PROJECT-STATUS: not-started -->/<!-- PROJECT-STATUS: retcon -->/' "$DOCS/overview.md"
-  # This flip is the single most load-bearing line in retcon: it is what routes every agent and
-  # status.sh into adoption. A silent no-op (marker text drifted, so the substitution matched
-  # nothing) would ship `not-started` and run the greenfield kickoff against existing code — so
-  # verify it took, mirroring the precondition guard on the stub-PLAN write just below.
   grep -q '<!-- PROJECT-STATUS: retcon -->' "$DOCS/overview.md" || {
     echo "init.sh: failed to set the retcon PROJECT-STATUS marker in overview.md" >&2
     echo "        (overview-template.md may have drifted). Aborting so the project does not ship" >&2
     echo "        routed to the greenfield kickoff instead of retcon adoption." >&2
     exit 1; }
   echo "  retcon: PROJECT-STATUS set to 'retcon' (adopting an existing codebase)"
-  # Seed the stub STEP-1 PLAN at the SAME in-flight path greenfield uses, so the Cross-Cutting
-  # Review and later check-ins find it where they look. Its substeps are the inventory work;
-  # RETCON-PROMPT.md upgrades it by addition once the inventory is confirmed. {{PROJECT}} was
-  # already substituted in step 3; fill {{DATE}} with the adoption date here.
-  mkdir -p "$ROOT/Upcoming Prompts"
-  if [ -f "$DOCS/templates/retcon-step-1-plan-stub.md" ]; then
-    TODAY="$(date +%Y-%m-%d)" perl -pe 's/\Q{{DATE}}\E/$ENV{TODAY}/g' \
-      "$DOCS/templates/retcon-step-1-plan-stub.md" > "$ROOT/Upcoming Prompts/${SLUG}-STEP-1-PLAN.md"
-    echo "  retcon: seeded stub STEP-1 PLAN (Upcoming Prompts/${SLUG}-STEP-1-PLAN.md)"
-  else
-    echo "  retcon: WARNING — stub STEP-1 PLAN template missing; RETCON-PROMPT.md will create the PLAN." >&2
-  fi
   # Scaffold the pre-answer-sheet scratch folder. RETCON-PROMPT.md's per-session harvest (Stage 3)
   # drops one transient sheet per in-scope session here; seeding it now gives that a home and makes
   # the AGENTS.md marker-loss fallback signal reliable from adoption start.

--- a/init.sh
+++ b/init.sh
@@ -259,6 +259,23 @@ preflight_git_commit
 command -v gh      >/dev/null 2>&1 || echo "Note: 'gh' not found — GitHub repo creation is unavailable, but manual remote URLs still work."
 command -v python3 >/dev/null 2>&1 || echo "Note: 'python3' not found — the later setup-workspace.sh will use its plain-shell fallback."
 
+# --- 0c. Fresh-template guard -----------------------------------------------
+# init.sh is a one-time bootstrap that crosses a destructive boundary below (it removes .git and
+# template-only files). It must run from a fresh, unpacked template checkout — never a second time
+# in an already-initialized project (a re-run would delete a mono repo's history, then fail), and
+# never on top of an unrelated repo. The root pointers (AGENTS.md / CLAUDE.md) carry a
+# THROUGHSTONE-TEMPLATE-GUARD block that step 3 strips during initialization; it is a stable
+# sentinel because it contains no {{PROJECT}} token, so — unlike the docs-hub directory name — it
+# is never rewritten by placeholder substitution (init.sh substitutes its own {{PROJECT}} too).
+# Its absence means this is not a fresh template. Refuse now, before anything is deleted.
+if ! grep -qlF 'THROUGHSTONE-TEMPLATE-GUARD' "$ROOT/AGENTS.md" "$ROOT/CLAUDE.md" 2>/dev/null; then
+  echo "init.sh: this does not look like a fresh Throughstone template checkout." >&2
+  echo "  init.sh is one-time and destructive (it removes .git and template-only files), so it will" >&2
+  echo "  not run on an already-initialized project or an unrelated repo — that would delete history." >&2
+  echo "  If you are starting over, re-download the template into a fresh, empty folder and run it there." >&2
+  exit 2
+fi
+
 say "Throughstone — setup"
 
 # --- 1. Questions (flags/env pre-answer; otherwise prompt) -------------------

--- a/tests/init-fresh-template-guard.sh
+++ b/tests/init-fresh-template-guard.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for init.sh's fresh-template guard.
+#
+# init.sh is a one-time, destructive bootstrap (it removes .git and template-only files). It must
+# refuse to run unless it is a fresh template checkout — detected by the THROUGHSTONE-TEMPLATE-GUARD
+# sentinel in the root pointers, which init strips during setup. This catches two footguns:
+#   - re-running init inside an already-initialized project (a mono re-run would delete the
+#     generated repo's history, then fail partway through);
+#   - running init on top of an unrelated repo.
+# Both must be refused BEFORE the destructive boundary, leaving any existing history intact.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-fresh-guard-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — build an init.sh fixture from HEAD, then overlay current worktree changes so
+# this test covers uncommitted bootstrap edits (same helper as the sibling init tests).
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+init_once() { # DIR EXTRA_ARGS...
+  local dir="$1"; shift
+  ( cd "$dir" && ./init.sh \
+      --non-interactive --slug=acme --desc="Guard test" \
+      --license=private --collab=solo --remotes=no "$@" )
+}
+
+# --- 1. A fresh template initializes normally (the guard must not over-fire). -----------------
+fresh="$TMP_ROOT/fresh"
+copy_template "$fresh"
+init_once "$fresh" --mode=existing --layout=mono --registries=yes >"$TMP_ROOT/fresh.out" 2>&1 \
+  || { echo "FAIL: guard blocked a fresh template checkout" >&2; cat "$TMP_ROOT/fresh.out" >&2; exit 1; }
+commits_before="$(git -C "$fresh" rev-list --count HEAD 2>/dev/null || echo 0)"
+[ "$commits_before" -ge 1 ] || { echo "FAIL: fresh init did not create a mono repo" >&2; exit 1; }
+
+# --- 2. Re-running init in that initialized project is refused, non-destructively. ------------
+if init_once "$fresh" --mode=existing --layout=mono --registries=yes >"$TMP_ROOT/rerun.out" 2>&1; then
+  echo "FAIL: init.sh re-ran inside an already-initialized project" >&2
+  cat "$TMP_ROOT/rerun.out" >&2
+  exit 1
+fi
+grep -Fq "does not look like a fresh Throughstone template checkout" "$TMP_ROOT/rerun.out" \
+  || { echo "FAIL: re-run refusal did not print the fresh-template message" >&2; cat "$TMP_ROOT/rerun.out" >&2; exit 1; }
+commits_after="$(git -C "$fresh" rev-list --count HEAD 2>/dev/null || echo 0)"
+[ "$commits_after" = "$commits_before" ] \
+  || { echo "FAIL: re-run destroyed the generated repo's history ($commits_before -> $commits_after)" >&2; exit 1; }
+[ -d "$fresh/Code/acme-docs" ] || { echo "FAIL: re-run mutated the initialized project" >&2; exit 1; }
+
+# --- 3. Running init on top of an unrelated repo (no sentinel) is refused before destruction. --
+unrelated="$TMP_ROOT/unrelated"
+mkdir -p "$unrelated"
+cp -p "$ROOT/init.sh" "$unrelated/init.sh"
+( cd "$unrelated" && git init -q && printf 'hi\n' > keep.txt && git add -A \
+    && git -c user.name=t -c user.email=t@e commit -qm "pre-existing" )
+unrelated_commit="$(git -C "$unrelated" rev-parse HEAD)"
+if init_once "$unrelated" --mode=new --layout=mono --registries=yes >"$TMP_ROOT/unrelated.out" 2>&1; then
+  echo "FAIL: init.sh ran on top of an unrelated repo" >&2
+  cat "$TMP_ROOT/unrelated.out" >&2
+  exit 1
+fi
+[ -d "$unrelated/.git" ] && [ "$(git -C "$unrelated" rev-parse HEAD)" = "$unrelated_commit" ] \
+  || { echo "FAIL: init.sh damaged an unrelated repo before refusing" >&2; exit 1; }
+[ -f "$unrelated/keep.txt" ] || { echo "FAIL: init.sh removed unrelated files before refusing" >&2; exit 1; }
+
+echo "init.sh fresh-template guard: PASS"

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -281,12 +281,51 @@ run_marker_recovery_negative_case() {
   fi
 }
 
+# run_missing_stub_case — a corrupt/incomplete scaffold download (the stub STEP-1 PLAN template is
+# absent). init.sh must abort BEFORE flipping the status marker rather than ship a `retcon` project
+# with no PLAN: the marker routes every agent to RETCON-PROMPT.md, which reads the stub as a
+# precondition and cannot regenerate it, so a marker-without-PLAN state would dead-end the resolver.
+run_missing_stub_case() {
+  local name="retcon-nostub"
+  local work="$TMP_ROOT/$name"
+  local overview="$work/Code/$name-docs/overview.md"
+
+  copy_template "$work"
+  rm -f "$work/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md"
+  if (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --mode=existing \
+      --slug="$name" \
+      --desc="Missing stub template" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1; then
+    echo "FAIL: init.sh accepted a missing stub STEP-1 PLAN template" >&2
+    return 1
+  fi
+
+  assert_file_contains "$TMP_ROOT/$name.out" "stub STEP-1 PLAN template is missing"
+  # The load-bearing marker must NOT have been flipped — no half-adopted `retcon` state ships.
+  ! grep -Fq "PROJECT-STATUS: retcon" "$overview" \
+    || { echo "FAIL: $name flipped the marker despite the missing stub template" >&2; return 1; }
+  # And no PLAN was seeded at the in-flight path.
+  if ls "$work/Upcoming Prompts/"*STEP-1-PLAN.md >/dev/null 2>&1; then
+    echo "FAIL: $name seeded a STEP-1 PLAN despite the missing template" >&2
+    return 1
+  fi
+}
+
 run_existing_case "retcon-multi" multi
 run_existing_case "retcon-mono"  mono
 run_existing_env_case
 run_new_case "green-explicit" --mode=new
 run_new_case "green-default"
 run_invalid_mode_case
+run_missing_stub_case
 run_marker_recovery_case
 run_marker_recovery_negative_case
 

--- a/tests/status-missing-marker.sh
+++ b/tests/status-missing-marker.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for status.sh's missing / unrecognized PROJECT-STATUS marker guard.
+#
+# When overview.md exists but carries none of the three recognized markers (not-started, retcon,
+# kickoff-complete) — a lost or corrupted marker — status.sh must NOT confidently resolve the index.
+# On a bare STEP-index seed that would misreport "Run STEP-1.1", which is wrong both for a
+# pre-kickoff greenfield (should run kickoff) and for a retcon whose marker was lost (should restore
+# the marker and follow RETCON-PROMPT.md). It must report an indeterminate result and point at the
+# AGENTS.md "First action" decision instead. The recognized markers still route as before.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATUS="$ROOT/Code/{{PROJECT}}-docs/scripts/status.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-status-marker-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+index="$TMP_ROOT/STEP-index.md"
+overview="$TMP_ROOT/overview.md"
+
+# A bare STEP-index seed: STEP-1 Planned, no implementation STEPs. This is the state a lost-marker
+# project sits over, and the one that used to misresolve to "Run STEP-1.1".
+{
+  printf '# idx\n\n'
+  printf '| STEP | Title | Owner | Status | Repos (projection) | Scope (one line) |\n'
+  printf '|------|-------|-------|--------|--------------------|------------------|\n'
+  printf '| STEP-1 | Architecture | | Planned | | Architecture-first. |\n'
+} > "$index"
+
+run_status() {
+  THROUGHSTONE_OVERVIEW="$overview" THROUGHSTONE_STEP_INDEX="$index" "$STATUS"
+}
+
+assert_contains() {
+  local output="$1" expected="$2"
+  printf '%s\n' "$output" | grep -Fq "$expected" || {
+    printf 'FAIL: expected status output to contain: %s\n' "$expected" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  }
+}
+refute_contains() {
+  local output="$1" needle="$2"
+  if printf '%s\n' "$output" | grep -Fq "$needle"; then
+    printf 'FAIL: status output should NOT contain: %s\n' "$needle" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+# 1. Marker line stripped entirely — indeterminate, never a confident STEP-1.1.
+printf '# Overview\n\n(the PROJECT-STATUS marker line has been lost)\n' > "$overview"
+out="$(run_status)"
+assert_contains "$out" "indeterminate"
+assert_contains "$out" "no recognized PROJECT-STATUS marker"
+assert_contains "$out" "RETCON-PROMPT.md"
+refute_contains "$out" "Run STEP-1.1"
+
+# 2. Unrecognized marker value — same guard (not one of the three known values).
+printf '# Overview\n\n<!-- PROJECT-STATUS: bogus -->\n' > "$overview"
+out="$(run_status)"
+assert_contains "$out" "indeterminate"
+refute_contains "$out" "Run STEP-1.1"
+
+# 3. Recognized markers still route as before (guard must not over-fire).
+printf '# Overview\n\n<!-- PROJECT-STATUS: retcon -->\n' > "$overview"
+assert_contains "$(run_status)" "marker: retcon"
+
+printf '# Overview\n\n<!-- PROJECT-STATUS: not-started -->\n' > "$overview"
+assert_contains "$(run_status)" "kickoff not started"
+
+# kickoff-complete falls through to ordinary index resolution (bare seed -> start STEP-1).
+printf '# Overview\n\n<!-- PROJECT-STATUS: kickoff-complete -->\n' > "$overview"
+out="$(run_status)"
+refute_contains "$out" "indeterminate"
+assert_contains "$out" "Run STEP-1.1"
+
+echo "status.sh missing-marker guard: PASS"


### PR DESCRIPTION
Robustness fixes to the existing-codebase adoption front door, from three review
passes over the `init.sh --mode=existing` path (main flow, edge cases, and restarts /
unusual conditions). None change the normal adoption or greenfield flow. The last two
are base-general — they harden greenfield too, not just retcon.

## 1. Seed the STEP-1 PLAN before flipping the status marker

The adoption marker routes every agent to `RETCON-PROMPT.md`, which reads the in-flight
STEP-1 PLAN as a precondition and cannot regenerate it. init.sh set the marker first and
merely warned (then continued) if the stub PLAN template was missing — so a corrupt
download could ship an adoption-mode project with no PLAN, dead-ending the resolver.
Section 5c now seeds the PLAN first and aborts loudly (re-download) if the template is
absent, before the marker is touched. Adds a regression test.

## 2. Tell adopters up front where to run init

Picking "existing codebase" could read as "run this inside my existing repo", where
init's setup boundary removes the checkout's `.git` and template-only files. A short note
now prints the moment the user selects existing-codebase mode, while they can still stop.

## 3. Report an indeterminate status when the kickoff marker is missing (base-general)

If `overview.md` exists but carries none of the three recognized PROJECT-STATUS markers
(lost/corrupted), `status.sh` used to fall through and confidently print "Run STEP-1.1" on
a bare seed — wrong for a pre-kickoff greenfield (should run kickoff) and for a
lost-marker retcon (should restore the marker → `RETCON-PROMPT.md`). It now reports
indeterminate and points at the AGENTS.md "First action" decision. Recognized markers
route as before. Adds `tests/status-missing-marker.sh`.

## 4. Refuse to run init.sh unless it's a fresh template checkout (base-general)

init.sh is one-time and destructive. Re-running it in an initialized project deleted the
generated repo's history (a mono re-run wipes root `.git`) then failed partway; pointed at
an unrelated repo it would do the same. A guard before the destructive boundary now keys
on the `THROUGHSTONE-TEMPLATE-GUARD` sentinel in the root pointers (a stable marker init
strips during setup — it carries no `{{PROJECT}}` token, so unlike the docs-hub directory
name it isn't defeated by init's own placeholder substitution). Refuses cleanly if absent.
Adds `tests/init-fresh-template-guard.sh`.

## Testing
- `tests/init-retcon-mode.sh`, `tests/status-missing-marker.sh`,
  `tests/init-fresh-template-guard.sh` pass, plus the rest of the suite.
- `tests/init-local-user-profile.sh` fails identically on the base branch (a pre-existing
  `marketing/` gitignore leak, fixed separately in #111) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
