### PR TITLE
Make the coverage sweep read the field, not hunt for a phrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,13 @@ any project built with it.
   decision — but `METHOD.md` §6 and the architecture doc template both showed it as a lone token
   (`deferred`), so the reader who meets it months later can't tell whether the gap blocks them, and
   the check-in has nothing to weigh. Both now require one sentence: what is missing, how big it is,
-  and what it means for someone building on the doc.
+  and what it means for someone building on the doc, written as an ordinary bold header field
+  (`**Coverage:** deferred — …`).
+- **The deferred-coverage sweep looked for a string the docs don't contain.** `runbooks/check-in.md`
+  told the check-in to enumerate architecture docs "carrying `Coverage: deferred`" — but the field is
+  written like every other header field, so the literal phrase never appears, and now that its value
+  is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
+  takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -444,12 +444,16 @@ maturity **status**, and (optionally) a **coverage** note — plus a change log:
 - **`Coverage:`** *(optional)* — how completely the doc describes its area. Omit it (or `full`)
   when the doc fully covers the area; mark a deliberately fat or partial area `deferred` (or
   `enumerated to depth N`) so the gap is recorded rather than mistaken for drift. **Never leave it
-  a bare word.** Write the line as one sentence — what is missing, how big it is, and what it means
-  for someone building on this doc: *"`Coverage: deferred` — 40 of ~600 tables enumerated; the rest
-  are named but their columns and relations are unread, so anything designed against them needs
-  checking first."* A reader meeting that line months later can tell whether it blocks them; a bare
-  token tells them nothing and gets ignored. Every check-in resurfaces a `Coverage: deferred` doc
-  for an explicit disposition (`runbooks/check-in.md`).
+  a bare word.** It is a header field like the others, and its value is one sentence — what is
+  missing, how big it is, and what it means for someone building on this doc:
+
+  `**Coverage:** deferred — 40 of ~600 tables enumerated; the rest are named but their columns and
+  relations are unread, so anything designed against them needs checking first.`
+
+  A reader meeting that line months later can tell whether it blocks them; a bare token tells them
+  nothing and gets ignored. Because the value is a sentence, anything looking for deferred coverage
+  **reads the field and compares it to `full`** rather than searching for a fixed phrase — that is
+  how the check-in's deferred-coverage sweep resurfaces these docs (`runbooks/check-in.md`).
 - A **Version Log** table at the bottom: one row per change (version, date, STEP, what).
 
 ADRs are *not* versioned this way — they're dated, carry a Status (Accepted / Superseded /

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -268,12 +268,19 @@ rewritten.** Two edits to `templates/architecture-sessions/*.md` and three docum
   `templates/architecture-doc-template.md` both showed the optional `Coverage:` field as a lone
   token (`deferred`), which tells a reader arriving months later nothing about whether the gap
   blocks them — and gives the check-in that resurfaces it nothing to weigh. Both now ask for what is
-  missing, how big it is, and what it means for someone building on the doc. **One thing to check:**
+  missing, how big it is, and what it means for someone building on the doc, written as an ordinary
+  bold header field (`**Coverage:** deferred — …`). **One thing to check:**
   if any of your architecture docs already carries a bare `Coverage:` value, expand it the next time
   that doc is touched; nothing rewrites it for you.
+- **The deferred-coverage sweep now reads the field instead of matching a phrase.**
+  `runbooks/check-in.md` told the sweep to enumerate docs "carrying `Coverage: deferred`", a literal
+  string that a doc written from the template never contains — the field is bold, like every other
+  header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
+  `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
+  it is worth re-running the sweep once by hand.
 
-Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4 and §6, `inputs/README.md`, and
-`templates/architecture-doc-template.md` as a group. Nothing else is affected: no `status.sh` /
+Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4 and §6, `inputs/README.md`,
+`templates/architecture-doc-template.md`, and `runbooks/check-in.md` as a group. Nothing else is affected: no `status.sh` /
 `check.sh` change, no project state touched.
 
 ### 1.7.1 migration

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -105,8 +105,11 @@ is unwritten. That deferral must be **resurfaced, not silently forgotten** —
 each check-in re-reads it and decides its fate, so the gap lives in the roadmap instead of resting
 on a passive line in a doc.
 
-Enumerate every **non-`Deprecated`** `architecture/NN-*.md` carrying `Coverage: deferred` (read the
-`Coverage:` field — don't hard-code a list). A `Status: Deprecated` doc is **listed as retired** by
+Enumerate every **non-`Deprecated`** `architecture/NN-*.md` whose **`Coverage:` field** says
+anything other than `full` — **read the field, don't grep for a phrase**. The doc writes it as a
+header field and its value is a sentence (`**Coverage:** deferred — 40 of ~600 tables enumerated;
+…`), so a literal search for "Coverage: deferred" matches nothing; a doc with no `Coverage:` line
+at all is fully covered and not swept. A `Status: Deprecated` doc is **listed as retired** by
 the index reconciliation above (`METHOD.md` §6) and is **never** surfaced here for backfill. For
 each deferred doc, weigh the postponed area against what the system now does and what the near-term
 roadmap will build, and record one explicit **disposition** in this check-in report:
@@ -226,7 +229,7 @@ Write a short **check-in report** under `reports/` in the docs hub. Use
   filed) — with the fixes applied and the bugs filed.
 - **Conditional coverage:** every discovered conditional-session template and its current
   disposition; list any whose trigger fired and the follow-up STEP created or already pending.
-- **Deferred coverage:** each non-`Deprecated` doc carrying `Coverage: deferred`, its recorded
+- **Deferred coverage:** each non-`Deprecated` doc whose `Coverage:` field is not `full`, its recorded
   disposition (backfill now / still defer / risk-seeded), and any backfill STEP filed or existing
   one retained; a `Deprecated` such doc is noted as retired, not backfilled.
 - **Inputs:** live inputs reconciled against the architecture docs — rows newly marked `Superseded`


### PR DESCRIPTION
Follow-on to #123, found while re-reading that change in context.

Two renderings of the same field were in circulation. The doc template writes `Coverage:` bold, like every other header field; `METHOD.md` §6 showed it plain. `runbooks/check-in.md` then told the deferred-coverage sweep to enumerate every architecture doc "carrying `Coverage: deferred`" — a literal string that a doc written from the template never contains, because the field is bold, and which #123 pushed further out of reach by making the value run on into a sentence.

That sweep is the mechanism that stops a deferral from becoming a permanent silent gap, so a matcher that cannot match is the feature failing quietly — and failing in the direction that looks like good news ("no deferred coverage this check-in").

### What changed

- The sweep reads the **`Coverage:` field** and takes any value other than `full`. That survives both renderings and any future wording. A doc with no `Coverage:` line is fully covered and isn't swept.
- `METHOD.md` §6 shows the same bold rendering the template does, and says why anything looking for deferred coverage compares the field instead of searching for a phrase.
- The check-in report summary line matches.

### Scope

Documentation only — no script change, no project state touched. The migration note tells anyone upgrading to pull `runbooks/check-in.md` with the two files from #123, and suggests re-running the sweep once by hand if a past check-in reported no deferred coverage.

### Verification

Maintainer suite passes.
