### PR TITLE
Ignore the whole marketing/ tree so a stray-file leak stops failing the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,11 @@
 
 # Maintainer-only notes (handoffs, design memos) — not part of the published template.
 .dev/
-marketing/outreach-targets.md
-marketing/tech-media-ai-coding-writer-outreach.md
+# Maintainer-only marketing & launch material (outreach lists, Product Hunt assets, decks) —
+# local scratch, not part of the published template. Ignore the whole tree so newly added
+# launch files don't leak into the repo or into test fixtures (copy_template overlays untracked
+# files) and trip the workspace-root hygiene check.
+marketing/
 # Local maintainer scratch list of outstanding improvements — not part of the published template.
 TODO.md
 


### PR DESCRIPTION
## Problem

`tests/init-local-user-profile.sh` fails (exit 1) on an otherwise-clean checkout,
independent of any feature work. Its `check.sh` run reports `0 fail(s), 1 warning(s)`,
and this test is the one that asserts a warning-free workspace root.

## Root cause

The warning is the root-hygiene check flagging a `marketing` directory in the fixture.
That folder is maintainer-local launch/outreach material (Product Hunt assets, the CTO
deck, outreach lists), but `.gitignore` only listed two `marketing/*.md` files by name —
so the folder's newer contents were untracked and un-ignored. The test helper
`copy_template` overlays every untracked, non-ignored file into its fixtures (by design,
to cover uncommitted bootstrap edits), so those stray files landed at the fixture root
and tripped the check.

## Fix

Ignore `marketing/` wholesale — the same treatment `.dev/` and `brand/explore/` already
get for maintainer-local content. Launch material stays out of both the repo and the
test fixtures. The two by-name lines it replaces are still covered.

## Testing

Full `tests/` suite passes (11/11), including the previously-failing
`init-local-user-profile.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
