### PR TITLE
Apply the project license only to repos the method creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ any project built with it.
   written like every other header field, so the literal phrase never appears, and now that its value
   is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
   takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
+- **The project license could be applied to a repo the method didn't create.** `METHOD.md` §7 lets a
+  repo be **registered in place** — referenced where it already sits instead of created under
+  `Code/` — but every instruction around `scripts/apply-project-license.sh` was written for a repo
+  the method had just scaffolded, and the helper itself checked only for a plain `LICENSE`. A repo
+  stating its terms any other way — `COPYING`, `NOTICE`, `LICENSE.md`, `LICENSE-<id>` — would take
+  the project's `LICENSE` and a `LICENSING.md` asserting that license over the entire repository,
+  written from an answer given at install time about code the method never authored. The helper now
+  refuses such a target before writing anything, and `METHOD.md` §7 states the rule the refusal
+  enforces — **the method records licensing; it never establishes licensing for code it did not
+  create** — with `AGENTS.md`, the planning session, and the repo README template all pointing at
+  it. A repo the method creates carries none of those files, so nothing about scaffolding a new
+  repo changes.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -135,6 +135,12 @@ that selection against the docs hub's canonical `LICENSE`, copies the project li
 for open-source projects, and creates no project `LICENSE` for proprietary projects. It also
 copies `LICENSE-THROUGHSTONE` because the standard generated repo retains Throughstone-authored
 README and CI scaffolding, and writes `LICENSING.md` to make those scopes explicit.
+**Run it only on a repo you create.** A repo **registered in place** — one that existed before
+this project did — keeps whatever licensing its owner set: read it, record it in the repo's
+`registries/repos.yml` entry, and leave it alone. The method records licensing; it never
+establishes licensing for code it did not create (`METHOD.md` §7), so do not apply the posture
+to such a repo, and do not treat a difference between it and the bootstrap selection as
+something to reconcile. The helper refuses a target that already states its own licensing.
 `scripts/setup-workspace.sh` sets up a new developer's machine (clones the siblings, writes
 the root pointers). From the workspace root, `./doctor.sh status`, `./doctor.sh check`, and
 `./doctor.sh links` are thin shortcuts to the docs hub's `scripts/status.sh`,

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -477,8 +477,8 @@ check-in report under `reports/` — then add the register row. **Every repo car
 what it is** — its role and the slice of the system it owns — stamped from that template and
 filled in when the repo is scaffolded (with a matching one-line `description` in
 `registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
-its root for its internal design. **Every new application-code repo also inherits the
-project-license posture established by `init.sh`:** read the authoritative selection from the
+its root for its internal design. **Every application-code repo the method *creates* also inherits
+the project-license posture established by `init.sh`:** read the authoritative selection from the
 docs hub's `.throughstone/project-license`. For an open-source selection, the docs hub must have
 a matching canonical `LICENSE`, which is copied unchanged to the new repo root. For
 `Proprietary`, the new repo gets no project `LICENSE`. Do not copy `LICENSE-THROUGHSTONE` into
@@ -486,6 +486,18 @@ application-code repos that contain no Throughstone-authored material. Repos sca
 this method do contain the Throughstone-authored README and CI starter, so
 `scripts/apply-project-license.sh` copies `LICENSE-THROUGHSTONE` and writes a visible
 `LICENSING.md` that distinguishes retained scaffold material from project-authored code.
+
+**The method records licensing; it never establishes licensing for code it did not create.** A
+repo **registered in place** (below) existed before the method reached it, so it already has an
+owner and a licensing status — a `LICENSE`, a `COPYING`, a `NOTICE`, vendored third-party terms,
+or a deliberate absence. Read what it uses and **record** it, in its `repos.yml` entry and
+wherever the architecture docs describe it; never apply a posture to it. A divergence from the
+`init.sh` selection is not an error to fix: that selection governs the method's own artifacts and
+the repos it creates, and several in-place repos may legitimately carry several different
+licenses. Choosing or changing a license for an existing repo is its owner's act, taken
+deliberately by them — never a side effect of adding the method to it. So
+`scripts/apply-project-license.sh` is run **only on a repo the method creates**; it refuses a
+target that already states its own licensing.
 
 **Where a repo lives — created as a sibling, or registered in place.** By default a repo is
 **created as a `Code/*` sibling** under the workspace root, and its `registries/repos.yml`

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -239,9 +239,10 @@ apply each area as a coherent review-required group, as with the legacy migratio
 
 ### 1.7.2 migration
 
-**Templates and guidance text only — no behavior changes, and nothing you already produced is
-rewritten.** Two edits to `templates/architecture-sessions/*.md` and three documentation fixes, all
-*Templates for future use* under §2, so they affect work you do after pulling them.
+**Templates, guidance text, and one guard added to a helper script — nothing you already produced
+is rewritten.** Edits to `templates/architecture-sessions/*.md`, documentation fixes, and a refusal
+added to `scripts/apply-project-license.sh`, all *Templates for future use* under §2, so they
+affect work you do after pulling them.
 
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
   here to run this session…" and ends by releasing a reader who wasn't sent to run it. When you
@@ -278,9 +279,24 @@ rewritten.** Two edits to `templates/architecture-sessions/*.md` and three docum
   header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
+- **The project license is applied only to repos the method creates.** `METHOD.md` §7 already let a
+  repo be **registered in place** — referenced where it sits, rather than created under `Code/` —
+  but every instruction around `scripts/apply-project-license.sh` was written as though every repo
+  were one the method had just scaffolded. Pointed at a repo that existed beforehand, the helper
+  would give it the project's `LICENSE` and a `LICENSING.md` asserting that license over the whole
+  repository. It now **refuses** a target that already states its own terms (`COPYING`, `NOTICE`,
+  `LICENSE.md`, `LICENSE-<id>`, …) before writing anything, and `METHOD.md` §7, `AGENTS.md`, the
+  planning session, and the repo README template state the rule: **the method records licensing; it
+  never establishes licensing for code it did not create.** No effect on repos you scaffolded
+  through the method — they carry none of those files, and re-running the helper on one behaves
+  exactly as before. **One thing to check:** if you have registered an existing repo in place and
+  ran the helper on it, look at that repo's `LICENSE` / `LICENSING.md` and decide, as its owner,
+  whether they say what you intend.
 
-Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4 and §6, `inputs/README.md`,
-`templates/architecture-doc-template.md`, and `runbooks/check-in.md` as a group. Nothing else is affected: no `status.sh` /
+Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4, §6 and §7, `AGENTS.md`,
+`inputs/README.md`, `templates/architecture-doc-template.md`, `templates/planning-session.md`,
+`templates/repo-readme-template.md`, `runbooks/check-in.md`, and
+`scripts/apply-project-license.sh` as a group. Nothing else is affected: no `status.sh` /
 `check.sh` change, no project state touched.
 
 ### 1.7.1 migration

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -6,6 +6,13 @@
 # extra license file cannot silently change whether the generated project is open-source or
 # proprietary. This helper is for newly scaffolded application-code repos that retain
 # Throughstone-authored README / CI material.
+#
+# It applies only to a repo the method CREATES. A repo that existed before the method reached it
+# — registered in place by its registries/repos.yml `location:` — already has an owner and a
+# licensing status, and setting a license for it is that owner's act, not the method's: read what
+# it already uses and record it, never apply. The pre-existing-licensing check below refuses such
+# a target, so pointing this helper at the wrong kind of repo fails loudly instead of writing a
+# license claim over code the method did not author.
 
 set -euo pipefail
 
@@ -24,6 +31,25 @@ if [ ! -d "$TARGET" ]; then
   echo "apply-project-license.sh: target directory does not exist: $TARGET" >&2
   exit 2
 fi
+
+# find_pre_existing_licensing TARGET — list root-level licensing files this helper never writes.
+# Reads: TARGET's root directory entries.
+# Writes: nothing (prints one path per line).
+# Returns: 0 always; empty output means the target carries no such file.
+#
+# A repo the method creates carries none of these, so this is inert on the path the helper is
+# for. A repo that predates the method may carry any of them — COPYING for a GPL project, NOTICE
+# for a project with attribution obligations, LICENSE.md/LICENSE-<id> for the many projects that
+# name the file differently. Plain LICENSE is deliberately not listed: verify_compatible already
+# rejects a differing one, and an identical one is this helper's own idempotent re-run.
+find_pre_existing_licensing() {
+  find "$1" -mindepth 1 -maxdepth 1 \
+    \( -iname 'COPYING*' -o -iname 'COPYRIGHT*' -o -iname 'NOTICE*' \
+       -o -iname 'LICENCE*' -o -iname 'LICENSE.*' -o -iname 'LICENSE-*' \
+       -o -iname 'LICENSES' \) \
+    ! -name 'LICENSE-THROUGHSTONE' \
+    -print 2>/dev/null | LC_ALL=C sort
+}
 
 # verify_compatible SOURCE TARGET LABEL — reject an existing target with different content.
 # Reads: SOURCE and TARGET, if TARGET exists.
@@ -50,6 +76,23 @@ copy_if_missing() {
     echo "$label: $target"
   fi
 }
+
+# Refuse a repo that already states its own licensing, before reading the posture or writing
+# anything. This is the guard against the destructive case: a target with no plain LICENSE but a
+# COPYING or NOTICE would otherwise take the project's LICENSE and a LICENSING.md asserting that
+# license over the whole repository — a claim about code the method did not write.
+PRE_EXISTING_LICENSING="$(find_pre_existing_licensing "$TARGET")"
+if [ -n "$PRE_EXISTING_LICENSING" ]; then
+  echo "apply-project-license.sh: target already states its own licensing:" >&2
+  printf '%s\n' "$PRE_EXISTING_LICENSING" | while IFS= read -r found; do
+    echo "  $found" >&2
+  done
+  echo "apply-project-license.sh: this helper applies the project posture to repos this method" >&2
+  echo "        creates. A repo that already existed keeps the licensing its owner set — record" >&2
+  echo "        what it uses (in the repo inventory and its architecture docs) rather than" >&2
+  echo "        applying a license to it. Nothing was written." >&2
+  exit 1
+fi
 
 # The posture file is written during bootstrap and must contain one of the supported
 # project-license IDs. It decides the licensing path; LICENSE files are validated against it,

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -87,7 +87,11 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    for an open-source selection, and copies that file unchanged. For `Proprietary`, no project
    `LICENSE` is created. It also copies `LICENSE-THROUGHSTONE`, because the standard repo README
    and CI starter are retained Throughstone-authored scaffold material, and writes
-   `LICENSING.md` to make clear that notice is not the application-code license. Repository
+   `LICENSING.md` to make clear that notice is not the application-code license. **Run it only on
+   repos you create** — a repo **registered in place**, which existed before this project did,
+   keeps the licensing its owner set (`METHOD.md` §7: the method records licensing, it never
+   establishes licensing for code it did not create). Record what such a repo uses and move on;
+   the helper refuses it. Repository
    visibility is separate: when adding a remote for each code repo, choose private or public
    deliberately rather than inferring it from the license. Publishing a proprietary repo makes
    its source visible without granting open-source reuse rights, so call that out explicitly.

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -14,12 +14,21 @@
   `templates/ci/code-repo-ci.yml` into this repo's `.github/workflows/ci.yml` and fill in its
   stack's test command (see `templates/ci/README.md`).
 
-  Apply the project license established at bootstrap by running
+  For a repo this method CREATES, apply the project license established at bootstrap by running
   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <this-repo-path>`. It copies the
   docs hub's canonical `LICENSE` unchanged for open-source projects. Proprietary projects
   get no project license file. It also copies `LICENSE-THROUGHSTONE` for this retained
   Throughstone-authored README/CI scaffolding and writes `LICENSING.md` to make the boundary
   between the two licenses explicit.
+
+  For a repo REGISTERED IN PLACE — one that existed before this project did — do NOT run it.
+  That repo already has an owner and a licensing status; the method records licensing, it never
+  establishes licensing for code it did not create (`METHOD.md` §7). Read what the repo uses
+  (`LICENSE`, `COPYING`, `NOTICE`, package metadata, vendored third-party terms, or a deliberate
+  absence), record that, and leave its licensing alone — including when it differs from the
+  bootstrap selection, which governs only this method's own artifacts and the repos it creates.
+  The Licensing section below describes a repo the method created; drop or rewrite it to match
+  reality in a repo it did not.
 -->
 
 ## Overview

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -420,6 +420,65 @@ run_missing_canonical_license_case() {
   assert_maintainer_tests_removed "$name" "$work"
 }
 
+# run_pre_existing_licensing_case — a repo that already states its own licensing must be refused
+# before anything is written. This is the created-vs-registered-in-place boundary: the method
+# records licensing for a repo it did not create, and never applies a posture to it.
+run_pre_existing_licensing_case() {
+  local name="license-pre-existing"
+  local work="$TMP_ROOT/$name"
+  local marker target status written
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Pre-existing licensing test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  # Each marker is a way a repo states its own terms without a plain LICENSE file, so none can be
+  # mistaken for this helper's own earlier run. Without the guard, every one of these targets
+  # would take an MIT LICENSE plus a LICENSING.md asserting MIT over the whole repository.
+  for marker in COPYING NOTICE COPYRIGHT LICENSE.md LICENSE-APACHE; do
+    target="$work/Code/$name-$(printf '%s' "$marker" | tr '[:upper:].' '[:lower:]-')"
+    mkdir -p "$target"
+    printf 'pre-existing terms\n' > "$target/$marker"
+    set +e
+    "$work/Code/$name-docs/scripts/apply-project-license.sh" \
+      "$target" >"$TMP_ROOT/$name-$marker.out" 2>&1
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || {
+      echo "FAIL: helper did not refuse a target carrying $marker" >&2
+      return 1
+    }
+    grep -Fq "target already states its own licensing" "$TMP_ROOT/$name-$marker.out" || {
+      echo "FAIL: refusal for $marker did not name the rule" >&2
+      return 1
+    }
+    grep -Fq "$marker" "$TMP_ROOT/$name-$marker.out" || {
+      echo "FAIL: refusal for $marker did not name the file it found" >&2
+      return 1
+    }
+    # The refusal happens before the first copy, so the target keeps only what it arrived with.
+    for written in LICENSE LICENSE-THROUGHSTONE LICENSING.md; do
+      [ ! -e "$target/$written" ] || {
+        echo "FAIL: helper wrote $written into a target carrying $marker" >&2
+        return 1
+      }
+    done
+  done
+
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
 # run_private_mono_case — the single repo retains and explains Throughstone's notice at root
 # without creating a project LICENSE for proprietary code.
 run_private_mono_case() {
@@ -599,6 +658,11 @@ run_public_proprietary_case
 run_invalid_visibility_case
 run_manual_multi_remote_case
 run_missing_canonical_license_case
+
+# --- Repos the method did not create -------------------------------------------
+# A repo registered in place keeps the licensing its owner set; the helper must refuse it rather
+# than write a license claim over code the method did not author.
+run_pre_existing_licensing_case
 
 # --- Invalid inputs fail before destructive bootstrap work ---------------------
 # Bad license input and missing license templates are detected before template files,


### PR DESCRIPTION
`METHOD.md` §7 lets a repo be **registered in place** — referenced where it already sits instead of created under `Code/` — but every instruction around `scripts/apply-project-license.sh` was written for a repo the method had just scaffolded, and the helper itself checked only for a plain `LICENSE`.

So a repo that states its terms any other way — `COPYING`, `NOTICE`, `LICENSE.md`, `LICENSE-<id>` — sailed through: it would take the project's `LICENSE` plus a `LICENSING.md` asserting that license over the entire repository. That is a claim about code the method never authored, written silently from an answer given at install time.

## What changed

- **`scripts/apply-project-license.sh` refuses a target that already states its own licensing**, before reading the posture or writing anything, and explains what to do instead. Plain `LICENSE` is deliberately not part of that check — a differing one was already refused, and an identical one is the helper's own idempotent re-run.
- **`METHOD.md` §7 states the rule the refusal enforces:** the method records licensing; it never establishes licensing for code it did not create. A repo registered in place keeps whatever its owner set, a divergence from the bootstrap selection is not an error to fix, and several in-place repos may legitimately carry several different licenses.
- **`AGENTS.md`, `templates/planning-session.md`, and `templates/repo-readme-template.md`** now say the helper is for repos the method creates, and what to do for one it did not: read the licensing, record it, leave it alone.
- **`tests/init-license-validation.sh`** covers the refusal for each marker file, asserts the message names both the rule and the file it found, and asserts nothing is written into the target.

## Greenfield impact

None. A repo the method creates carries none of those files, so scaffolding a new repo behaves exactly as before, as does re-running the helper on one already stamped.

## Verified

- Full maintainer suite 11/11.
- Removing the guard makes the new assertions fail (exit 1), so the test bites.
- Fresh generated project from this branch: `check.sh` 0 fail / 0 warn, `links.sh` 0 fail. In that project the helper stamps a newly created repo, is idempotent on re-run, and refuses a repo carrying `COPYING` + `NOTICE` while leaving it untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
