### PR TITLE
Record an adopted repo's licensing instead of setting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ error/corruption and re-run paths, not normal operation.
     warning then follows the gap: the doc's `Coverage:` line says what is missing, how big it is, and
     what it means for someone building on it (never a bare "deferred"), and a genuinely risky gap gets
     a `risks.yml` row the periodic check-in re-surfaces.
+  - **Your repos' licensing is recorded, never set.** Adoption registers every repo where it already
+    sits, so each one's licensing stays its owner's: the recon map records what each repo actually
+    says — the identifier and the file it came from, `none stated` where nothing does, plus vendored
+    third-party terms — and nothing writes a `LICENSE` into a repo you already had. The license you
+    pick at install time covers this method's own artifacts and anything it creates for you, so a
+    repo whose license differs from it is not a problem to fix, and adopted repos carrying several
+    different licenses is a normal result rather than an inconsistency.
 
 ### Changed
 - **`status.sh` no longer guesses when the kickoff marker is missing.** If `overview.md` exists but

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -143,7 +143,8 @@ is complete.
 
 ### `inv-3` — Draft the recon map
 Copy `templates/reports/recon-map-report-template.md` to `reports/YYYY-MM-DD-step-0001-recon-map.md`
-and fill every section from the scan: inventory, stack per repo, entry points/services, data stores,
+and fill every section from the scan: inventory, stack per repo (including each repo's licensing
+**as found** — recorded, never set), entry points/services, data stores,
 integrations, existing-docs classification + trust, tests/CI, and the confidence/unknowns. Propose a
 **Scope** for each Inventory row (`adopt` unless the code says otherwise) — the user settles it at
 `inv-4`; a draft proposal is not the decision. Stamp the
@@ -285,6 +286,18 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   record a short per-repo note (stack, entry points, role) in that README — its living home, which the
   owning `architecture/` docs deepen later (never back into the frozen recon map). Register repos
   **in place** by their real location; never relocate the user's code.
+  **Never license an adopted repo.** Every repo here is registered in place, so its licensing is
+  its owner's and the method only records it (`METHOD.md` §7: the method records licensing; it
+  never establishes licensing for code it did not create). Concretely: do **not** run
+  `scripts/apply-project-license.sh` against any of these repos — it will refuse one that states
+  its own terms, and the ones it would not refuse are exactly the repos that would silently gain a
+  `LICENSE` and a `LICENSING.md` claiming it over code you did not write. The repo's licensing
+  went into the recon map's **Stack Per Repo** row at `inv-3`; that record is the whole of the
+  work here. The license chosen at install time governs this method's own artifacts — the docs hub
+  and anything it later creates — not the code being adopted, so a repo whose license differs from
+  it is **not a finding**, several adopted repos may carry several different licenses, and none of
+  that is reconciled. If the user raises relicensing, it is their act on their repo: say what you
+  observed and stop there.
 - **Per doc-set** — copy the found source docs into `inputs/` and add each one's
   `inputs/inputs-index.md` row(s) (`Live`), per the base inputs lifecycle (point-in-time; the code
   wins on conflict). Their

--- a/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
@@ -52,9 +52,20 @@ PLAN upgrade projects only the `adopt` rows into work.
 
 ## Stack Per Repo
 
-| Repo | Languages | Frameworks / runtimes | Build / package manager | Notes |
-|------|-----------|-----------------------|-------------------------|-------|
-| {{repo}} | {{langs}} | {{frameworks, runtime versions}} | {{tool}} | {{monorepo? generated code? notable pins}} |
+**Licensing is recorded as found, never set here.** These repos existed before the method reached
+them, so each one's licensing is its owner's, and the method's job is to write down what is
+already true (`METHOD.md` §7). Read the repo root — `LICENSE`, `COPYING`, `NOTICE`, `LICENSE.md`,
+`LICENSE-<id>` — plus the `license` field in its package metadata (`package.json`,
+`pyproject.toml`, `Cargo.toml`, `*.gemspec`, …), and note vendored third-party trees that carry
+their own terms. Record what you find: an identifier and the file it came from
+(`GPL-2.0 (COPYING)`), or `none stated` when the repo says nothing, which is itself a fact worth
+recording rather than a gap to fill. Where the repo's own files disagree with each other, say so
+instead of picking a winner. Nothing here is compared against, or reconciled with, the license
+chosen at install time.
+
+| Repo | Languages | Frameworks / runtimes | Build / package manager | Licensing (as found) | Notes |
+|------|-----------|-----------------------|-------------------------|----------------------|-------|
+| {{repo}} | {{langs}} | {{frameworks, runtime versions}} | {{tool}} | {{identifier (file it came from) / none stated; + vendored terms}} | {{monorepo? generated code? notable pins}} |
 
 ## Entry Points & Services
 

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -142,6 +142,17 @@ run_existing_case() {
   # The UI session's option-page procedure is for deciding a design system, not describing one that
   # already ships.
   assert_file_contains "$docs/RETCON-PROMPT.md" "documents the design system that already exists"
+  # Every adopted repo is registered in place, so the method records its licensing and never sets
+  # it. Losing either half is silent: the prohibition is the only thing standing between the
+  # README stamp comment's license instruction and someone's production repo, and the recon-map
+  # column is the record that makes "record it" an actual place rather than a sentiment.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "Never license an adopted repo"
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "\`scripts/apply-project-license.sh\` against any of these repos"
+  assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
+    "Licensing (as found)"
+  assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
+    "Licensing is recorded as found, never set here"
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).


### PR DESCRIPTION
The adoption half of the licensing rule landed on the base line in #126. This is the reader-side instruction that makes it concrete for an adoption.

## The problem

Every repo an adoption registers is **registered in place** — the user's code, where it already sits. But the per-asset substep told the agent to stamp a README from `templates/repo-readme-template.md`, and that template's stamp comment tells it to run `scripts/apply-project-license.sh` on the repo. Pointed at someone's existing production repo, that writes a `LICENSE` and a `LICENSING.md` asserting that license over code the method never authored.

\#126 makes the helper refuse a repo that states its own terms, and makes the template comment distinguish a repo the method created from one it adopted. But an adoption shouldn't be relying on a downstream refusal — and a repo that states *nothing* is exactly the one the helper cannot refuse.

## What changed

- **`RETCON-PROMPT.md`'s per-repo substep states the prohibition directly** — never run the helper against an adopted repo — rather than depending on the template comment's clause being read.
- **The record has a home.** The recon map's **Stack Per Repo** table gains a **Licensing (as found)** column: the identifier and the file it came from (`GPL-2.0 (COPYING)`), `none stated` where the repo says nothing, vendored third-party trees that carry their own terms, and disagreement between a repo's own files reported rather than resolved. `inv-3`'s fill list names it, so it isn't collected only if someone happens to read the template closely.
- **Divergence from the install-time selection is explicitly not a finding.** That selection governs the method's own artifacts and what it creates; adopted repos may carry several different licenses, and none of that is reconciled. Relicensing stays the user's act on the user's repo.
- **`tests/init-retcon-mode.sh`** asserts both halves ship — the prohibition and the recon-map column — since losing either is silent.

## Verified

- Full maintainer suite 14/14.
- Fresh adoption fixture (`--mode=existing`, built from a `git archive` of this branch): `check.sh` 0 fail / 0 warn, `links.sh` 0 fail, both rules present in the generated docs hub with no unresolved placeholders.
- Greenfield inert: fresh greenfield fixture from the same branch has a byte-identical `STEP-index.md` and `repos.yml`, an empty `Upcoming Prompts/`, and `check.sh` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
