### PR TITLE
Name every field a lifted doc needs, and the status a substep may carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ any project built with it.
 ### Fixed
 - **`11-interface-contracts.md` punctuation drift.** Its go-ahead paragraph had ASCII hyphens where
   every sibling file had em dashes — identical wording otherwise. Now byte-identical to the rest.
+- **Lifting a document into `architecture/` could fail the check that guards it.**
+  `inputs/README.md` told you to add the `Version` / `Status` header when lifting a spec or finished
+  design doc, but omitted the **Version Log** — which `scripts/check.sh` check 4 requires of every
+  numbered architecture doc, and which a document written outside the method almost never arrives
+  with. All three fields are now named at the point of the lift.
+- **The STEP index's status legend didn't mention `N/A`.** A substep whose area structurally doesn't
+  apply (the UI session on an API-only system) is marked `N/A` — accepted by `check.sh` and skipped
+  by the next-action resolver — but the legend listed only the five STEP states, so the one place a
+  reader checks before writing a status didn't describe a value the file legitimately contains.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -239,9 +239,9 @@ apply each area as a coherent review-required group, as with the legacy migratio
 
 ### 1.7.2 migration
 
-**Session templates only — no project files change.** Two edits to
-`templates/architecture-sessions/*.md`, both *Templates for future use* under §2, so they affect
-sessions you run after pulling them and rewrite nothing you already produced.
+**Templates and guidance text only — no behavior changes, and nothing you already produced is
+rewritten.** Two edits to `templates/architecture-sessions/*.md` and two documentation fixes, all
+*Templates for future use* under §2, so they affect work you do after pulling them.
 
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
   here to run this session…" and ends by releasing a reader who wasn't sent to run it. When you
@@ -255,9 +255,18 @@ sessions you run after pulling them and rewrite nothing you already produced.
   items are. If you have **customized session templates or added your own**, adopt the same heading so
   generic readers find your work list too — `METHOD.md` §4 documents the skeleton, and it is the only
   change you might want to make by hand.
+- **Lifting a document into `architecture/` now names all three header fields.** `inputs/README.md`
+  told you to add the `Version` / `Status` header and omitted the **Version Log**, which `check.sh`
+  check 4 also requires of every numbered architecture doc — so a lifted spec could fail the check
+  that guards it. Pull the updated `inputs/README.md`. If you have **already lifted** a document,
+  run `scripts/check.sh`: check 4 names any doc missing a field.
+- **The STEP index's status legend now mentions `N/A`.** A substep whose area structurally doesn't
+  apply is marked `N/A`, which `check.sh` and the next-action resolver have always accepted, but the
+  legend at the top of `prompts/STEP-index.md` listed only the five STEP states. Optional: copy the
+  added line into your project's index if you want the legend to describe what the file may contain.
 
-Pull `templates/architecture-sessions/*.md` and `METHOD.md` §4 as a group. Nothing else is affected:
-no `status.sh` / `check.sh` change, no project state touched.
+Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4, and `inputs/README.md` as a group.
+Nothing else is affected: no `status.sh` / `check.sh` change, no project state touched.
 
 ### 1.7.1 migration
 

--- a/Code/{{PROJECT}}-docs/inputs/README.md
+++ b/Code/{{PROJECT}}-docs/inputs/README.md
@@ -37,9 +37,11 @@ inputs is only *how* it gets there:
 - A **protocol / API spec, or another finished, authoritative doc** is often already in final form.
   Don't leave it living here with `../architecture/` merely *pointing* at it — **lift it into
   `../architecture/` as soon as it's in play.** That lift may be a **whole-file copy, or a light
-  reformat** to follow the doc conventions (add the `Version`/`Status` header, fit the naming). From
-  then on the architecture copy is the living version you keep true, and the original stays here as
-  provenance.
+  reformat** to follow the doc conventions: fit the naming, and add the **`Version`**, **`Status`**,
+  and **`Version Log`** header fields every architecture doc carries — `scripts/check.sh` requires
+  all three of a numbered doc however it got there, and a document written outside the method almost
+  never arrives with them. From then on the architecture copy is the living version you keep true,
+  and the original stays here as provenance.
   - *Use judgment, though:* lifting isn't always the right move — sometimes you **reference** the
     input from `../architecture/` and keep it here, long-lived and `Live`, instead of copying it in.
     A large external standard you don't own and only partially implement (a long RFC/ISO) is the

--- a/Code/{{PROJECT}}-docs/templates/step-index-seed.md
+++ b/Code/{{PROJECT}}-docs/templates/step-index-seed.md
@@ -7,6 +7,9 @@ worked, and completed.
 > Status values: **Planned** · **In progress** · **Done** (archived to `prompts/`) ·
 > **Deferred** (consciously not needed now; keep a revisit trigger) ·
 > **Abandoned** (reserved but won't be built — keep the row so the number is never reused).
+> Those five are the STEP states. A **substep** row uses the same values plus **N/A** (this area
+> structurally doesn't apply — an API-only system's UI session, say); keep the row either way, since
+> the next-action resolver skips `Deferred` and `N/A` rather than reading an absence (`METHOD.md` §10).
 > Flip a STEP to **In progress** when you start it, so the overlap warning can see it.
 > STEP numbers are global and never reset (see `METHOD.md` §1, §8).
 > **What to do next** is always derivable from this index — see the next-action resolver in


### PR DESCRIPTION
Two documentation fixes found while reviewing a feature that reads these rules closely. Both are cases where the guidance was narrower than the rule it describes, so following it exactly produced something the tooling rejects — or left a reader without the value they needed. No behavior changes.

**Lifting a document into `architecture/` could fail the check that guards it.** `inputs/README.md` tells you to lift a finished spec or still-true design doc rather than leaving `architecture/` pointing at `inputs/`, and describes the reformat as "add the `Version`/`Status` header, fit the naming". But `scripts/check.sh` check 4 requires a third field of every numbered architecture doc — the **Version Log** — and a document written outside the method almost never arrives with any of the three, so the instruction as written produced a doc that failed the check meant to guard it. All three fields are now named at the point of the lift, with the reason.

**The STEP index's status legend didn't mention `N/A`.** A substep whose area structurally doesn't apply — the UI / Design System session on an API-only system — is marked `N/A`: `check.sh` check 3 accepts it, `METHOD.md` §10's resolver skips on it, and session 1.3 explicitly instructs it. The legend at the top of the index listed only the five STEP states, so the one place a reader checks before writing a status didn't describe a value the file legitimately contains. Added as a substep-only value, with the reason the row is kept rather than deleted; the five STEP states are unchanged.

Both are guidance text, so they ride the 1.7.2 line as *Templates for future use*. The migration note now covers them — including the one case worth acting on: if you have already lifted a document, `scripts/check.sh` will name any doc missing a field.

**Verified:** full suite 11/11; a fresh generated project passes `check.sh` 0 fail / 0 warn with both changes present in its `prompts/STEP-index.md` and `inputs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
