### PR TITLE
Harvest the architecture sessions from the running code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,25 @@ error/corruption and re-run paths, not normal operation.
   code and provenance-tagged, confirmed with the user before the clean `architecture/` doc is written.
   `init.sh` scaffolds an `Upcoming Prompts/retcon/` scratch home for these when adopting an existing
   codebase.
+- **Adoption harvests the architecture sessions instead of interviewing them** (`RETCON-PROMPT.md`
+  Stage 3). For each in-scope session, adoption reads the session template as reference data, drafts
+  an answer to every decision **from the running code** into that session's pre-answer sheet, confirms
+  each answer with you proportionate to confidence and consequence, then writes the clean
+  `architecture/` doc from the shared doc template. Decisions the code cannot answer — intent, scope,
+  what comes next — are asked directly, as greenfield would. Anything left unconfirmed is recorded as
+  `Coverage: deferred` with a tracked risk rather than guessed into fact, and provenance stays in the
+  working sheet, never in the architecture doc. Also true of the harvest:
+  - **It never invents decision records.** A decision the harvest read out of your code is described
+    in the doc's Decision Summary, never written up as an ADR — that would date and rationalize a
+    choice nobody stated. If *you* make a decision during adoption, or tell it that one was made and
+    what drove it, it says so and asks before recording an ADR.
+  - **Sessions run one at a time and survive interruption.** Each session is harvested, confirmed, and
+    written before the next begins, so every harvest reads its predecessors' confirmed docs instead of
+    drafts. A session in progress resumes from its sheet — the confirmations you already gave are
+    never re-asked or overwritten.
+  - **Nothing is skipped silently.** A conditional session the map includes is tracked and harvested
+    like any other, and a session whose area your system doesn't have (a UI session on an API-only
+    service) is recorded `N/A` or `Deferred` with a reason read from the code.
 
 ### Changed
 - **`status.sh` no longer guesses when the kickoff marker is missing.** If `overview.md` exists but

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -29,7 +29,7 @@ AGENTS.md and follow it."*
   `Code/{{PROJECT}}-docs/overview.md` for review; seed it from the one-line description in
   *What is {{PROJECT}}* below). The user should not have to pre-write `overview.md` or paste a
   kickoff command. The bootstrap flips the marker to `kickoff-complete` when it finishes.
-- **`retcon` → Adoption mode (existing codebase).** The project is being adopted from an
+- **`retcon` → adopting an existing codebase.** The project is being adopted from an
   existing codebase, not designed from scratch. **Do not run the greenfield kickoff.** Read
   `Code/{{PROJECT}}-docs/RETCON-PROMPT.md` and follow it: it is a single PLAN-driven resolver
   over the in-flight **STEP-1 PLAN** (`Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md`, a stub
@@ -89,10 +89,9 @@ with or without the session label (preferred with the label, e.g.
 interview the user one decision at a time, then write the output architecture doc and update
 `prompts/STEP-index.md`. No copy-paste, no special commands.
 
-> **Adoption exception:** if `overview.md` reads `PROJECT-STATUS: retcon`, do **not** cold-interview a
-> session here — the project is adopting an existing codebase. Follow `RETCON-PROMPT.md` instead; it
-> reads the session files as reference data to harvest from the running code, never by triggering
-> their interview.
+> **Retcon exception:** if `overview.md` reads `PROJECT-STATUS: retcon`, do **not** interview a
+> session here — the project is adopting an existing codebase. Follow `RETCON-PROMPT.md` instead.
+> (`METHOD.md` §4, *Running a session*, states the full rule for when a session's interview starts.)
 
 **"STEP-1.N", "Run STEP-1.N: <session label>", "session N.M", and "Run session N.M:
 <session label>" are all the user's go-ahead — begin in that same reply.** Don't

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -161,6 +161,15 @@ it interviews you one decision at a time, then writes the output doc and updates
 *"STEP-1.N"* and *"session N.M"* forms also work, with or without a leading "Run" and with
 or without `: <session label>`, but the labeled form gives chat/task UIs a clearer title.
 
+**When a session's interview actually starts** — the rule every reader of these files keys on: a
+session interviews you only when an agent was **sent to run that session** *and* the project is not
+mid-adoption (`overview.md` shows `PROJECT-STATUS: retcon`). Every other reading takes the file as
+reference material. That covers the Cross-Cutting Review enumerating each conditional, the periodic
+check-in re-evaluating them, and adoption harvesting a session's decisions from existing code — none
+of which should trigger an interview. The rule is enforced in two places: each session file's closing
+paragraph (which fires only for an agent sent to run it) and `AGENTS.md`'s session runner (which
+holds the adoption half, since an adopting project *is* being asked to run the session).
+
 Each session reads what it needs (`overview.md`, anything relevant in `inputs/`, and earlier
 architecture docs) from disk, so **you can clear the chat / start fresh between sessions** —
 the state lives in files, not in the conversation. This keeps STEP-1's many sessions from

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -34,9 +34,12 @@ The work runs in stages, each a set of PLAN substeps:
 - **Stage 1 — Intake** (`inv-1`) — frame the adoption. Below.
 - **Stage 2 — Map + plan** (`inv-2`…`inv-5`, then the per-asset substeps) — scan and inventory, draft
   the recon map, the user confirms it, upgrade this PLAN by addition, then document each asset. Below.
-- **Stage 3 — Harvest→confirm** the architecture sessions `1.1`–`1.13`, then the Cross-Cutting
-  Review (`1.14`) and land. *Forthcoming in the next build increment; until it lands, Stages 1–2 are
-  the resolvable work.*
+- **Stage 3 — Harvest→confirm** (`1.1`…`1.13`) — for each in-scope architecture session: read its
+  template as reference data, draft an answer to every decision **from the running code**, confirm
+  those answers with the user, and write the clean `architecture/` doc. Below.
+- **Stage 4 — Cross-Cutting Review + land** (`1.14`) — reconcile everything against the code, then
+  land the baseline. *Forthcoming in the next build increment; until it lands, Stages 1–3 are the
+  resolvable work.*
 
 When the baseline lands (after the Cross-Cutting Review), STEP-1 becomes an ordinary `Done` row marked
 **RETCON**, `PROJECT-STATUS` flips to `kickoff-complete`, and from that instant this is ordinary
@@ -152,8 +155,8 @@ reconciling each block **row by row** rather than treating a present table heade
 (an earlier run may have written a header and some rows but not all): append an `asset-N` row for
 **every** frozen recon-map Inventory asset that lacks one; append any missing **session** row so the
 table holds the full fixed `1.1`–`1.14` set (a dropped tail would silently skip the Cross-Cutting
-Review); append any missing **conditional** row from the seeded set; and add any `risks.yml` row not
-already present. Then mark `inv-5` **Done**. (`inv-1`…`inv-4` are already `Done` from as-you-go
+Review); append any missing **conditional** row from the seeded set, plus the lettered session row
+each `Include` needs; and add any `risks.yml` row not already present. Then mark `inv-5` **Done**. (`inv-1`…`inv-4` are already `Done` from as-you-go
 marking.) The appends:
 
 - **Per-asset substeps** — the confirmed **Inventory** (from the recon map) projected into work
@@ -185,9 +188,16 @@ marking.) The appends:
   table greenfield authors from `templates/step-plan-template.md` (its columns and its seeded rows),
   but decide each row from **code-visible surfaces**: a client/mobile surface →
   `conditional-native-app`, any authentication → `conditional-identity-auth`, PII →
-  `conditional-privacy-compliance`. Seed now; refine as sessions harvest. (If an included conditional
-  later earns a lettered `1.Xa` STEP-index row + doc number, follow the Conditional-sessions note in
-  `templates/step-index-seed.md` for that.)
+  `conditional-privacy-compliance`. Seed now; refine as sessions harvest.
+
+  **Every `Include` also gets a lettered row in the session table above** — `1.6a`, `1.7b`, … placed
+  next to the core session that owns it, with the same Status column, and named in the conditional
+  table's decision cell so the two agree. Without that row nothing ever resolves it: Stage 3 walks
+  the session table, and `prompts/STEP-index.md` — where greenfield puts the lettered substep — is
+  held at its seed until landing. Assign its output-doc number by the rule in that conditional's own
+  template, and follow the Conditional-sessions note in `templates/step-index-seed.md` when landing
+  puts the row into the index. A conditional included *later*, as a session harvests, gets its row
+  the same way at that moment.
 
 **Seed `registries/risks.yml` from the confirmed map.** Give each genuinely-risky item the map
 surfaces — in **Confidence & Unknowns**, **Coverage & Confidence**, **Tests & CI** (e.g. no tests or
@@ -231,13 +241,150 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   drop a kind.
 
 When the per-asset substeps are done, the lowest open substep is the first architecture session
-(`1.1`) — **Stage 3, the per-session harvest→confirm wrapper** (RETCON-PROMPT's second half).
-*Forthcoming in the next build increment; until it lands, Stage 2 is the resolvable work.*
+(`1.1`) — **Stage 3**, below.
 
-> **When you reach `1.1` and Stage 3 is not present in this prompt, STOP.** Report that the inventory
-> baseline (Stages 1–2) is complete and the harvest→confirm sessions are pending a future build
-> increment, then wait. **Do NOT** run the architecture sessions from
-> `templates/architecture-sessions/` — those are the greenfield **cold-interview** files, and running
-> one against an adopted codebase would interview the architecture from scratch, exactly what retcon
-> exists to avoid. (When Stage 3 lands it will drive `1.1`–`1.13` as a harvest that reads those files
-> as reference data, never by triggering their interview.)
+## Stage 3 — Harvest→confirm the architecture sessions  (`1.1`…`1.13`)
+
+Greenfield runs each of these sessions as an **interview**: it asks you every decision, because
+nothing exists yet to read. Adoption inverts it — the answers are already in the running code, so
+this stage **drafts them from reality first and then confirms them with you**. That is the whole
+point of retcon, and it is why the session templates are used here as *reference data* rather than
+run: their decision lists say what an area must settle, and your code says how this system settled it.
+
+### Resolving and tracking sessions
+**Resolve the lowest-open row** in the PLAN's session table — Status not `Done`, `N/A`, or
+`Deferred` — and run the loop below for it. That table holds the fixed `1.1`–`1.14` set **and the
+lettered rows for any conditional the map included** (`1.6a`, `1.7b`, …), so a conditional is
+resolved in place like any other session.
+
+**Run them strictly serially — harvest, confirm, and write one session before starting the next.**
+Do **not** batch: harvesting several sessions up front and confirming them later looks more efficient
+— the unattended reading happens in one pass, the user's time arrives in one block — **but** it
+sends the work out of sequence, and the rework costs more than the batching saves. A sheet drafted
+before its upstream sessions are confirmed rests on answers the user has not corrected yet, so one
+correction at `1.3` quietly invalidates drafted rows in every later sheet: each has to be re-read
+against the code and re-confirmed with the user, and any it slips past surfaces at the Cross-Cutting
+Review as a contradiction to adjudicate there instead. Serial harvesting means each session reads its
+predecessors' **confirmed** docs, so the review inherits the contradictions the *system* has, not
+ones this process introduced. It is also how greenfield runs its sessions, which is the baseline
+this adoption has to end up equivalent to.
+
+**Track it across sittings.** A session is the largest unit in this stage — a full harvest plus a
+real conversation, easily more than one chat. So flip the row to **`In progress`** when you start it,
+and to **`Done`** when its doc is written; those are the same values the `inv-N` and `asset-N`
+tables use.
+
+**Resuming an `In progress` session: read its sheet, never restart it.** The sheet in
+`Upcoming Prompts/retcon/` is the state — its **`Status`** (`Harvested` vs `Confirmed`) says which
+half you were in, and its **`Confirm`** column says which rows you had already walked with the user.
+Continue from the first unfilled row. **Never overwrite an existing sheet**: a re-harvest throws away
+the user's confirmations, which are the expensive part.
+
+**A session whose area doesn't exist.** Some sessions carry their own applicability note (the UI
+session on an API-only system, for instance). Don't invent a doc for an area the code doesn't have,
+and don't quietly skip it either: record **`N/A`** (structurally inapplicable) or **`Deferred`** (may
+arrive later) on the row, with a one-line reason drawn from the code — "no client surface in any
+adopted repo", not "not needed". Both are ordinary substep statuses in this method, so landing
+carries them into the index unchanged. If it's a conditional, mirror the same disposition in the
+PLAN's *Conditional sessions considered* table.
+
+`1.14` is the Cross-Cutting Review + land, not a harvest — see the note at the end of this stage.
+
+### 1. Read the session file as reference data
+Open `templates/architecture-sessions/NN-<topic>.md` (or the `conditional-*.md` the PLAN's conditional
+table included) and take from it:
+
+- **`## Decisions to make (in order)`** — the work list. Every session template uses that heading,
+  whatever its items are called in the notes beneath it. This is what your pre-answer sheet's rows
+  come from.
+- **`## Output`** — what the resulting `architecture/` doc must contain, and its number/filename.
+- **`## How this session works`** and the framing sections — the *lens* the session applies. Keep it;
+  a harvest that ignores the lens produces a description, not an architecture doc.
+
+**Do not run the session.** Its closing paragraph is addressed to an agent that was *sent to run*
+that session, and says so; you are reading the file to harvest it, so that paragraph is not your
+instruction. Two more things belong to the interview,
+not to you: its **`## Next`** hand-off (the resolver here is this PLAN, not the STEP index) and any
+instruction to mark a substep `Done` in `prompts/STEP-index.md` — during adoption the index is held
+at its greenfield seed, and session progress lives in the PLAN (step 5 below).
+
+### 2. Pick the shape — as-built, or forward-intent
+Most sessions are **as-built**: the code already answers them (component boundaries, data model,
+interface contracts, infrastructure, environments, observability, tests). Harvest, then confirm.
+
+Some decisions have **no as-built answer** because they are about intent rather than structure —
+what the system should become, what is deliberately out of scope, what the next milestone is. Those
+get a **near-normal interview**: ask the user directly, exactly as greenfield would, and record the
+answer as a forward decision.
+
+**ADRs: never assumed, sometimes asked for.** Several session templates tell a greenfield run to
+write an ADR for a significant or contested choice. Do **not** follow that for anything you harvested:
+the choice was made long before adoption, and writing it up now would fabricate a decision record
+with a date and a rationale nobody stated. As-built decisions live in the doc's **Decision Summary**
+table, which is where a reader expects "this is how it is" rather than "this is when we chose it."
+
+The exception is **user-directed**: if, during adoption, the user *makes* a decision or tells you
+that a decision was made and what drove it, that is contemporaneous or first-hand testimony, not
+reconstruction, and it may become a normal ADR. Say so explicitly and get approval before writing —
+something like *"that sounds like a decision worth recording as an ADR — want me to write one?"* —
+and take a no gracefully; the answer still lands in the Decision Summary either way. The line is
+**user-directed vs. agent-assumed**, not old vs. new.
+
+The test is per decision, not per session: **can the running code answer this?** A single session
+usually mixes both — the Security session harvests the auth mechanism from the code and asks you
+about the acceptable-risk posture. Never interview what the code can answer; never guess what only a
+human can.
+
+### 3. Harvest — draft every answer from reality
+Copy `templates/retcon-preanswer-sheet.md` to `Upcoming Prompts/retcon/<N.N>-<session>.md` — **unless
+a sheet for this session already exists, in which case continue it** (see *Resuming* above) — and
+fill one row per decision: the **drafted answer**, its **provenance** (every source that informed it — a
+code path, a doc in `inputs/` with its trust level, the user's memory, or `inferred` / `unknown`),
+and your **confidence**. Read the code; use the confirmed recon map and the per-asset notes for
+orientation. This step is **human-free** — the one exception is a payload too big to enumerate
+under the depth-dial posture, where you stop and ask rather than silently sampling.
+
+Add rows the template never listed when the system raises decisions the generic list didn't foresee.
+Mark a decision `unknown` rather than inventing an answer: an honest gap survives the confirm pass,
+a plausible fabrication may not.
+
+### 4. Confirm with the user  ▸ checkpoint
+Walk **every** row, proportionate to **confidence × consequence**: a high-confidence from-code
+answer gets a fast "this is what the code does — right?", while a low-confidence or load-bearing one
+gets a real discussion. Harvest and confirm normally run back to back, so nothing has moved in
+between — but when a session is **resumed after a gap**, reconcile the sheet against any
+`architecture/` doc confirmed since you drafted it first, and raise the conflict rather than quietly
+picking a side.
+
+Record each outcome in the sheet's **Confirm** column: *confirmed as-is*, *corrected: …*, or
+*deferred* — and a deferred decision gets `Coverage: deferred` on the doc plus a `registries/risks.yml`
+row with a revisit trigger, so the check-in resurfaces it. Never leave a row unwalked.
+
+### 5. Write the clean doc, then mark the session `Done`
+Write the `architecture/` doc the session's `## Output` section names, from
+`templates/architecture-doc-template.md` — so it carries **`Version`**, **`Status`**, and a
+**`Version Log`** (`check.sh` check 4 requires all three; a doc written freehand fails the baseline's
+own check). `Version` follows the house convention recorded at intake — and where intake recorded
+**none**, keep the template's starting `v0.1.0` rather than inventing a higher number: the doc is new
+even though the system is not, and a bigger version implies a revision history these docs deliberately
+don't claim. `Status` reflects how settled the harvested reality is — a confirmed as-built doc is
+normally **`Current`**, whether or not the product has shipped. Where step 4 deferred something, add
+a `Coverage:` line **as a header field** (the template's comment shows where) naming what is missing
+and why it matters.
+
+Follow the session's `Output` section for the body, the doc number, and its filename — with the two
+carve-outs already stated: no `prompts/STEP-index.md` bookkeeping, and **no ADR for a harvested
+decision** (only a user-directed one, with their approval).
+
+The doc states **what the system is**. Provenance and confidence stay in the sheet and never leak
+into it: no "harvested from", no per-sentence sourcing, no confidence hedges. Drift and debt the
+harvest surfaced *are* content — record them as reality plus a flagged gap, with a `risks.yml` row.
+
+Then mark the session's row `Done` in the PLAN and resolve the next lowest-open `1.N`. Leave the
+sheet in place — it is transient scratch, discarded when STEP-1 lands, not archived as history.
+
+> **When you reach `1.14` and Stage 4 is not present in this prompt, STOP.** Report that the
+> architecture baseline (Stages 1–3) is complete — every in-scope session harvested, confirmed, and
+> written — and that the Cross-Cutting Review and the baseline land are pending a future build
+> increment, then wait. Do **not** improvise the land: leaving `PROJECT-STATUS: retcon` in place and
+> the STEP index at its seed is the correct, resumable state.

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -237,28 +237,6 @@ apply each area as a coherent review-required group, as with the legacy migratio
 - *Project state* (your `inputs/` contents): entirely yours — nothing is auto-created or
   rewritten. The folder is optional; a session reads what's there and ignores an empty folder.
 
-### 1.7.2 migration
-
-**Session templates only — no project files change.** Two edits to
-`templates/architecture-sessions/*.md`, both *Templates for future use* under §2, so they affect
-sessions you run after pulling them and rewrite nothing you already produced.
-
-- **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
-  here to run this session…" and ends by releasing a reader who wasn't sent to run it. When you
-  invoke a session normally, behavior is unchanged — you type `Run STEP-1.N` and get the first
-  question back exactly as before. What changes is a file *read* for another purpose (the
-  Cross-Cutting Review checking conditional applicability, the check-in re-evaluating them): those
-  readers are now told the go-ahead isn't theirs, instead of relying on their own instructions to
-  outweigh it.
-- **One work-list heading.** The Glossary and Cross-Cutting Review templates now head their work list
-  `## Decisions to make (in order)`, matching the other fifteen, each with a note explaining what its
-  items are. If you have **customized session templates or added your own**, adopt the same heading so
-  generic readers find your work list too — `METHOD.md` §4 documents the skeleton, and it is the only
-  change you might want to make by hand.
-
-Pull `templates/architecture-sessions/*.md` and `METHOD.md` §4 as a group. Nothing else is affected:
-no `status.sh` / `check.sh` change, no project state touched.
-
 ### 1.7.1 migration
 
 **Upgrading from 1.7.0?** A small follow-up that gives the `inputs/` folder a lifecycle. It rewrites
@@ -329,6 +307,36 @@ now scaffolds an `Upcoming Prompts/retcon/` scratch folder when it adopts an exi
 home for the transient per-session sheets the harvest writes. Both are **adoption-only and
 greenfield-inert**: an existing project generated no such folder and needs none. Pull the new
 template if you may adopt another codebase later; otherwise there is no action.
+
+**Session templates: the go-ahead is now conditional, and the work-list heading is uniform (not
+adoption-specific).** Two edits to `templates/architecture-sessions/*.md`, both *Templates for future
+use* under §2, so they affect sessions you run after pulling them and rewrite nothing you already
+produced.
+
+- Each session file's closing paragraph now opens "If you were sent here to run this session…" and
+  ends by releasing a reader who wasn't. Invoking a session normally is unchanged — you type
+  `Run STEP-1.N` and get the first question back exactly as before. What changes is a file *read* for
+  another purpose (the Cross-Cutting Review checking conditional applicability, the check-in
+  re-evaluating them): those readers are now told the go-ahead isn't theirs, instead of relying on
+  their own instructions to outweigh it. `METHOD.md` §4 states the rule, and `AGENTS.md`'s session
+  runner points at it.
+- The Glossary and Cross-Cutting Review templates now head their work list
+  `## Decisions to make (in order)`, matching the other fifteen, each with a note explaining what its
+  items are. If you have **customized session templates or added your own**, adopt the same heading so
+  generic readers find your work list too. That is the only change here you might want to make by
+  hand; pull `templates/architecture-sessions/*.md` and `METHOD.md` §4 as a group. No `status.sh` /
+  `check.sh` change, no project state touched.
+
+**Session harvest (adoption only).** `RETCON-PROMPT.md` gains its per-session half: an adoption now
+reads each architecture-session template as reference data, drafts every decision from the running
+code, confirms them with you, and writes the clean `architecture/` doc. It reuses what your project
+already has — the session templates unchanged, `templates/architecture-doc-template.md` for the
+output, `registries/risks.yml` for anything deferred, and the method's own substep statuses
+(`In progress`, `Deferred`, `N/A`) for tracking — and adds no new machinery, so what it produces is
+an ordinary Throughstone baseline rather than an adoption-shaped one. **Adoption-only and
+greenfield-inert:** a project already built with Throughstone ran those sessions as interviews and has
+nothing to migrate. The one related change that is *not* adoption-specific — the conditional go-ahead
+and the uniform work-list heading — is the entry above.
 
 **`status.sh` marker-loss handling (general robustness, not adoption-specific).** `scripts/status.sh`
 picks up a small hardening: when `overview.md` has no recognized `PROJECT-STATUS` marker (lost or

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -108,7 +108,9 @@ the way — not a pretty description a mature team already knows.
          harvest→confirm; 1.14 is the Cross-Cutting Review + land, not a harvest;
        • the `Conditional sessions considered` table — seeded from code-visible surfaces
          (client surfaces, PII, auth) and refined as sessions harvest, exactly as
-         greenfield seeds-then-refines it;
+         greenfield seeds-then-refines it; every `Include` ALSO gets a lettered row
+         (1.6a, 1.7b, …) in the session table above, since that table is what the harvest
+         resolves while STEP-index is held at its seed;
        • `registries/risks.yml` rows seeded from the confirmed map's Confidence & Unknowns /
          Coverage & Confidence (genuinely-risky items only; STEP-index stays at its seed).
      That upgraded PLAN — at this same path, Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md —

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -116,6 +116,12 @@ run_existing_case() {
   fi
   assert_file_contains "$docs/RETCON-PROMPT.md" "Stage 1 — Intake"
   assert_file_contains "$docs/RETCON-PROMPT.md" "Upgrade this PLAN by addition"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "Stage 3 — Harvest→confirm"
+  # The harvest writes architecture docs from the shared template, so they carry Version / Status /
+  # Version Log and the landed baseline passes its own check.sh check 4.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "templates/architecture-doc-template.md"
+  # The work list is addressed by the one heading every session template now uses (1.7.2 contract).
+  assert_file_contains "$docs/RETCON-PROMPT.md" "## Decisions to make (in order)"
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).


### PR DESCRIPTION
Second part of the harvest work, on top of the map+plan spine. Adoption could inventory a system and
write its STEP-1 plan, then stopped at the first architecture session with nothing to do — the
per-session half of the resolver didn't exist. This adds it as **Stage 3** of `RETCON-PROMPT.md`.

## The loop

Resolve the lowest-open session from the PLAN, then per session:

1. **Read the template as reference data** — its decision list (under the one heading every session
   now uses), its `Output` contract, and the lens it applies. *Not* its go-ahead, its `Next` hand-off,
   or its instruction to mark `prompts/STEP-index.md`: the index is held at its greenfield seed during
   adoption, and session progress lives in the PLAN.
2. **Pick the shape, per decision** — harvest what the running code can answer; interview what only a
   human can (intent, scope, the next milestone), exactly as greenfield would. Most sessions mix both:
   the Security session harvests the auth mechanism and asks about acceptable risk.
3. **Harvest** — draft every answer into that session's pre-answer sheet with provenance and
   confidence. Human-free, except a payload too big to enumerate under the depth posture, where it
   asks instead of silently sampling. `unknown` is a legal answer; a fabricated one isn't.
4. **Confirm** — walk every row proportionate to confidence × consequence, after reconciling against
   any doc confirmed since the harvest.
5. **Write the clean doc** from `templates/architecture-doc-template.md` — so it carries Version /
   Status / Version Log and the landed baseline passes its own `check.sh` check 4. Provenance stays in
   the sheet; deferrals become a `Coverage:` field plus a tracked risk.

Then mark the session `Done` and resolve the next.

## What a review of the above changed

Reviewing the first draft found four defects, all fixed here (the branch is squashed to one commit):

- **Serial, and said so.** Sessions are harvested, confirmed, and written one at a time. Batching the
  harvests looks cheaper but drafts every later sheet against answers the user hasn't corrected yet,
  so one correction manufactures contradictions for the Cross-Cutting Review to adjudicate against
  the code. Serial is also how greenfield runs its sessions.
- **Interruption-safe.** A session is the largest unit in the stage, so it spans chats. Rows flip to
  `In progress` on start, and a resumed agent reads the existing sheet's `Status` and `Confirm`
  column rather than re-copying the template over confirmations the user already gave.
- **Conditionals are tracked.** An `Include`d conditional had nowhere to live — the session table
  held only `1.1`–`1.14`, the conditional table records a decision rather than progress, and the STEP
  index is held at its seed. It now also gets a lettered row (`1.6a`, `1.7b`) in the table the
  harvest resolves.
- **ADRs are never assumed.** Several session templates tell a greenfield run to write an ADR for a
  significant choice; following that during adoption fabricates a decision record for a choice nobody
  stated. Harvested decisions stay in the doc's Decision Summary. The exception is user-directed — if
  the user makes a decision, or reports one and what drove it, the agent proposes an ADR and writes it
  only with approval.
- **Inapplicable areas are recorded, not skipped.** A session whose area doesn't exist takes `N/A` or
  `Deferred` with a reason from the code — both already valid substep statuses, so landing carries
  them into the index unchanged. `1.14` is the review + land, which stops with a
clear report until that increment lands.

## One rule, stated once

`METHOD.md` §4 now says when a session's interview starts — *an agent was sent to run that session,
and the project isn't mid-adoption* — and `AGENTS.md`'s session-runner exception points at it instead
of restating it. That also renames the exception to **Retcon exception** and drops "Adoption mode" as
a label: "adopt" already means *adopting the method* elsewhere in these docs (8 uses in
`UPDATING-THROUGHSTONE.md` alone), so labels key on `retcon` — the value the reader sees in
`overview.md` — while prose keeps "adopting an existing codebase".

## Verification

Walked session **1.9 (Environments)** end to end against a fixture repo (compose file, `.env.example`,
a staging→prod CI workflow):

- sheet drafted from the code — 7 rows, 5 from-code, 2 honest `unknown`s
- confirm pass recorded an outcome on **7/7** rows, two deferred to `Coverage` + risks
- clean doc written from the shared template: **`check.sh` 0 fail / 0 warn**, check 4 passing
- provenance and confidence appear 11× in the sheet and **0×** in the architecture doc

The walk found two gaps, both fixed before commit: where the `Coverage` field belongs (a header
field, per the doc template), and what `Version` a baseline doc starts at when the project has no
convention (the template's `v0.1.0` — a higher number would imply a revision history these docs
deliberately don't claim).

Full suite 14/14; `tests/init-retcon-mode.sh` now asserts Stage 3 ships with its doc-template and
work-list-heading contracts intact. Release notes and the migration bullet ride along.

