### PR TITLE
Stop architecture sessions from starting cold under adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Work toward the **2.0** line, which adds **existing-codebase adoption** ("retcon
 be stood up by reverse-engineering a running system instead of interviewing its architecture from
 scratch. Entries accumulate here as the capability lands. The adoption capability is
 **greenfield-inert** — a project stood up from scratch never enters it and behaves exactly as before;
-the few general robustness fixes under **Changed** touch only error/corruption and re-run paths, not
-normal operation.
+every entry under **Changed** is either gated on the adoption status or a general robustness fix that
+touches only error/corruption and re-run paths, not normal operation.
 
 ### Added
 - **Existing-codebase adoption front door** (`init.sh` → `RETCON-PROMPT.md`) — `init.sh` now opens with
@@ -45,6 +45,13 @@ normal operation.
   codebase.
 
 ### Changed
+- **Architecture-session templates defer to the adoption resolver.** Each
+  `templates/architecture-sessions/*.md` now carries a short adoption check above its "Begin now"
+  go-ahead: when `overview.md` reads `PROJECT-STATUS: retcon`, the session is **not** started cold —
+  the file is reference data that `RETCON-PROMPT.md` harvests from the running code. Without it, an
+  adoption that opened a session file to read its decision list would hit an instruction telling it to
+  interview the architecture from scratch, the very thing adoption exists to avoid. The check is gated
+  on a status only an adopted project holds, so greenfield sessions are unchanged.
 - **`status.sh` no longer guesses when the kickoff marker is missing.** If `overview.md` exists but
   carries no recognized `PROJECT-STATUS` value (`not-started` / `retcon` / `kickoff-complete` — a lost
   or corrupted marker), the helper now reports the status as **indeterminate** and points at the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -308,6 +308,15 @@ home for the transient per-session sheets the harvest writes. Both are **adoptio
 greenfield-inert**: an existing project generated no such folder and needs none. Pull the new
 template if you may adopt another codebase later; otherwise there is no action.
 
+**Adoption check on the architecture-session templates.** Every
+`templates/architecture-sessions/*.md` gains a short note above its "Begin now" go-ahead: under
+`PROJECT-STATUS: retcon` the file is reference data for `RETCON-PROMPT.md` to harvest from, and the
+session is not started cold. Sessions run **in place** from these templates, so the note is live as
+soon as you pull them — but it is **gated on a status your project never holds** (an existing project
+is `kickoff-complete`), so running a session, re-running one, or adding a conditional behaves exactly
+as before. **No action**; pull the updated session templates with the rest of 2.0 if you may adopt
+another codebase later.
+
 **`status.sh` marker-loss handling (general robustness, not adoption-specific).** `scripts/status.sh`
 picks up a small hardening: when `overview.md` has no recognized `PROJECT-STATUS` marker (lost or
 corrupted), the helper now reports the status as *indeterminate* and points at the `AGENTS.md` "First

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/01-system-overview.md
@@ -108,4 +108,8 @@ numbered core session, use `Run STEP-1.N: <Session label from the index>` (for e
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/02-phasing-roadmap.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/02-phasing-roadmap.md
@@ -76,4 +76,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 session, use `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from
 that conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/03-architecture-overview.md
@@ -92,4 +92,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 conditional's template. This session may have marked the UI / Design System row `N/A` or
 added a Native-app row, so trust the index. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/04-data-model.md
@@ -75,4 +75,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/05-scaling-performance.md
@@ -78,4 +78,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/06-security-threat-model.md
@@ -105,4 +105,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/07-ui-design-system.md
@@ -134,4 +134,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/08-infrastructure-deployment.md
@@ -101,4 +101,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/09-environments.md
@@ -73,4 +73,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/10-observability.md
@@ -74,4 +74,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-interface-contracts.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/11-interface-contracts.md
@@ -110,4 +110,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` section 10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now - in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user - in the one or two sentences from **What this session does** above - what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply - nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
@@ -124,4 +124,8 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.N" or "session N.M", with or without a leading "Run" and with or without the session label, is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md` (plus anything relevant in `inputs/` and any earlier architecture docs) silently. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/13-glossary.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/13-glossary.md
@@ -68,6 +68,10 @@ a numbered core session, use `Run STEP-1.N: <Session label from the index>` (for
 `Run STEP-1.Xa: <Conditional session label>` and the invocation by name from that
 conditional's template. See the next-action resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.13" or "session 1.13", with or without a leading
 "Run" and with or without ": Glossary", is your go-ahead, not a request for acknowledgement:
 don't say "ready when you are", don't recap this file, don't ask whether to start. Read

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/14-cross-cutting-review.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/14-cross-cutting-review.md
@@ -104,6 +104,10 @@ building: **start a fresh chat** and run the **implementation planning session**
 (`templates/planning-session.md`, *"Run planning session: Phase-1 implementation roadmap"*) — it outlines the Phase-1
 implementation STEPs. See the next-action resolver (`METHOD.md` §10).
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "STEP-1.14" or "session 1.14", with or without a leading
 "Run" and with or without ": Cross-Cutting Review", is your go-ahead, not a request for
 acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-identity-auth.md
@@ -85,4 +85,8 @@ bookkeeping instead of modifying STEP-1; re-run the planning session before more
 implementation work if these decisions change the remaining roadmap. Tell the user to
 **start a fresh chat** for the next action from the resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "run the identity-auth session" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md`, anything relevant in `inputs/`, the relevant architecture docs, and any active follow-up PLAN silently; the PLAN determines the execution mode and output-doc number when this is not part of STEP-1. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-native-app.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-native-app.md
@@ -84,4 +84,8 @@ bookkeeping instead of modifying STEP-1; re-run the planning session before more
 implementation work if these decisions change the remaining roadmap. Tell the user to
 **start a fresh chat** for the next action from the resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "run the native-app session" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md`, anything relevant in `inputs/`, the relevant architecture docs, and any active follow-up PLAN silently; the PLAN determines the execution mode and output-doc number when this is not part of STEP-1. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/conditional-privacy-compliance.md
@@ -111,4 +111,8 @@ bookkeeping instead of modifying STEP-1; re-run the planning session before more
 implementation work if these decisions change the remaining roadmap. Tell the user to
 **start a fresh chat** for the next action from the resolver in `METHOD.md` §10.
 
+> **Adoption check.** If `overview.md` reads `PROJECT-STATUS: retcon`, the "Begin now" go-ahead
+> below does **not** apply — this file is reference data for `RETCON-PROMPT.md` to harvest from,
+> not a session to start cold.
+
 **Begin now — in this same reply.** "run the privacy session" is your go-ahead, not a request for acknowledgement: don't say "ready when you are", don't recap this file, don't ask whether to start. Read root `.throughstone/local-user.md`, `overview.md`, anything relevant in `inputs/`, the relevant architecture docs, and any active follow-up PLAN silently; the PLAN determines the execution mode and output-doc number when this is not part of STEP-1. Then, in this one reply: **(1)** tell the user — in the one or two sentences from **What this session does** above — what you're about to cover (plain language); then **(2)** immediately **ask decision 1**, calibrated to the profile's experience level. That orientation plus the first question is your entire first reply — nothing more.

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -6,6 +6,9 @@
 #   - Existing mode sets PROJECT-STATUS: retcon, seeds the stub STEP-1 PLAN at the greenfield
 #     in-flight path, keeps the STEP index greenfield-identical, and leaves check.sh clean; a
 #     fresh agent is routed to RETCON-PROMPT.md (status.sh).
+#   - Every architecture-session template carries the adoption check, above its "Begin now"
+#     go-ahead and byte-identical across all of them — so a session file read under adoption
+#     cannot fire its cold interview, and the 17 copies cannot drift apart.
 #   - New mode (explicit and default) is unchanged: PROJECT-STATUS: not-started, no stub PLAN,
 #     the greenfield kickoff message.
 #   - An invalid --mode fails before the destructive bootstrap boundary.
@@ -116,6 +119,41 @@ run_existing_case() {
   fi
   assert_file_contains "$docs/RETCON-PROMPT.md" "Stage 1 — Intake"
   assert_file_contains "$docs/RETCON-PROMPT.md" "Upgrade this PLAN by addition"
+
+  # 5c. Every architecture-session template carries the adoption check, and it sits ABOVE that
+  #     file's "Begin now" go-ahead — an agent reading the file top-down must meet the gate before
+  #     the instruction that fires the cold interview.
+  local session guard_line begin_line sessions=0 guard_sig="" sig
+  for session in "$docs"/templates/architecture-sessions/*.md; do
+    sessions=$((sessions + 1))
+    # `|| true` so a missing match reports below instead of tripping `set -e` silently.
+    guard_line="$(grep -n -m1 -F 'Adoption check' "$session" | cut -d: -f1 || true)"
+    begin_line="$(grep -n -m1 -F '**Begin now' "$session" | cut -d: -f1 || true)"
+    if [ -z "$guard_line" ]; then
+      echo "FAIL: $name $(basename "$session") has no adoption check before its go-ahead" >&2
+      return 1
+    fi
+    if [ -n "$begin_line" ] && [ "$guard_line" -gt "$begin_line" ]; then
+      echo "FAIL: $name $(basename "$session") adoption check sits below its go-ahead" >&2
+      return 1
+    fi
+    # One uniform block, not 17 copies free to drift: compare each file's check byte for byte
+    # against the first one seen. Presence alone would pass a file whose wording had been edited
+    # into something weaker — or contradictory — while every other file kept the original.
+    sig="$(awk '/^> \*\*Adoption check\./ { inblock = 1 }
+                inblock && /^>/          { print; next }
+                inblock                  { exit }' "$session" | cksum)"
+    if [ -z "$guard_sig" ]; then
+      guard_sig="$sig"
+    elif [ "$sig" != "$guard_sig" ]; then
+      echo "FAIL: $name $(basename "$session") adoption check differs from the other sessions" >&2
+      return 1
+    fi
+  done
+  if [ "$sessions" -eq 0 ]; then
+    echo "FAIL: $name no architecture-session templates to check" >&2
+    return 1
+  fi
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).


### PR DESCRIPTION
## Why

Every `templates/architecture-sessions/*.md` ends with a "Begin now — in this same reply" footer
that treats being read as a go-ahead to start interviewing the user. Under
`PROJECT-STATUS: retcon` that is exactly backwards: adoption opens those files to read their
decision lists and harvest answers from the running code, and would instead hit an instruction to
interview the architecture from scratch — the one thing adoption exists to avoid.

## What

One uniform adoption check immediately above each footer, in all 14 core sessions and the 3
conditionals: under adoption the file is reference data for `RETCON-PROMPT.md`, and the go-ahead
below does not apply. It sits next to the footer deliberately — an agent that reads only the middle
of the file (the decision list) meets neither, and one that reads to the end meets the gate before
the instruction that fires the interview.

`AGENTS.md` already guarded the path where the *user* types "Run STEP-1.N" under adoption. This
closes the path where the session file itself is what gets read, and makes the two
belt-and-suspenders.

Wording note: `14-cross-cutting-review.md` and the conditionals get the same block as the rest.
Under adoption the review does run, and a late-discovered conditional may legitimately be asked
cold — but that call belongs to the resolver, so the check says "don't start this on your own"
rather than "never interview."

## Greenfield impact: none

The check is gated on a status only an adopted project holds (`not-started` and `kickoff-complete`
both read it as inert). Diffed against v1.7.1, the entire delta in a generated session file is the
three-line check; the interview text is byte-identical.

## Verified

- Full maintainer suite 13/13, `links` clean.
- `tests/init-retcon-mode.sh` now asserts every generated session template carries the check, that
  it sits above that file's go-ahead, and that all 17 copies are **byte-identical** — presence alone
  would pass a file whose wording had been edited into something weaker while the others kept the
  original. All four negative cases were run and confirmed to fail: check removed → `has no adoption
  check before its go-ahead`; check moved below the footer → `adoption check sits below its
  go-ahead`; one file's wording weakened, and a whitespace-only edit → `adoption check differs from
  the other sessions`.
- Fresh `init.sh --mode=existing` fixture: `check.sh` 0 fail / 0 warn, `status.sh` routes to
  `RETCON-PROMPT.md`, 17/17 session templates carry the check, no unresolved placeholders.
- Fresh greenfield fixture: `not-started` marker, `check.sh` 0/0, ordinary kickoff routing; flipped
  to `kickoff-complete` it resolves normally to `Run STEP-1.1`.

Release notes and the upgrade migration bullet land in this PR, per the standing directive.


