### PR TITLE
Document the status.sh and init.sh robustness fixes in the 2.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ any project built with it.
 
 Work toward the **2.0** line, which adds **existing-codebase adoption** ("retcon"): a new project can
 be stood up by reverse-engineering a running system instead of interviewing its architecture from
-scratch. Entries accumulate here as the capability lands. Everything below is **greenfield-inert** —
-a project stood up from scratch behaves exactly as before.
+scratch. Entries accumulate here as the capability lands. The adoption capability is
+**greenfield-inert** — a project stood up from scratch never enters it and behaves exactly as before;
+the few general robustness fixes under **Changed** touch only error/corruption and re-run paths, not
+normal operation.
 
 ### Added
 - **Existing-codebase adoption front door** (`init.sh` → `RETCON-PROMPT.md`) — `init.sh` now opens with
@@ -41,6 +43,20 @@ a project stood up from scratch behaves exactly as before.
   code and provenance-tagged, confirmed with the user before the clean `architecture/` doc is written.
   `init.sh` scaffolds an `Upcoming Prompts/retcon/` scratch home for these when adopting an existing
   codebase.
+
+### Changed
+- **`status.sh` no longer guesses when the kickoff marker is missing.** If `overview.md` exists but
+  carries no recognized `PROJECT-STATUS` value (`not-started` / `retcon` / `kickoff-complete` — a lost
+  or corrupted marker), the helper now reports the status as **indeterminate** and points at the
+  `AGENTS.md` "First action" decision, instead of confidently resolving the index (which on a bare seed
+  could misreport "Run STEP-1.1" — wrong both for a pre-kickoff greenfield and for a retcon whose marker
+  was lost). Normal operation, with a valid marker, is unchanged; this hardens greenfield and adoption
+  alike.
+- **`init.sh` refuses to run outside a fresh template checkout.** The one-time bootstrap is destructive
+  (it removes `.git` and template-only files), so it now checks for the template sentinel in the root
+  pointers before doing anything and stops with a clear message if it is absent — preventing a
+  second run inside an already-initialized project (which could delete the generated repo's history)
+  or a run on top of an unrelated repo. A first run on a fresh download is unaffected.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -281,7 +281,9 @@ resolver) instead of interviewing it from scratch. Most of it — the front door
 adoption-only templates — is new machinery a project already built with Throughstone never touches;
 you get it automatically when you pull 2.0 and re-run `init.sh` to adopt a new codebase, with nothing
 to migrate. This section collects the few things an *existing* project picks up on upgrade, added as
-each 2.0 change lands. Nothing here rewrites project files, and all of it is greenfield-inert.
+each 2.0 change lands. Nothing here rewrites project files. The adoption machinery is
+greenfield-inert; the couple of general robustness fixes at the end change only error/corruption and
+re-run paths, never normal operation.
 
 **`throughstone:` field on repo rows.** `registries/repos.yml` gains a per-row `throughstone:` field
 recording how the method relates to each repo — value `managed` today, with `external` reserved for a
@@ -305,6 +307,20 @@ now scaffolds an `Upcoming Prompts/retcon/` scratch folder when it adopts an exi
 home for the transient per-session sheets the harvest writes. Both are **adoption-only and
 greenfield-inert**: an existing project generated no such folder and needs none. Pull the new
 template if you may adopt another codebase later; otherwise there is no action.
+
+**`status.sh` marker-loss handling (general robustness, not adoption-specific).** `scripts/status.sh`
+picks up a small hardening: when `overview.md` has no recognized `PROJECT-STATUS` marker (lost or
+corrupted), the helper now reports the status as *indeterminate* and points at the `AGENTS.md` "First
+action" decision, rather than falling through and possibly misreporting "Run STEP-1.1". **No action,
+and no change in normal operation** — a project with a valid marker (every healthy project) sees
+identical output. Pull the updated `scripts/status.sh` to get it.
+
+**`init.sh` fresh-template guard (general safety).** `init.sh` now refuses to run unless it is a fresh
+template checkout — it keys on the `THROUGHSTONE-TEMPLATE-GUARD` sentinel in the root
+`AGENTS.md`/`CLAUDE.md` that setup strips — stopping a destructive second run inside an
+already-initialized project or a run on top of an unrelated repo. This affects **only re-runs of the
+bootstrap**: an existing project already finished `init.sh` and never runs it again, so there is
+**nothing to do**. It matters only if you later download 2.0 to adopt or start another codebase.
 
 ## 3. Manual Mode
 


### PR DESCRIPTION
Documents the two general-robustness fixes that landed with the front-door hardening
(PR #110) in the 2.0 notes. The adoption feature itself was already covered; this fills
the gap for the base-general changes.

## CHANGELOG.md ([Unreleased] / 2.0)
New **Changed** group:
- `status.sh` now reports **indeterminate** (and points at the AGENTS.md "First action"
  decision) when `overview.md` has no recognized `PROJECT-STATUS` marker, instead of
  misresolving to "Run STEP-1.1". Normal operation unchanged.
- `init.sh` refuses to run outside a fresh template checkout, guarding against a
  destructive re-run or a run on top of an unrelated repo.

Also scopes the "greenfield-inert" line to the adoption capability, since these two
touch the shared scripts on error/corruption and re-run paths.

## UPDATING-THROUGHSTONE.md (2.0 migration)
Matching entries, both **no-action** for an existing project: `status.sh` is unchanged in
normal operation, and `init.sh` only guards re-runs of the one-time bootstrap.

Maintainer-only changes (the `marketing/` gitignore fix) are intentionally not surfaced
in user-facing notes.

## Testing
`tests/links.sh` and `tests/site-publish.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
