### PR TITLE
Say what the license posture actually covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ any project built with it.
   create** — with `AGENTS.md`, the planning session, and the repo README template all pointing at
   it. A repo the method creates carries none of those files, so nothing about scaffolding a new
   repo changes.
+- **`.throughstone/project-license` was described more broadly than it acts.** It was called "the
+  project-license posture" and "the authoritative selection" everywhere, but it only ever governs
+  **Throughstone-authored and method-created material** — the docs hub, `prompts/`, and any repo
+  the method creates. In a project built entirely from scratch those are the same set; in one that
+  also references code it did not create they are not, and the wider reading is what sent the
+  posture into repos it had no business licensing. `METHOD.md` §7, `AGENTS.md`, the planning
+  session, the helper's own header, and both licensing banners now say the narrower thing, which
+  is what was always true.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -127,17 +127,19 @@ pointers are committed files; see `METHOD.md` §7.) The repos are siblings:
 entry points to a repo whose **README is its "about"** (what it is, how to set it up; plus an
 `ARCHITECTURE.md` if it has deep internals). **Before working in a repo, read its README
 first** — the same way you read the architecture docs before a design change.
-When creating an application-code repo, also apply the project-license posture recorded at
+When creating an application-code repo, also apply the license posture recorded at
 bootstrap by running
 `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <new-repo-path>`. The authoritative
-selection is in `Code/{{PROJECT}}-docs/.throughstone/project-license`; the helper validates
+selection is in `Code/{{PROJECT}}-docs/.throughstone/project-license`, and it covers
+**Throughstone-authored and method-created material** — this docs hub, `prompts/`, and any repo
+the method creates — not code the method didn't write; the helper validates
 that selection against the docs hub's canonical `LICENSE`, copies the project license unchanged
 for open-source projects, and creates no project `LICENSE` for proprietary projects. It also
 copies `LICENSE-THROUGHSTONE` because the standard generated repo retains Throughstone-authored
 README and CI scaffolding, and writes `LICENSING.md` to make those scopes explicit.
 **Run it only on a repo you create.** A repo **registered in place** — one that existed before
-this project did — keeps whatever licensing its owner set: read it, record it in the repo's
-`registries/repos.yml` entry, and leave it alone. The method records licensing; it never
+this project did — keeps whatever licensing its owner set: read it, record it as found beside
+that repo's `registries/repos.yml` entry, and leave it alone. The method records licensing; it never
 establishes licensing for code it did not create (`METHOD.md` §7), so do not apply the posture
 to such a repo, and do not treat a difference between it and the bootstrap selection as
 something to reconcile. The helper refuses a target that already states its own licensing.

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -4,8 +4,9 @@
 
 > Built with **Throughstone** — this file and the other scaffold files (`templates/`,
 > `runbooks/`, `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause; the full text is
-> retained as `LICENSE-THROUGHSTONE` in this docs hub. Your own application code is under the
-> open-source license you chose at setup or remains private/proprietary. For open-source
+> retained as `LICENSE-THROUGHSTONE` in this docs hub. Application code this project creates is
+> under the open-source license you chose at setup or remains private/proprietary; a repo that
+> existed before this project keeps the licensing its owner set (§7). For open-source
 > projects, the docs hub's `LICENSE` is the canonical project-license file copied into each
 > application-code repo when that repo is created. The durable selection is recorded separately
 > in `.throughstone/project-license`, so a missing license file cannot silently change it.
@@ -478,8 +479,12 @@ what it is** — its role and the slice of the system it owns — stamped from t
 filled in when the repo is scaffolded (with a matching one-line `description` in
 `registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
 its root for its internal design. **Every application-code repo the method *creates* also inherits
-the project-license posture established by `init.sh`:** read the authoritative selection from the
-docs hub's `.throughstone/project-license`. For an open-source selection, the docs hub must have
+the license posture established by `init.sh`:** read the authoritative selection from the docs
+hub's `.throughstone/project-license`. That file records the license for **Throughstone-authored
+and method-created material** — this docs hub, `prompts/`, and any repo the method creates — which
+in a project built from scratch is everything, and in a project that also references code it did
+not create is exactly that subset. It is not a claim about code the method didn't write. For an
+open-source selection, the docs hub must have
 a matching canonical `LICENSE`, which is copied unchanged to the new repo root. For
 `Proprietary`, the new repo gets no project `LICENSE`. Do not copy `LICENSE-THROUGHSTONE` into
 application-code repos that contain no Throughstone-authored material. Repos scaffolded through
@@ -490,8 +495,9 @@ this method do contain the Throughstone-authored README and CI starter, so
 **The method records licensing; it never establishes licensing for code it did not create.** A
 repo **registered in place** (below) existed before the method reached it, so it already has an
 owner and a licensing status — a `LICENSE`, a `COPYING`, a `NOTICE`, vendored third-party terms,
-or a deliberate absence. Read what it uses and **record** it, in its `repos.yml` entry and
-wherever the architecture docs describe it; never apply a posture to it. A divergence from the
+or a deliberate absence. Read what it uses and **record** it as found — in the repo inventory
+entry that describes it, and wherever the architecture docs cover it; never apply a posture to
+it. A divergence from the
 `init.sh` selection is not an error to fix: that selection governs the method's own artifacts and
 the repos it creates, and several in-place repos may legitimately carry several different
 licenses. Choosing or changing a license for an existing repo is its owner's act, taken

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -36,8 +36,9 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 
 > Built with **Throughstone**. The scaffold files (`METHOD.md`, `templates/`, `runbooks/`,
 > `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause — full text in
-> `LICENSE-THROUGHSTONE`. Your application code and project docs are yours, under the
-> open-source license you chose at setup or kept private/proprietary. For open-source projects,
+> `LICENSE-THROUGHSTONE`. Your application code and project docs are yours. What this project
+> creates is under the open-source license you chose at setup or kept private/proprietary; a repo
+> that existed beforehand keeps the licensing its owner set. For open-source projects,
 > this repo's `LICENSE` is the canonical project-license file copied unchanged into each
 > application-code repo when it is created. `.throughstone/project-license` records the durable
 > selection independently, and the repo-scaffolding helper validates the two before copying.

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -292,8 +292,14 @@ affect work you do after pulling them.
   exactly as before. **One thing to check:** if you have registered an existing repo in place and
   ran the helper on it, look at that repo's `LICENSE` / `LICENSING.md` and decide, as its owner,
   whether they say what you intend.
-
-Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4, §6 and §7, `AGENTS.md`,
+- **`.throughstone/project-license` is described more narrowly.** The posture file was called "the
+  project license" everywhere, but it only ever governed **Throughstone-authored and method-created
+  material** — your docs hub, `prompts/`, and any repo the method creates. Nothing about the file
+  changes; the wording around it does, in `METHOD.md` §7, `AGENTS.md`, `README.md`, the planning
+  session, and the helper's header. Pull them with the group below. **One thing to check:** if a
+  repo of yours was registered in place rather than created by the method, its licensing is its
+  own — record what it actually uses beside its inventory entry rather than assuming the posture.
+Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4, §6 and §7, `AGENTS.md`, `README.md`,
 `inputs/README.md`, `templates/architecture-doc-template.md`, `templates/planning-session.md`,
 `templates/repo-readme-template.md`, `runbooks/check-in.md`, and
 `scripts/apply-project-license.sh` as a group. Nothing else is affected: no `status.sh` /

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -4,7 +4,9 @@
 #
 # The posture file is the durable source of truth, separate from LICENSE, so a missing or
 # extra license file cannot silently change whether the generated project is open-source or
-# proprietary. This helper is for newly scaffolded application-code repos that retain
+# proprietary. It records the license for THROUGHSTONE-AUTHORED AND METHOD-CREATED material —
+# the docs hub, prompts/, and any repo the method creates — not for code the method did not
+# write. This helper is for newly scaffolded application-code repos that retain
 # Throughstone-authored README / CI material.
 #
 # It applies only to a repo the method CREATES. A repo that existed before the method reached it

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -81,17 +81,18 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    `.env.example`, and adding a **stack-appropriate `.gitignore`** to each new code repo
    (language/build artifacts — `node_modules/`, `__pycache__/`, `target/`, `dist/`, … — plus
    the `.env` / `.secrets/` secret-file block so local secrets never get committed). Apply the
-   project-license posture too: run
+   license posture too: run
    `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <new-repo-path>` for every new code
-   repo. It reads `.throughstone/project-license`, requires the canonical docs-hub `LICENSE`
+   repo. It reads `.throughstone/project-license` — which covers Throughstone-authored and
+   method-created material, not code the method didn't write — requires the canonical docs-hub `LICENSE`
    for an open-source selection, and copies that file unchanged. For `Proprietary`, no project
    `LICENSE` is created. It also copies `LICENSE-THROUGHSTONE`, because the standard repo README
    and CI starter are retained Throughstone-authored scaffold material, and writes
    `LICENSING.md` to make clear that notice is not the application-code license. **Run it only on
    repos you create** — a repo **registered in place**, which existed before this project did,
    keeps the licensing its owner set (`METHOD.md` §7: the method records licensing, it never
-   establishes licensing for code it did not create). Record what such a repo uses and move on;
-   the helper refuses it. Repository
+   establishes licensing for code it did not create). Record what such a repo uses where its
+   inventory entry describes it and move on; the helper refuses it. Repository
    visibility is separate: when adding a remote for each code repo, choose private or public
    deliberately rather than inferring it from the license. Publishing a proprietary repo makes
    its source visible without granting open-source reuse rights, so call that out explicitly.


### PR DESCRIPTION
Follow-up to #126, on the same question. **Rescoped after review:** the `registries/repos.yml` `license:` field this PR originally carried has moved to the 2.0 line, where it has a reason to exist — see the note at the bottom. What's left here is the wording, which does belong on the 1.7.x line because #126 is already here.

## The problem

`.throughstone/project-license` is called "the project-license posture" and "the authoritative selection" in `METHOD.md` §7, `AGENTS.md`, `README.md`, the planning session, and the helper's own header. But it only ever governs **Throughstone-authored and method-created material** — the docs hub, `prompts/`, and any repo the method creates.

In a project built entirely from scratch that set is everything, which is why the loose wording read as true. In a project that also **registers a repo in place** — allowed by `METHOD.md` §7 since 1.7.0 — it is strictly smaller, and the wider reading is exactly what sent the posture into repos it had no business licensing (#126).

Both licensing banners went further still, telling the reader their application code is under the license they chose at setup. That is false for a repo that existed before the project did.

And #126 left a loose end here: §7 says to record an in-place repo's licensing "in its `repos.yml` entry", which asks for a record with nowhere to put it.

## What changed

- **Every consumer states the narrower scope** — `METHOD.md` §7, `AGENTS.md`, `README.md`, `templates/planning-session.md`, and `scripts/apply-project-license.sh`'s header.
- **Both licensing banners** (`METHOD.md` and the docs-hub `README.md`) scope their claim to what the project creates, and say a repo that existed beforehand keeps the licensing its owner set.
- **§7's "record it" is now something you can actually do today** — as found, beside the repo's inventory entry and in the architecture docs that cover it.

No file-format change, so the helper's `cat`/`case` reader and every existing test are untouched. This is documentation only.

## Verified

Full maintainer suite 11/11.

## Deliberately not here

The `license:` inventory field. Its motivation is a project whose repos carry *different* licenses, which doesn't arise until a project can adopt code it didn't create — and the precedent for a base inventory field written by both front doors (`throughstone: managed`) put it on the 2.0 line, not in a patch release. Landing it here would also cost every existing project a migration item for a field nothing reads yet. It goes to the 2.0 branch with the adoption work that needs it, and §7 gets sharpened there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
