### PR TITLE
Ignore the whole marketing/ tree, not two files by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,11 @@
 
 # Maintainer-only notes (handoffs, design memos) — not part of the published template.
 .dev/
-marketing/outreach-targets.md
-marketing/tech-media-ai-coding-writer-outreach.md
+# Maintainer-only marketing & launch material (outreach lists, Product Hunt assets, decks) —
+# local scratch, not part of the published template. Ignore the whole tree so newly added
+# launch files don't leak into the repo or into test fixtures (copy_template overlays untracked
+# files) and trip the workspace-root hygiene check.
+marketing/
 # Local maintainer scratch list of outstanding improvements — not part of the published template.
 TODO.md
 


### PR DESCRIPTION
Cherry-pick of `9468d25` from the 2.0 line onto `main`, so both branches agree about `marketing/`.

`main`'s `.gitignore` names two marketing files individually; every other launch file added since is
untracked. That leaks in one specific place: `tests/*.sh` build their fixtures with `copy_template`,
which overlays untracked worktree files on top of `git archive HEAD` — so an untracked `marketing/`
lands at the fixture's workspace root and trips `init-local-user-profile.sh`'s workspace-root hygiene
check. Ignoring the tree fixes it, and matches what the 2.0 branch already does.

Maintainer-local material only; nothing here ships in the template.
