### PR TITLE
Close the gaps an adversarial read of the harvest stage found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ error/corruption and re-run paths, not normal operation.
   - **Your existing documents get used, not just filed.** Adoption copies every document it finds
     into `inputs/`, then the session covering that area acts on it: a finished spec or still-true
     design doc is **lifted** into `architecture/` as the living copy (the original stays as
-    provenance), a PRD or research note is synthesized into the doc being written, and the
+    provenance), a PRD or research note is synthesized into the doc being written, decision records
+    your team actually wrote are adopted into `adr/` with their original dates and registered there,
+    a still-accurate runbook lands in `runbooks/`, and the
     `inputs-index.md` ledger records what has been superseded and what still holds. Where a document
     disagrees with the code, the code wins and the disagreement is written down as staleness rather
     than averaged away. Nothing is retired without you — a fully-superseded input is offered for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ error/corruption and re-run paths, not normal operation.
   - **Nothing is skipped silently.** A conditional session the map includes is tracked and harvested
     like any other, and a session whose area your system doesn't have (a UI session on an API-only
     service) is recorded `N/A` or `Deferred` with a reason read from the code.
+  - **You decide what's in scope, and a UI that exists is described, not re-chosen.** A scan of a
+    real system turns up things you don't want adopted — an abandoned service, a dead prototype —
+    so the confirm gate settles each asset as adopted or excluded, and only the adopted ones become
+    work; an excluded one stays recorded as found-and-dismissed. And where a new project's UI
+    session offers you palettes and type scales to choose from, an adoption reads the ones your
+    product already ships and writes them down.
   - **Your existing documents get used, not just filed.** Adoption copies every document it finds
     into `inputs/`, then the session covering that area acts on it: a finished spec or still-true
     design doc is **lifted** into `architecture/` as the living copy (the original stays as

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -163,10 +163,10 @@ or without `: <session label>`, but the labeled form gives chat/task UIs a clear
 
 **When a session's interview actually starts** — the rule every reader of these files keys on: a
 session interviews you only when an agent was **sent to run that session** *and* the project is not
-mid-adoption (`overview.md` shows `PROJECT-STATUS: retcon`). Every other reading takes the file as
-reference material. That covers the Cross-Cutting Review enumerating each conditional, the periodic
-check-in re-evaluating them, and adoption harvesting a session's decisions from existing code — none
-of which should trigger an interview. The rule is enforced in two places: each session file's closing
+mid-adoption (that is, `overview.md` does **not** show `PROJECT-STATUS: retcon`). Every other
+reading takes the file as reference material. That covers the Cross-Cutting Review enumerating each
+conditional, the periodic check-in re-evaluating them, and adoption harvesting a session's decisions
+from existing code — none of which should trigger an interview. The rule is enforced in two places: each session file's closing
 paragraph (which fires only for an agent sent to run it) and `AGENTS.md`'s session runner (which
 holds the adoption half, since an adopting project *is* being asked to run the session).
 

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -47,7 +47,11 @@ When the baseline lands (after the Cross-Cutting Review), STEP-1 becomes an ordi
 
 ## Read first
 1. `Code/{{PROJECT}}-docs/METHOD.md` — the methodology (doc genres, sessions, naming). Internalize it.
-2. `Code/{{PROJECT}}-docs/overview.md` — what the user says this system is.
+2. `Code/{{PROJECT}}-docs/overview.md` — normally still the blank template at this point: adoption
+   skips the kickoff interview that fills it, and `1.1` writes the brief near the end (Stage 3). The
+   one-line description the user gave `init.sh` is in this docs hub's `AGENTS.md` (*What is
+   {{PROJECT}}*) — read that for the seed, and read `overview.md` for the release-stage line once
+   Stage 1 has written it.
 3. `Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md` — the in-flight PLAN you resolve; read its
    *Decisions already locked* and *Ground rules*.
 4. `Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md` — the artifact Stage 2 produces.
@@ -212,8 +216,9 @@ marking.) The appends:
   `conditional-privacy-compliance`. Seed now; refine as sessions harvest.
 
   **Every `Include` also gets a lettered row in the session table above** — `1.6a`, `1.7b`, … placed
-  next to the core session that owns it, with the same Status column, and named in the conditional
-  table's decision cell so the two agree. Without that row nothing ever resolves it: Stage 3 walks
+  next to the core session that owns it, with the same Status column, and written into the
+  conditional table's **`Substep / reason / revisit trigger`** cell (the `Decision` cell holds
+  `Include` / `Deferred` / `N/A` and nothing else) so the two agree. Without that row nothing ever resolves it: Stage 3 walks
   the session table, and `prompts/STEP-index.md` — where greenfield puts the lettered substep — is
   held at its seed until landing. Assign its output-doc number by the rule in that conditional's own
   template, and follow the Conditional-sessions note in `templates/step-index-seed.md` when landing
@@ -227,7 +232,18 @@ so the check-in re-surfaces it. **Write rows into the file's own `risks:` list, 
 commented example documents** (`id`, `status`, `title`, `category`, `severity`, `owner`, `opened`,
 `source`, `description`, `impact`, `mitigation`, `revisit_trigger`, `refs`) — the file ships as
 `risks: []` with that example beneath it. Nothing validates this registry mechanically, so a row
-invented in a different shape stays broken until a human reads it. During adoption the risk lives in `risks.yml` **only** — do
+invented in a different shape stays broken until a human reads it.
+
+**What `source` and `refs` point at here.** That file's recording rule wants every row anchored to a
+durable artifact that carries the detail, and tells you to *create* one first if none exists —
+naming an ADR or a follow-up STEP among the options. Adoption has neither available: no ADR for
+anything harvested, and no new row in `prompts/STEP-index.md`. It doesn't need them, because the
+artifact already exists. For a row seeded here, it is the **confirmed recon map** —
+`reports/<date>-step-0001-recon-map.md`, plus the section that surfaced the item (Confidence &
+Unknowns, Coverage & Confidence, Tests & CI) — which is a dated report under `reports/`, exactly the
+genre that rule's last clause allows. For a row opened later, at a session's confirm pass, it is the
+`architecture/` doc that session writes, plus its `Coverage:` line (Stage 3, step 4). Write no ADR
+and no STEP to satisfy the registry. During adoption the risk lives in `risks.yml` **only** — do
 **not** add a `Planned` backfill STEP to `prompts/STEP-index.md`; the index stays at its greenfield
 seed until the baseline lands (see *How this prompt works*), when a deferred area becomes ordinary
 forward work like any other risk. **One edit to the index is allowed before landing** — floated `1.2`
@@ -238,6 +254,12 @@ reads the archive folder name from that heading. No row, status, or STEP is touc
 `asset-N` is `Done` does the next action become the first architecture session — the **first open row
 in the session table**, read top to bottom, which starts at `1.1` (Stage 3). So the next action now
 is the first per-asset substep, `asset-1`.
+
+That rule describes the hand-off **out of Stage 2**, and it does not send the resolver backwards
+later. Once Stage 3 has started, an `asset-N` row appended mid-stage — a harvest found an asset the
+map missed (Stage 3, *An asset the harvest finds that the map missed*) — does **not** outrank the
+session in flight: an `In progress` session finishes first, and the late asset is worked at the next
+session boundary. Stage 3's two-step rule governs from `1.1` onward.
 
 ### The per-asset substeps (depth)
 Resolve each in turn — the **lowest-open `asset-N`** (Status ≠ `Done`); mark its row `Done` once the
@@ -380,19 +402,21 @@ index.
 **And leave `prompts/STEP-index.md` alone entirely.** During adoption the index is held at its
 greenfield seed and all session progress lives in the PLAN (step 5 below), so *every* index
 instruction a session template carries is redirected here — not just the familiar "mark this substep
-`Done`." The session files ask for three different index edits, and all three land in the PLAN
-instead:
+`Done`." These are the shapes the session files ask for today, and every one of them lands in the
+PLAN instead — a session that asks for something not listed here is redirected the same way:
 
 | The session says | You do this instead |
 |------------------|---------------------|
 | mark my substep `Done` (every session) — or `Deferred` (`1.6`) | flip the row in the PLAN's **session table** |
+| note the open questions carried forward (`1.1`) | nothing goes in the index — they belong in the **Open Questions** table of the `architecture/` doc you are writing, which the doc template already carries |
 | mark *another* session's row `Deferred` / `N/A` (`1.3` dispositions the UI / Design System row) | flip **that session's** row in the PLAN's session table, with the one-line reason from the code, exactly as *A session whose area doesn't exist* above describes — then mirror it in the *Conditional sessions considered* table if it is a conditional |
 | add a lettered conditional row, e.g. `1.7a` (`1.3`) | append the lettered row to the PLAN's session table (see `inv-5`), and record the decision in the PLAN's *Conditional sessions considered* table |
 | reflect the phase plan in the roadmap (`1.2`) | the phase plan is the **`architecture/02-*` doc's** content; the index gets nothing but the `{{PHASE_1_NAME}}` fill described under the float below |
 
-The single exception in the whole adoption is that `{{PHASE_1_NAME}}` fill. No row, status, STEP, or
-phase heading is touched before landing — landing is what reconciles the index, in one pass, against
-the PLAN it can then trust.
+The single exception in the whole adoption is that `{{PHASE_1_NAME}}` fill — the phase name, and the
+scaffolding comment beneath it, and nothing else. No row, no status, no STEP, and no other part of
+the file is touched before landing — landing is what reconciles the index, in one pass, against the
+PLAN it can then trust.
 
 ### 2. Pick the shape — as-built, or forward-intent
 Most sessions are **as-built**: the code already answers them (component boundaries, data model,
@@ -422,7 +446,10 @@ about the acceptable-risk posture. Never interview what the code can answer; nev
 human can.
 
 ### 3. Harvest — draft every answer from reality
-Copy `templates/retcon-preanswer-sheet.md` to `Upcoming Prompts/retcon/<N.N>-<session>.md` — **unless
+Copy `templates/retcon-preanswer-sheet.md` to `Upcoming Prompts/retcon/<substep>-<session>.md`,
+naming it from the substep id exactly as that row carries it — a lettered conditional keeps its
+letter (`1.7b-native-app.md`), the same way `prompts/README.md` names a substep prompt
+`STEP-N.M-PROMPT.md` and treats a fractional substep like `5a` as an ordinary id. **Unless
 a sheet for this session already exists, in which case continue it** (see *Resuming* above) — and
 fill one row per decision: the **drafted answer**, its **provenance** (every source that informed it — a
 code path, a doc in `inputs/` with its trust level, the user's memory, or `inferred` / `unknown`),
@@ -454,7 +481,16 @@ an honest record of where it stopped. Never leave a row unwalked. Once every row
 **Deferring here works like deferring at the depth dial** (Stage 1): say what it costs before the
 user chooses, then carry the warning into the doc's `Coverage:` line and — when the gap is genuinely
 risky rather than merely incomplete — a `registries/risks.yml` row with a revisit trigger, so the
-periodic check-in re-surfaces it (in that file's documented row shape, as at `inv-5`). During adoption the risk lives in `risks.yml` only: do **not** add
+periodic check-in re-surfaces it (in that file's documented row shape, and pointing at the artifacts
+named at `inv-5`).
+
+**A deferral taken here is not a harvested decision, and it is not automatically an ADR.** It is a
+live choice the user makes during adoption, so the no-reconstructed-ADRs rule doesn't apply to it —
+but its record is the `Coverage:` line plus the `risks.yml` row, and that is normally the whole
+record. Some session templates say otherwise: `1.6` Security asks you to capture every contested or
+deferred decision as an ADR, "deferrals especially". Under adoption, treat that the way step 2 treats
+any user-directed decision — propose it, don't assume it (*"want me to record that deferral as an
+ADR?"*), and take a no gracefully. The `Coverage:` line and the risk row are written either way. During adoption the risk lives in `risks.yml` only: do **not** add
 a backfill STEP to `prompts/STEP-index.md`, which is held at its greenfield seed until the baseline
 lands, at which point a deferred area becomes ordinary forward work like any other risk.
 
@@ -469,11 +505,10 @@ don't claim. `Status` reflects how settled the harvested reality is — a confir
 normally **`Current`**, whether or not the product has shipped.
 
 Where step 4 deferred something, add a `Coverage:` line **as a header field** (the template's comment
-shows where) — and **never a bare `deferred`**. It reads as one sentence: what is missing, how big it
-is, and what it means for someone building on this doc. *"`Coverage: deferred` — 40 of ~600 tables
-enumerated; the rest are named but their columns and relations are unread, so anything designed
-against them needs checking first."* A reader who meets that line months later can tell whether it
-blocks them; a bare word tells them nothing and gets ignored.
+shows where and gives the shape) — one sentence saying what is missing, how big it is, and what it
+means for someone building on this doc, **never a bare `deferred`**. That is the ordinary rule for
+the field (`METHOD.md` §6), not an adoption one; it just carries more weight here, because a
+baseline read out of a large existing system defers more than a greenfield one does.
 
 Follow the session's `Output` section for the body, the doc number, and its filename — with the two
 carve-outs already stated: **no edit to `prompts/STEP-index.md`**, whichever of its edits that
@@ -493,6 +528,11 @@ recorded, nothing more*. Acting on one is this session's job, for the documents 
 The base inputs lifecycle already says how (`inputs/README.md`); adoption only adds *when*, and one
 rule of precedence.
 
+The recon map already classified each document and recorded a **Disposition** for it. Those words
+map onto the rules below: *ingest* → **lift** or **adopt**, *point-at* → **reference**, *summarize* →
+**synthesize**, *flag stale* → record the drift as content. The map named the intent; these bullets
+say what it means in practice.
+
 - **The code still wins.** An input is secondary evidence, whatever its trust level in the recon map.
   Where it disagrees with what you read in the code, the code is the answer — and the disagreement
   itself is **content**: record the reality, and flag the doc as stale in that respect. Do not quietly
@@ -504,13 +544,30 @@ rule of precedence.
   practical consequences. Every `architecture/` doc is `NN-kebab-title.md`, so a lift needs a number:
   take the **next free number above the core block**, the same rule a conditional session's output
   doc follows (`METHOD.md` §4) — never a `01`–`14` slot, which belongs to the session that owns it and
-  would collide with the doc you are about to write. It **needs the `Version` / `Status` /
+  would collide with the doc you are about to write. **Free means unused on disk *and* unclaimed in
+  the PLAN.** An included conditional was given its output-doc number back at `inv-5`, long before it
+  runs, so that number is spoken for even though no file carries it yet; skip it, and skip any number
+  an earlier lift took. Record the number you take beside that input's row the way a conditional's is
+  recorded, so the next lift and the next conditional both see it. It **needs the `Version` / `Status` /
   `Version Log` header** like any other architecture doc (`check.sh` check 4 reads every numbered
   doc, however it got there) — a whole-file copy of a spec rarely arrives with one, so add it. And a
   large external standard you don't own is the case where you **reference instead of lift**, per the
   same base rule.
 - **A PRD, prior design doc, or research note is synthesized, not lifted** — you read it, and what
   survives appears in the doc you write. The input doesn't come across verbatim.
+- **A real decision record is adopted into `adr/`, not synthesized away.** A team that wrote ADRs (or
+  a dated decisions log) wrote them *at the time*, first-hand — that is evidence, not reconstruction,
+  so the no-fabricated-history rule doesn't bar it; the rule bars inventing a record for a choice
+  nobody wrote down. Copy each into `adr/` under this project's numbering, keep its original date and
+  author, register it in `adr/README.md` (`check.sh` check 5 reconciles the two), and say in the doc
+  that it predates adoption. Judgment: only for a record that was actually ratified and still
+  describes a live decision. Something merely ADR-*shaped* — an unratified rationale note, a
+  superseded proposal — is a design note: **synthesize** it. Either way the decision itself appears in
+  your doc's **Decision Summary**, which is where a reader looks for "this is how it is".
+- **A runbook is operational content, not architecture.** If it still matches what the code and infra
+  do, it belongs in `runbooks/`; if it doesn't, leave it in `inputs/` flagged stale and record the
+  real procedure where the owning session's doc covers it. Don't fold a procedure into an
+  `architecture/` doc to avoid deciding.
 - **Update the ledger either way.** Flip that input's `inputs-index.md` row to record what
   `architecture/` has now superseded and what still holds, so a later session builds on current
   material rather than re-reading a stale seed.
@@ -568,7 +625,10 @@ different job. Nothing about their templates changes — these are the notes the
   described. And it fills the **`{{PHASE_1_NAME}}` placeholder** in `prompts/STEP-index.md`'s
   `## Phase 1 — {{PHASE_1_NAME}}` heading — the one edit to that file adoption makes before landing,
   because the heading is where landing reads the archive folder name (`prompts/001-<phase-name>/`).
-  Leaving the placeholder unresolved would strand the baseline at archive time.
+  Leaving the placeholder unresolved would strand the baseline at archive time. Do it exactly as the
+  kickoff does at the same heading (`BOOTSTRAP-PROMPT.md`): set the name **and delete the
+  explanatory comment beneath it**, so an adopted index and a greenfield one of the same age read
+  the same.
 
 > `1.14`'s side of this — reconciling Phasing against `1.3`/`1.5` once all three exist, and turning
 > foreclosure into gap analysis — belongs to the Cross-Cutting Review, in the increment below.

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -48,10 +48,10 @@ When the baseline lands (after the Cross-Cutting Review), STEP-1 becomes an ordi
 ## Read first
 1. `Code/{{PROJECT}}-docs/METHOD.md` — the methodology (doc genres, sessions, naming). Internalize it.
 2. `Code/{{PROJECT}}-docs/overview.md` — normally still the blank template at this point: adoption
-   skips the kickoff interview that fills it, and `1.1` writes the brief near the end (Stage 3). The
-   one-line description the user gave `init.sh` is in this docs hub's `AGENTS.md` (*What is
-   {{PROJECT}}*) — read that for the seed, and read `overview.md` for the release-stage line once
-   Stage 1 has written it.
+   skips the kickoff interview that fills it, and the brief is written later, by `1.1`, the first
+   architecture session (Stage 3). The one-line description the user gave `init.sh` is in this docs
+   hub's `AGENTS.md` (*What is {{PROJECT}}*) — read that for the seed, and read `overview.md` for
+   the release-stage line once Stage 1 has written it.
 3. `Upcoming Prompts/{{PROJECT}}-STEP-1-PLAN.md` — the in-flight PLAN you resolve; read its
    *Decisions already locked* and *Ground rules*.
 4. `Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md` — the artifact Stage 2 produces.
@@ -144,7 +144,9 @@ is complete.
 ### `inv-3` — Draft the recon map
 Copy `templates/reports/recon-map-report-template.md` to `reports/YYYY-MM-DD-step-0001-recon-map.md`
 and fill every section from the scan: inventory, stack per repo, entry points/services, data stores,
-integrations, existing-docs classification + trust, tests/CI, and the confidence/unknowns. Stamp the
+integrations, existing-docs classification + trust, tests/CI, and the confidence/unknowns. Propose a
+**Scope** for each Inventory row (`adopt` unless the code says otherwise) — the user settles it at
+`inv-4`; a draft proposal is not the decision. Stamp the
 front matter too — **Reviewed commit(s)** (the `repo@sha` state this map describes) and **Depth dial**
 — so the snapshot is pinned to an exact point in time. Set the **Coverage & Confidence** section from
 intake — the depth-dial posture and any areas you are already choosing to bound. Write the **Summary**
@@ -155,7 +157,14 @@ Leave `Status: Draft`. Mark `inv-3` **Done** once the draft is written.
 **Detect, then confirm.** Present the draft and let the user correct it — this is the one hard gate,
 the birth-certificate checkpoint, before anything is built on the map. What the gate locks is the
 **Inventory — the complete list of assets**; that "we now have the whole list" is the clean point the
-rest of Stage 2 scopes from. On sign-off, stamp `Status: Confirmed on <date>`: the **confirmed
+rest of Stage 2 scopes from.
+
+**Complete is not the same as in scope, so settle both here.** A breadth scan of a real account
+turns up things that shouldn't be adopted — an abandoned service, a dead prototype, a repo another
+team owns. Walk the Inventory with the user and set each row's **Scope**: `adopt`, or
+`excluded — <reason>`. Excluded rows stay in the map (found-and-dismissed is a finding, and it stops
+the next scan from re-raising them); only `adopt` rows become work at `inv-5`. Ask rather than
+assume — "still in use?" is a question the code often can't answer. On sign-off, stamp `Status: Confirmed on <date>`: the **confirmed
 Inventory is frozen — never rewritten** (an asset discovered later is a recorded finding, not a silent
 edit). The per-asset **detail is not frozen** — it deepens later in the living docs (repo READMEs,
 `architecture/`), and some exploration is deliberately deferred for weeks or months via the depth dial
@@ -171,14 +180,16 @@ the completion flag. If a
 resumed agent finds `inv-5` still open, the upgrade was interrupted — re-run it **idempotently**,
 reconciling each block **row by row** rather than treating a present table header as a complete block
 (an earlier run may have written a header and some rows but not all): append an `asset-N` row for
-**every** frozen recon-map Inventory asset that lacks one; append any missing **session** row so the
+**every** frozen recon-map Inventory asset marked `adopt` that lacks one — and none for an
+`excluded` row, in either the first run or a re-run; append any missing **session** row so the
 table holds the full fixed `1.1`–`1.14` set (a dropped tail would silently skip the Cross-Cutting
 Review); append any missing **conditional** row from the seeded set, plus the lettered session row
 each `Include` needs; and add any `risks.yml` row not already present. Then mark `inv-5` **Done**. (`inv-1`…`inv-4` are already `Done` from as-you-go
 marking.) The appends:
 
-- **Per-asset substeps** — the confirmed **Inventory** (from the recon map) projected into work
-  units: one **row per asset**, tracked in their own appended table (its own columns — not
+- **Per-asset substeps** — the confirmed **Inventory** (from the recon map), its `adopt` rows
+  projected into work
+  units: one **row per adopted asset**, tracked in their own appended table (its own columns — not
   the `inv-N` table's — but the same `Planned` · `In progress` · `Done` Status convention, so a
   resumed agent can tell which are left). Number them `asset-1`, `asset-2`, … in discovery order — one
   per **repo**, one per **doc-set** (related docs grouped), one per **resource**:
@@ -211,9 +222,13 @@ marking.) The appends:
   position in this table does, and this table is what the harvest walks.
 - **The `Conditional sessions considered` table** — mirror the `Conditional sessions considered`
   table greenfield authors from `templates/step-plan-template.md` (its columns and its seeded rows),
-  but decide each row from **code-visible surfaces**: a client/mobile surface →
-  `conditional-native-app`, any authentication → `conditional-identity-auth`, PII →
-  `conditional-privacy-compliance`. Seed now; refine as sessions harvest.
+  but decide each row from **code-visible surfaces**, scoped as tightly as the rows themselves: a
+  **mobile or desktop app** — a shipped client binary, not a web front end →
+  `conditional-native-app`; **user accounts, login, or access control** — not a service-to-service
+  key → `conditional-identity-auth`; **personal or regulated data** → `conditional-privacy-compliance`.
+  A styled web UI with none of those is a `1.7` question, not a conditional — the same line `1.3`
+  draws. Seed now; refine as sessions harvest. Each false `Include` costs a whole harvest session
+  and a row nobody later deletes, so decide it, don't hedge it.
 
   **Every `Include` also gets a lettered row in the session table above** — `1.6a`, `1.7b`, … placed
   next to the core session that owns it, with the same Status column, and written into the
@@ -363,9 +378,12 @@ baseline itself. So:
 - **Tell the user when you meet it**, at the confirm pass for the session that found it. This is a
   correction to the birth certificate they signed, and it is their call whether it is in scope at all
   (an abandoned service in the same account may not be).
-- **Append an `asset-N` row** to the per-asset table — continuing the numbering, never renumbering —
-  and do that asset's ordinary per-asset work: the `repos.yml` row and stamped README for a repo, the
-  `inputs/` copy and ledger row for a doc, the routing note for a resource.
+- **If they adopt it, append an `asset-N` row** to the per-asset table — continuing the numbering,
+  never renumbering — and do that asset's ordinary per-asset work: the `repos.yml` row and README
+  note for a repo, the `inputs/` copy and ledger row for a doc, the routing note for a resource. **If
+  they exclude it**, it gets no row and no work; record it as a one-line note beside the per-asset
+  table (*"found at `1.8`: staging-2 deploy target, excluded — decommissioned"*), the same
+  found-and-dismissed record an `excluded` Inventory row carries, since the frozen map can't take it.
 - **Do it once the session in flight is `Done`**, not by interrupting it. The "every `asset-N` before
   the first session" rule describes the hand-off out of Stage 2; a late one slots in at the next
   session boundary, which keeps the serial rule intact.
@@ -379,9 +397,9 @@ reality, and flag the gap.
 `1.14` is the Cross-Cutting Review + land, not a harvest — see the note at the end of this stage.
 
 **Some sessions carry an extra note.** The loop below is the same for every session, but a few need
-something it alone doesn't give them — a brief to fill, or a consequence of running Phasing last.
-Those notes are the last two subsections of this stage; **check whether the row you just resolved has
-one before you start it.**
+something it alone doesn't give them — a brief to fill, a session whose procedure assumes nothing
+exists yet, or a consequence of running Phasing last. Those notes are the subsections that follow
+the loop; **check whether the row you just resolved has one before you start it.**
 
 ### 1. Read the session file as reference data
 Open `templates/architecture-sessions/NN-<topic>.md` (or the `conditional-*.md` the PLAN's conditional
@@ -446,17 +464,19 @@ about the acceptable-risk posture. Never interview what the code can answer; nev
 human can.
 
 ### 3. Harvest — draft every answer from reality
-Copy `templates/retcon-preanswer-sheet.md` to `Upcoming Prompts/retcon/<substep>-<session>.md`,
-naming it from the substep id exactly as that row carries it — a lettered conditional keeps its
-letter (`1.7b-native-app.md`), the same way `prompts/README.md` names a substep prompt
-`STEP-N.M-PROMPT.md` and treats a fractional substep like `5a` as an ordinary id. **Unless
-a sheet for this session already exists, in which case continue it** (see *Resuming* above) — and
+Copy `templates/retcon-preanswer-sheet.md` to `Upcoming Prompts/retcon/<substep>-<session>.md` —
+**unless a sheet for this session already exists, in which case continue it** (see *Resuming*
+above) — and
 fill one row per decision: the **drafted answer**, its **provenance** (every source that informed it — a
 code path, a doc in `inputs/` with its trust level, the user's memory, or `inferred` / `unknown`),
 and your **confidence**. Read the code; use the confirmed recon map and the per-asset notes for
 orientation. This step is **human-free** — the one exception is a payload too big to enumerate under
 the depth-dial posture, where you stop and escalate rather than silently sampling: state the cost of
 deferring, in this system's terms, and let the user choose (Stage 1, *Deferring is a real choice*).
+
+Name the sheet from the substep id exactly as its row in the PLAN carries it — a lettered
+conditional keeps its letter (`1.7b-native-app.md`), the same way `prompts/README.md` names a
+substep prompt `STEP-N.M-PROMPT.md` and treats a fractional substep like `5a` as an ordinary id.
 
 Add rows the template never listed when the system raises decisions the generic list didn't foresee.
 Mark a decision `unknown` rather than inventing an answer: an honest gap survives the confirm pass,
@@ -490,9 +510,11 @@ but its record is the `Coverage:` line plus the `risks.yml` row, and that is nor
 record. Some session templates say otherwise: `1.6` Security asks you to capture every contested or
 deferred decision as an ADR, "deferrals especially". Under adoption, treat that the way step 2 treats
 any user-directed decision — propose it, don't assume it (*"want me to record that deferral as an
-ADR?"*), and take a no gracefully. The `Coverage:` line and the risk row are written either way. During adoption the risk lives in `risks.yml` only: do **not** add
-a backfill STEP to `prompts/STEP-index.md`, which is held at its greenfield seed until the baseline
-lands, at which point a deferred area becomes ordinary forward work like any other risk.
+ADR?"*), and take a no gracefully. The `Coverage:` line and the risk row are written either way.
+
+During adoption the risk lives in `risks.yml` only: do **not** add a backfill STEP to
+`prompts/STEP-index.md`, which is held at its greenfield seed until the baseline lands, at which
+point a deferred area becomes ordinary forward work like any other risk.
 
 ### 5. Write the clean doc, then mark the session `Done`
 Write the `architecture/` doc the session's `## Output` section names, from
@@ -560,8 +582,13 @@ say what it means in practice.
   so the no-fabricated-history rule doesn't bar it; the rule bars inventing a record for a choice
   nobody wrote down. Copy each into `adr/` under this project's numbering, keep its original date and
   author, register it in `adr/README.md` (`check.sh` check 5 reconciles the two), and say in the doc
-  that it predates adoption. Judgment: only for a record that was actually ratified and still
-  describes a live decision. Something merely ADR-*shaped* — an unratified rationale note, a
+  that it predates adoption. It carries **`Accepted`** — the status means the system is living with
+  this decision, which is exactly what you verified against the code; where the code shows the
+  decision was later reversed, it is `Superseded by …` and names what replaced it. Reshape it into
+  `templates/adr-template.md`'s sections only where that is lossless: a record that resists the
+  shape keeps its original body under the standard header, since what you are preserving is
+  first-hand testimony, not a format. Judgment: only for a record that was actually ratified and
+  still describes a live decision. Something merely ADR-*shaped* — an unratified rationale note, a
   superseded proposal — is a design note: **synthesize** it. Either way the decision itself appears in
   your doc's **Decision Summary**, which is where a reader looks for "this is how it is".
 - **A runbook is operational content, not architecture.** If it still matches what the code and infra
@@ -601,6 +628,23 @@ This is a **transcription, not a second interview** — every answer was confirm
 ago, so don't re-ask any of it. Show the user the filled brief once and let them correct the voice:
 it is their document, and it is the one artifact here written for a human arriving cold rather than
 for the method.
+
+### `1.7` documents the design system that already exists
+Read `1.7`'s `## How this session works` as an *interview procedure*, not as its lens, and don't
+follow it here. It tells a greenfield run to generate rendered HTML option pages in a temporary
+`ui-design/` folder, offer three or four labelled directions per decision, and wait for the user to
+pick — machinery for reaching a decision nobody has made yet. This system already made them: the
+palette, the type scale, the spacing, the component set, the navigation pattern are all sitting in
+the code, the stylesheets, the design tokens, or the component library.
+
+So harvest and **document what is there**. Its decision list is still the right work list — walk it,
+read each answer out of the code, and confirm it. **No option pages, no `ui-design/` folder, no
+asking the user to choose** anything the product already ships. Accessibility and localization are
+harvested the same way: record what the code actually does, not what it should do.
+
+Where the code genuinely has no answer — no accessibility story, no localization, no documented
+component set — that is a **gap to record**, exactly like any other as-built gap: state the reality,
+flag it, and let the forward work decide. Don't design it now; a baseline describes.
 
 ### The sessions that need a word about the float
 Floating Phasing changes what the earlier sessions that read it can read, and gives Phasing itself a

--- a/Code/{{PROJECT}}-docs/architecture/README.md
+++ b/Code/{{PROJECT}}-docs/architecture/README.md
@@ -19,7 +19,9 @@ Most of these are produced by the **architecture sessions** during STEP-1
 > Filled in and reconciled by the **Cross-Cutting Review** once the docs exist, and kept
 > current at each **check-in** (`../runbooks/check-in.md`). Each doc's own
 > header is the authoritative Version/Status; this table is a convenience map. During STEP-1,
-> `prompts/STEP-index.md` is the live view of which sessions have produced their docs.
+> `prompts/STEP-index.md` is the live view of which sessions have produced their docs — except while
+> a project is adopting an existing codebase, where the index is held at its seed and the in-flight
+> STEP-1 PLAN carries that view instead (`RETCON-PROMPT.md`).
 
 | # | Doc | Version | Status |
 |---|-----|---------|--------|

--- a/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
@@ -40,9 +40,15 @@
 
 Every repo, doc, and resource discovered — the breadth pass. One row per asset.
 
-| Asset | Kind | Location | Notes |
-|-------|------|----------|-------|
-| {{name}} | {{repo / doc / data store / service / integration / CI / deploy surface / environment / observability / other}} | {{path / URL / host}} | {{one line — role, ownership, anything notable}} |
+**Scope** is the user's call at the confirm gate, not the scan's: `adopt` means this asset is
+brought under the method and gets a work substep; `excluded — <reason>` means it was found and
+deliberately left out (an abandoned service, a dead prototype, someone else's repo). An excluded
+row **stays here** — that it was seen and dismissed is exactly what this record is for — but the
+PLAN upgrade projects only the `adopt` rows into work.
+
+| Asset | Kind | Location | Scope | Notes |
+|-------|------|----------|-------|-------|
+| {{name}} | {{repo / doc / data store / service / integration / CI / deploy surface / environment / observability / other}} | {{path / URL / host}} | {{adopt / excluded — reason}} | {{one line — role, ownership, anything notable}} |
 
 ## Stack Per Repo
 

--- a/Code/{{PROJECT}}-docs/templates/retcon-preanswer-sheet.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-preanswer-sheet.md
@@ -1,6 +1,10 @@
 # {{PROJECT}} — Pre-answer sheet: {{N.N — session name}}
 
-**Session:** `{{templates/architecture-sessions/NN-....md}}`   <!-- the in-scope harvest session (1.1–1.13) this sheet covers -->
+**Session:** `{{templates/architecture-sessions/NN-....md}}`   <!-- the in-scope harvest session this
+                                                                   sheet covers — any row in the PLAN's
+                                                                   session table, including a lettered
+                                                                   conditional (1.7b); 1.14 is the
+                                                                   Cross-Cutting Review, not a harvest -->
 **Harvested:** {{YYYY-MM-DD}}
 **Sources read:** {{the confirmed recon map + which per-asset docs / inputs / code paths}}
 **Status:** {{Harvested → Confirmed}}   <!-- Stamp Harvested once EVERY row has a drafted answer;
@@ -11,10 +15,12 @@
 <!-- WHAT THIS IS. A pre-answer sheet is retcon's per-session hand-off: instead of interviewing a
      session cold, the harvest DRAFTS an answer to each of that session's decisions FROM REALITY
      (the confirmed recon map, the per-asset docs, and the running code), and the confirm pass then
-     walks every decision with the user. One sheet per in-scope harvest session (`1.1`–`1.13`; `1.14`
-     is the Cross-Cutting Review + land, not a harvest), keyed to that
+     walks every decision with the user. One sheet per in-scope harvest session — `1.1`–`1.13` plus
+     any lettered conditional the PLAN included (`1.14` is the Cross-Cutting Review + land, not a
+     harvest) — keyed to that
      session's decision list — NOT a pre-written draft of the doc (a draft doc anchors the user and
-     forces provenance into the final doc).
+     forces provenance into the final doc). Name the file from the substep id, letter and all:
+     `Upcoming Prompts/retcon/1.7b-native-app.md`.
 
      IT EVOLVES. Seed the rows from the session template's decision list, but treat the sheet as a
      living working doc, not a fixed form: add rows as harvest and confirm surface decisions the
@@ -29,8 +35,10 @@
         (code and a doc, or several files) — list every source in Provenance, not just the strongest.
      2. CONFIRM (with the user): walk each row proportionate to confidence × consequence — a
         from-code answer gets a fast "right?", a low-confidence or load-bearing one a real
-        discussion — and record the outcome in Confirm. Then write the clean `architecture/` doc at
-        its `Version` and `Status`. Record each decision by its Confirm outcome — independently of
+        discussion — and record the outcome in Confirm. Then write the clean `architecture/` doc
+        from `templates/architecture-doc-template.md`, at its `Version` and `Status` — the template
+        carries the `Version Log` that `scripts/check.sh` check 4 also requires, which a doc written
+        freehand loses. Record each decision by its Confirm outcome — independently of
         those two doc axes: a confirmed decision as plain fact; a decision left unconfirmed as
         `Coverage: deferred` with a `registries/risks.yml` row.
 

--- a/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
+++ b/Code/{{PROJECT}}-docs/templates/retcon-step-1-plan-stub.md
@@ -68,7 +68,7 @@ the way — not a pretty description a mature team already knows.
 | inv-1 | Intake | Depth dial set; rough repo/doc/resource locations, the project's lifecycle stage, and any house version convention recorded (RETCON-PROMPT.md Stage 1). | Planned |
 | inv-2 | Scan & inventory | A list of every repo, doc, and resource (data stores, services, integrations, CI, deploy surfaces, environments, observability); each existing doc classified with a trust level. | Planned |
 | inv-3 | Recon-map skeleton | A draft `reports/<date>-step-0001-recon-map.md` — inventory, stack per repo, entry points/services, data stores, integrations, existing-docs classification, test/CI presence, confidence/unknowns, and a **Coverage & Confidence** section. | Planned |
-| inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it. | Planned |
+| inv-4 | Confirm the inventory ▸ checkpoint | The **user-corrected** recon map — the birth-certificate checkpoint, before anything is built on it; each asset also marked `adopt` or `excluded — reason`. | Planned |
 | inv-5 | Upgrade this PLAN | **Append** (never rewrite) the per-asset substeps (`asset-N` id + Status) + the in-scope `1.1`–`1.14` sessions (`1.N` id + Status) + the `Conditional sessions considered` table; seed `registries/risks.yml` from the confirmed map's unknowns/coverage; then mark `inv-5` `Done` last (inv-1–inv-4 already `Done` from as-you-go marking). | Planned |
 
 ### Intake results (inv-1)
@@ -98,7 +98,9 @@ the way — not a pretty description a mature team already knows.
      UPGRADES this PLAN BY ADDITION — it does not rewrite any of it (the only in-place fill-ins are
      Stage 1's Intake-results values and flipping a substep's Status to Done — done as each substep
      completes, inv-5 marked last). It APPENDS, at the END of this PLAN (after Definition of done):
-       • the per-asset substeps — one row per repo/doc-set/resource in their own
+       • the per-asset substeps — one row per ADOPTED repo/doc-set/resource (the Inventory
+         rows the user marked `adopt` at inv-4; an `excluded` one stays recorded in the map
+         and gets no substep) in their own
          `# | Asset | Kind | Status` table (`asset-N` ids; same Status tracking as the inv-N
          table above), each documenting one asset so nothing is lost (a repo is not a 1.N
          session); resolve the lowest-open `asset-N` before 1.1;
@@ -138,7 +140,7 @@ the way — not a pretty description a mature team already knows.
 
 ## Definition of done (inventory phase)
 - [ ] inv-1–inv-4 complete: intake recorded, everything inventoried, the recon map drafted and
-      **confirmed by the user**.
+      **confirmed by the user** — including each asset's scope (`adopt` / `excluded — reason`).
 - [ ] inv-5 complete: this PLAN upgraded by addition — per-asset substeps (`asset-N` id + Status) + the
       in-scope 1.1–1.14 sessions (`1.N` id + Status) + the `Conditional sessions considered` table appended; `inv-5` marked
       `Done` last (inv-1–inv-4 already `Done` from as-you-go marking); `registries/risks.yml` seeded

--- a/init.sh
+++ b/init.sh
@@ -400,7 +400,11 @@ else
 fi
 
 # registries/ is always kept in multi-repo because setup-workspace.sh and remote recording use
-# it as the sibling-repo inventory. Mono can prune it because the root repo is self-contained.
+# it as the sibling-repo inventory. Mono can prune it because the root repo is self-contained —
+# EXCEPT when adopting an existing codebase, where the registries are working state rather than
+# inventory: RETCON-PROMPT.md registers every adopted repo in repos.yml and seeds risks.yml from
+# the confirmed recon map, so pruning them strands the adoption partway through with no
+# instruction. Validate the flag either way, then override, so a bad value is still an error.
 KEEP_REGISTRIES=1
 if [ "$LAYOUT" = "2" ]; then
   if [ -n "$REGISTRIES_IN" ]; then
@@ -409,8 +413,12 @@ if [ "$LAYOUT" = "2" ]; then
       n|no|false|0) KEEP_REGISTRIES=0 ;;
       *) echo "init.sh: invalid --registries '$REGISTRIES_IN' (yes | no)." >&2; exit 2 ;;
     esac
-  elif [ "$NONINTERACTIVE" != "1" ]; then
+  elif [ "$NONINTERACTIVE" != "1" ] && [ "$MODE" != "existing" ]; then
     yesno "Include registries/ (repo inventory; useful for multi-repo)?" || KEEP_REGISTRIES=0
+  fi
+  if [ "$MODE" = "existing" ] && [ "$KEEP_REGISTRIES" = "0" ]; then
+    KEEP_REGISTRIES=1
+    echo "  note: keeping registries/ — adopting an existing codebase records repos and risks there."
   fi
 fi
 

--- a/init.sh
+++ b/init.sh
@@ -162,7 +162,8 @@ Options:
   --license=NAME        mit | bsd-3 | apache-2.0 | private
   --holder=NAME         Copyright holder (required for open-source licenses)
   --layout=LAYOUT       multi | mono                    (default: multi)
-  --registries=yes|no   Keep registries/ (mono-repo only; default: yes)
+  --registries=yes|no   Keep registries/ (mono-repo only; default: yes; always kept
+                         with --mode=existing, which records repos and risks there)
   --collab=MODE         solo | team                     (default: solo)
   --adr-authority=TEXT  Who accepts ADRs (team only; default: consensus of maintainers)
   --trunk-branch=NAME   Generated repo trunk branch     (default: main)

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -135,6 +135,13 @@ run_existing_case() {
   # Every doc kind the recon map classifies needs a destination; a real decision record keeps its
   # own genre instead of being synthesized into an architecture doc.
   assert_file_contains "$docs/RETCON-PROMPT.md" "adopted into \`adr/\`, not synthesized away"
+  # A breadth scan finds things that shouldn't be adopted, so the confirm gate settles scope and the
+  # PLAN upgrade projects only the adopted rows into work.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "Complete is not the same as in scope"
+  assert_file_contains "$docs/templates/reports/recon-map-report-template.md" "excluded — <reason>"
+  # The UI session's option-page procedure is for deciding a design system, not describing one that
+  # already ships.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "documents the design system that already exists"
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -128,6 +128,13 @@ run_existing_case() {
   # Adoption skips the kickoff interview, so a session fills the project brief instead — otherwise
   # the project lands with overview.md still the blank template every later session reads first.
   assert_file_contains "$docs/RETCON-PROMPT.md" "also fills in \`overview.md\`"
+  # A lifted doc and an included conditional's output doc draw numbers from the same pool above the
+  # core block, but a conditional's is assigned in the PLAN long before any file carries it — so
+  # "free" has to mean unclaimed, not merely absent from disk.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "Free means unused on disk"
+  # Every doc kind the recon map classifies needs a destination; a real decision record keeps its
+  # own genre instead of being synthesized into an architecture doc.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "adopted into \`adr/\`, not synthesized away"
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).


### PR DESCRIPTION
A second review pass over the per-session harvest, read line by line against the files it actually consumes: the seventeen session templates, the registries it writes, the recon map it reads, and the base rules it borrows. Eleven fixes.

### Two could produce a wrong artifact

**A lifted document could take a number already spoken for.** A lifted doc and an included conditional session's output doc draw from the same pool of numbers above the core block — but a conditional's number is assigned in the PLAN long before that session runs, so no file carries it yet. An agent reading "next free number" as "not on disk" takes it, and the conditional collides later. *Free* now means unused on disk **and** unclaimed in the PLAN, and a lift records the number it took.

**Two kinds of found document had nowhere to go.** The recon map classifies every document it finds into six kinds; the harvest had a rule for two of them. A team's own decision records — written at the time, first-hand, the opposite of the reconstruction this method forbids — could only be synthesized away into an architecture doc, and so could a runbook. Now: real decision records are adopted into `adr/` with their original dates and a registry row, something merely ADR-*shaped* is treated as a design note, and a still-accurate runbook lands in `runbooks/`. The map's own disposition vocabulary is mapped onto these verbs, so a frozen map routes to the right rule.

### Three contradictions a literal reader would act on

- The table redirecting each session's index edits into the PLAN was missing one the very first session asks for (the open questions it carries forward), and claimed a count that was already wrong against its own rows. The list is open-ended now — that sentence has been wrong twice.
- Stage 2 states its resolution order absolutely, so an asset row appended during a later stage sent a resumed chat backwards over a half-walked session. Same stranding fixed earlier for late conditional rows, arriving through the other door; the carve-out now lives in both places.
- The paragraph granting the single pre-land index edit listed "phase heading" among the things never touched — revoking the exception it had just made.

### Seven narrower

Deferring an area is a live decision, not a harvested one, so the Security session's "capture deferrals as an ADR" is answered directly: propose, don't assume, and write the `Coverage:` line and risk row either way. Seeding `risks.yml` now names what `source` and `refs` point at during an adoption — that file's own rule sends a writer with no artifact to an ADR or a follow-up STEP, both of which adoption forbids. The pre-answer sheet still described the output doc by two of its three header fields, the missing one being what `check.sh` catches. Sheets are named from the substep id, letter included, the way substep prompts already are, so a lettered conditional's sheet is findable on resume. The Phasing session now clears the scaffolding comment under the phase heading, as the kickoff does, so both front doors leave that file alike. The rule for when a session's interview starts had a parenthetical that read as its own inverse. And the first file an adopting agent is told to read is now described as what it is at that moment: the blank template.

Two regression assertions added for the pair that would otherwise fail silently.

### Sequencing

Merge the base-line PR first. The `Coverage:` paragraph here shrinks to a pointer at `METHOD.md` §6, which that PR writes; a forward merge follows once it lands.

### Verification

- Suite 14/14.
- A fresh adoption fixture and a fresh greenfield one both regenerate `check.sh` at 0 fail / 0 warn, links clean, and `status.sh` routes correctly under the adoption marker.
- Greenfield inert: the two fixtures' `STEP-index.md` and `repos.yml` are byte-identical, and greenfield's `Upcoming Prompts/` stays empty.
