### PR TITLE
Say what a partial doc is missing, not just that it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ any project built with it.
   apply (the UI session on an API-only system) is marked `N/A` — accepted by `check.sh` and skipped
   by the next-action resolver — but the legend listed only the five STEP states, so the one place a
   reader checks before writing a status didn't describe a value the file legitimately contains.
+- **A `Coverage:` line could be a bare word that told a later reader nothing.** The field records
+  that a doc deliberately describes only part of its area, and every check-in resurfaces it for a
+  decision — but `METHOD.md` §6 and the architecture doc template both showed it as a lone token
+  (`deferred`), so the reader who meets it months later can't tell whether the gap blocks them, and
+  the check-in has nothing to weigh. Both now require one sentence: what is missing, how big it is,
+  and what it means for someone building on the doc.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -443,8 +443,13 @@ maturity **status**, and (optionally) a **coverage** note — plus a change log:
   not reconciled against current code or backfilled.
 - **`Coverage:`** *(optional)* — how completely the doc describes its area. Omit it (or `full`)
   when the doc fully covers the area; mark a deliberately fat or partial area `deferred` (or
-  `enumerated to depth N`) so the gap is recorded rather than mistaken for drift. Every check-in
-  resurfaces a `Coverage: deferred` doc for an explicit disposition (`runbooks/check-in.md`).
+  `enumerated to depth N`) so the gap is recorded rather than mistaken for drift. **Never leave it
+  a bare word.** Write the line as one sentence — what is missing, how big it is, and what it means
+  for someone building on this doc: *"`Coverage: deferred` — 40 of ~600 tables enumerated; the rest
+  are named but their columns and relations are unread, so anything designed against them needs
+  checking first."* A reader meeting that line months later can tell whether it blocks them; a bare
+  token tells them nothing and gets ignored. Every check-in resurfaces a `Coverage: deferred` doc
+  for an explicit disposition (`runbooks/check-in.md`).
 - A **Version Log** table at the bottom: one row per change (version, date, STEP, what).
 
 ADRs are *not* versioned this way — they're dated, carry a Status (Accepted / Superseded /

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -240,7 +240,7 @@ apply each area as a coherent review-required group, as with the legacy migratio
 ### 1.7.2 migration
 
 **Templates and guidance text only — no behavior changes, and nothing you already produced is
-rewritten.** Two edits to `templates/architecture-sessions/*.md` and two documentation fixes, all
+rewritten.** Two edits to `templates/architecture-sessions/*.md` and three documentation fixes, all
 *Templates for future use* under §2, so they affect work you do after pulling them.
 
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
@@ -264,9 +264,17 @@ rewritten.** Two edits to `templates/architecture-sessions/*.md` and two documen
   apply is marked `N/A`, which `check.sh` and the next-action resolver have always accepted, but the
   legend at the top of `prompts/STEP-index.md` listed only the five STEP states. Optional: copy the
   added line into your project's index if you want the legend to describe what the file may contain.
+- **A `Coverage:` line is now a sentence, not a bare word.** `METHOD.md` §6 and
+  `templates/architecture-doc-template.md` both showed the optional `Coverage:` field as a lone
+  token (`deferred`), which tells a reader arriving months later nothing about whether the gap
+  blocks them — and gives the check-in that resurfaces it nothing to weigh. Both now ask for what is
+  missing, how big it is, and what it means for someone building on the doc. **One thing to check:**
+  if any of your architecture docs already carries a bare `Coverage:` value, expand it the next time
+  that doc is touched; nothing rewrites it for you.
 
-Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4, and `inputs/README.md` as a group.
-Nothing else is affected: no `status.sh` / `check.sh` change, no project state touched.
+Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4 and §6, `inputs/README.md`, and
+`templates/architecture-doc-template.md` as a group. Nothing else is affected: no `status.sh` /
+`check.sh` change, no project state touched.
 
 ### 1.7.1 migration
 

--- a/Code/{{PROJECT}}-docs/templates/architecture-doc-template.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-doc-template.md
@@ -4,7 +4,12 @@
 **Status:** Draft        <!-- Draft → Current → Deprecated; see METHOD.md §6 -->
 <!-- Optional — add a **Coverage:** line only for a deliberately fat or partial area:
      omit (or `full`) = fully described; `deferred` / `enumerated to depth N` records a chunk
-     intentionally not yet enumerated (resurfaced at each check-in). See METHOD.md §6. -->
+     intentionally not yet enumerated (resurfaced at each check-in). Never a bare word: write it
+     as one sentence — what is missing, how big it is, and what it means for someone building on
+     this doc. For example:
+       **Coverage:** deferred — 40 of ~600 tables enumerated; the rest are named but their
+       columns and relations are unread, so anything designed against them needs checking first.
+     See METHOD.md §6. -->
 **Last updated:** {{DATE}} ({{STEP}})
 **Audience:** {{who should read this}}
 


### PR DESCRIPTION
The optional `Coverage:` header field records that an architecture doc deliberately describes only part of its area, and every check-in resurfaces it for an explicit decision. Both places that define the field — `METHOD.md` §6 and the doc template's own comment, which is what an author reads at the moment of writing — modelled it as a lone token: `deferred`.

A bare token can't be acted on. The reader who meets it months later can't tell whether the gap blocks what they're about to build, and the check-in that resurfaces the doc has nothing to weigh — so the field records that a gap exists while withholding everything that would let someone close it.

Both now ask for one sentence — what is missing, how big it is, and what it means for someone building on this doc — and show a filled example in place of the token:

> **Coverage:** deferred — 40 of ~600 tables enumerated; the rest are named but their columns and relations are unread, so anything designed against them needs checking first.

### Scope

Documentation only. Nothing you have already produced is rewritten, `check.sh` is unchanged (it validates the field's presence, not its value), and a doc with no `Coverage:` line is unaffected. `CHANGELOG.md` gets a Fixed entry and the migration section a bullet, noting that an existing bare value is worth expanding the next time that doc is touched.

### Verification

- Maintainer suite passes.
- A freshly generated greenfield project runs `check.sh` at 0 fail / 0 warn with the new template comment in place.
