### PR TITLE
Say what the license question covers when adopting a codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,10 @@ error/corruption and re-run paths, not normal operation.
     third-party terms — and nothing writes a `LICENSE` into a repo you already had. The license you
     pick at install time covers this method's own artifacts and anything it creates for you, so a
     repo whose license differs from it is not a problem to fix, and adopted repos carrying several
-    different licenses is a normal result rather than an inconsistency.
+    different licenses is a normal result rather than an inconsistency. `init.sh` now says that at
+    the point it asks: when you're adopting, the license and copyright-holder questions state up
+    front that they cover the documentation hub being created and anything created later, not the
+    code you're bringing — so you aren't answering about repos that already have their own answer.
 
 ### Changed
 - **`status.sh` no longer guesses when the kickoff marker is missing.** If `overview.md` exists but

--- a/init.sh
+++ b/init.sh
@@ -337,7 +337,21 @@ DESC="$(want "$DESC_IN" 'One-line description')"
 # License — accept a friendly token from --license, else ask the two-part question. The durable
 # result is PROJECT_LICENSE_ID, written later to .throughstone/project-license so generated
 # helpers can distinguish proprietary projects from missing LICENSE files.
+#
+# When adopting an existing codebase the question needs its scope said out loud. The repos being
+# adopted already answer "open source or proprietary?" — possibly differently from each other —
+# and a user reading the bare question reasonably thinks they are recording that fact about their
+# code. They are not: this selection covers the documentation hub being created here and anything
+# the method creates later, and their existing repos keep the licensing their owners set (the
+# method records licensing, it never establishes it for code it did not create). The same scope
+# governs the copyright-holder answer below, which is why the note precedes both.
 LICENSE_CHOICE=""
+if [ "$MODE" = "existing" ] && [ -z "$LICENSE_IN" ] && [ "$NONINTERACTIVE" != "1" ]; then
+  echo
+  echo "  The next two answers cover the documentation hub Throughstone is creating for you,"
+  echo "  and any repo it creates later — NOT the code you're adopting. Your existing repos keep"
+  echo "  whatever licensing they already have; the agent records what it finds, never changes it."
+fi
 if [ -n "$LICENSE_IN" ]; then
   normalize_license_choice "$LICENSE_IN" \
     || { echo "init.sh: invalid --license '$LICENSE_IN' (mit | bsd-3 | apache-2.0 | private)." >&2; exit 2; }

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -183,6 +183,55 @@ run_existing_env_case() {
     || { echo "FAIL: $name (env) did not seed the stub PLAN" >&2; return 1; }
 }
 
+# run_license_scope_note_case — the interactive license/holder questions say what they cover when
+# adopting an existing codebase, and say nothing extra when starting from scratch. Without the
+# note the questions read as "what is your code licensed under?", which is not what they set:
+# a user answering about their existing repos would be choosing the docs hub's license instead.
+run_license_scope_note_case() {
+  local name="retcon-license-note" green="green-license-note"
+  local work="$TMP_ROOT/$name" green_work="$TMP_ROOT/$green"
+  local note="NOT the code you're adopting"
+
+  # Answers, in order: mode=existing, open source, MIT, copyright holder.
+  copy_template "$work"
+  (
+    cd "$work"
+    printf '2\n1\n1\nThroughstone Test\n' | ./init.sh \
+      --slug="$name" \
+      --desc="Adoption license scope note" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  assert_file_contains "$TMP_ROOT/$name.out" "$note"
+  # The note must precede the questions it scopes — after the fact it explains nothing.
+  [ "$(grep -n "$note" "$TMP_ROOT/$name.out" | head -1 | cut -d: -f1)" \
+    -lt "$(grep -n "Is this project open source" "$TMP_ROOT/$name.out" | head -1 | cut -d: -f1)" ] || {
+    echo "FAIL: $name printed the scope note after the license question" >&2
+    return 1
+  }
+  assert_file_contains "$work/Code/$name-docs/overview.md" "PROJECT-STATUS: retcon"
+
+  # Greenfield creates every repo it licenses, so there is nothing to scope and no note.
+  copy_template "$green_work"
+  (
+    cd "$green_work"
+    printf '1\n1\n1\nThroughstone Test\n' | ./init.sh \
+      --slug="$green" \
+      --desc="Greenfield license question" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$green.out" 2>&1
+
+  if grep -Fq "$note" "$TMP_ROOT/$green.out"; then
+    echo "FAIL: $green printed the adoption license-scope note" >&2
+    return 1
+  fi
+  assert_file_contains "$green_work/Code/$green-docs/overview.md" "PROJECT-STATUS: not-started"
+}
+
 # run_new_case NAME EXTRA_ARGS... — greenfield must be untouched (marker, no PLAN, message).
 run_new_case() {
   local name="$1"; shift
@@ -359,6 +408,7 @@ run_missing_stub_case() {
 run_existing_case "retcon-multi" multi
 run_existing_case "retcon-mono"  mono
 run_existing_env_case
+run_license_scope_note_case
 run_new_case "green-explicit" --mode=new
 run_new_case "green-default"
 run_invalid_mode_case


### PR DESCRIPTION
The adoption-facing half of the same question as #128. Independent of it — this touches only `init.sh`'s interactive prompt and its test — so it can land in either order.

## The problem

`init.sh` asks the license question through the same `choose_license_interactively` in both modes, and asks for a copyright holder right after. When you're adopting an existing codebase, the repos you're bringing in already answer "open source or proprietary?" — possibly differently from each other. A user reading the bare question reasonably believes they're recording that fact about their code.

They aren't. The selection covers the documentation hub being created and anything the method creates later. And the copyright holder being asked for is the holder of *that new material*, which in a company codebase may not be the same party as the code's.

## What changed

Under `--mode=existing`, the interactive path states the scope before both questions:

```
  The next two answers cover the documentation hub Throughstone is creating for you,
  and any repo it creates later — NOT the code you're adopting. Your existing repos keep
  whatever licensing they already have; the agent records what it finds, never changes it.
```

It precedes the license question so it scopes both answers, not just the one. Greenfield prints nothing new — it creates every repo it licenses, so there is nothing to scope. The non-interactive path is untouched (a caller passing `--license` has already made the choice).

## Verified

- Full maintainer suite 14/14.
- New test pins three things, since a note that drifts out of place is as good as absent: the text appears in an interactive adoption run, it appears **before** the license question, and it does **not** appear in an interactive greenfield run — each case also asserting the resulting `PROJECT-STATUS` marker, so the run really took the path being tested.
- Real interactive run reviewed in place for reading order and wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
