### PR TITLE
Seed risks in the shape the registry documents

### DIFF
--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -223,7 +223,11 @@ marking.) The appends:
 **Seed `registries/risks.yml` from the confirmed map.** Give each genuinely-risky item the map
 surfaces — in **Confidence & Unknowns**, **Coverage & Confidence**, **Tests & CI** (e.g. no tests or
 an empty CI gate on a shipped system), or anywhere else — a `risks.yml` row with a revisit trigger,
-so the check-in re-surfaces it. During adoption the risk lives in `risks.yml` **only** — do
+so the check-in re-surfaces it. **Write rows into the file's own `risks:` list, in the shape its
+commented example documents** (`id`, `status`, `title`, `category`, `severity`, `owner`, `opened`,
+`source`, `description`, `impact`, `mitigation`, `revisit_trigger`, `refs`) — the file ships as
+`risks: []` with that example beneath it. Nothing validates this registry mechanically, so a row
+invented in a different shape stays broken until a human reads it. During adoption the risk lives in `risks.yml` **only** — do
 **not** add a `Planned` backfill STEP to `prompts/STEP-index.md`; the index stays at its greenfield
 seed until the baseline lands (see *How this prompt works*), when a deferred area becomes ordinary
 forward work like any other risk. **One edit to the index is allowed before landing** — floated `1.2`
@@ -389,7 +393,7 @@ Record each outcome in the sheet's **Confirm** column: *confirmed as-is*, *corre
 **Deferring here works like deferring at the depth dial** (Stage 1): say what it costs before the
 user chooses, then carry the warning into the doc's `Coverage:` line and — when the gap is genuinely
 risky rather than merely incomplete — a `registries/risks.yml` row with a revisit trigger, so the
-periodic check-in re-surfaces it. During adoption the risk lives in `risks.yml` only: do **not** add
+periodic check-in re-surfaces it (in that file's documented row shape, as at `inv-5`). During adoption the risk lives in `risks.yml` only: do **not** add
 a backfill STEP to `prompts/STEP-index.md`, which is held at its greenfield seed until the baseline
 lands, at which point a deferred area becomes ordinary forward work like any other risk.
 


### PR DESCRIPTION
Final part of the harvest work: walk the whole thing end to end, fold what the walk finds.

## The walk

A two-repo fixture built to exercise every branch the harvest now has — a Python API (JWT auth, an
order/payment data model with PII, a Stripe webhook), a Flutter client (deep links, push), and an
authoritative API spec sitting in the repo as a document to harvest. `init.sh --mode=existing` →
intake → recon map → PLAN upgraded with the run-order session table → two sessions harvested end to
end (`1.11` Interface Contracts, which lifts the spec; `1.4` Data Model, which defers a fat payload).

### What it asserted

| | |
|---|---|
| Next action resolves to `1.5`, **not** `1.2` | the float holds — run order governs, not session number |
| `1.6a` and `1.7b` carry resolvable rows | an included conditional can actually be reached |
| privacy conditional deferred with a trigger | a *not now* is recorded, not dropped |
| lifted spec is the living `architecture/` doc | with its code-vs-doc drift recorded, not averaged away |
| ledger shows superseded vs still-live parts | `inputs-index.md` reflects what the harvest consumed |
| deferred payload carries a real warning | "3 of ~40 tables… anything designed against them needs checking" |
| deferral tracked as a risk | with a revisit trigger for the check-in |
| provenance appears **0×** in the clean docs | it stays in the transient sheet |
| index at seed, `PROJECT-STATUS: retcon` | a mid-harvest project is still resumable, not half-landed |
| `check.sh` **0 fail / 0 warn** | including check 4 on both harvested docs |

## What it found

One friction, fixed here: the resolver says to add a `risks.yml` row with a revisit trigger, but never
says the file ships as `risks: []` with a fully documented example schema beneath it (`id`, `status`,
`severity`, `category`, `source`, `revisit_trigger`, `refs`, …). An agent appending a free-form row
leaves the list empty and the rows dangling — and **nothing catches it**: `check.sh` validates the
STEP index, ADRs, architecture docs, session templates and root hygiene, but has no risks check. Both
seeding sites now point at the documented row shape.

That is the whole yield of the walk; the rest of the flow behaved as written.

## Scope note

This completes the harvest half of adoption. The Cross-Cutting Review and the baseline land are the
next increment — Stage 3 ends with a STOP note that leaves a fully-harvested project in a correct,
resumable state rather than improvising the land.

Full suite 14/14.
