### PR TITLE
Record what each repo is licensed under in the repo inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ error/corruption and re-run paths, not normal operation.
   each repo (`managed` today; `external` reserved for a later partial-adoption feature). Inert
   (nothing reads it yet) and read as `managed` when absent, so existing inventories are unaffected.
   Both the greenfield and adoption front doors write it identically, so their repo inventories match.
+- **`license:` field on repo inventory rows** (`registries/repos.yml`) — records what each repo is
+  licensed under, so the inventory shows the licensing picture across every repo at once, which no
+  single `LICENSE` file can and which starts mattering as soon as a project's repos don't share one
+  license. For a repo the method creates it is the bootstrap posture, written by `init.sh` on the
+  seed rows; for an adopted repo it is what that repo already says, recorded as found — an
+  identifier and the file it came from, or `none stated`. It is a record, never an instruction: the
+  repo's own license file stays authoritative, a missing value means "not recorded" so existing
+  inventories are unaffected, and repos carrying different licenses is a normal inventory rather
+  than an inconsistency to reconcile.
 - **Recon-map report template** (`templates/reports/recon-map-report-template.md`, indexed in
   `reports/README.md`) — the point-in-time "birth certificate" an adoption produces at STEP-1:
   inventory, stack per repo, services, data stores, integrations, existing-docs classification,

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -281,8 +281,8 @@ session boundary. Stage 3's two-step rule governs from `1.1` onward.
 Resolve each in turn — the **lowest-open `asset-N`** (Status ≠ `Done`); mark its row `Done` once the
 asset is recorded. Reading one asset at a time keeps even a 20-repo system legible.
 
-- **Per repo** — register it in `registries/repos.yml` (a row: real `location`, `type`, and
-  `throughstone: managed`), stamp a Throughstone README from `templates/repo-readme-template.md`, and
+- **Per repo** — register it in `registries/repos.yml` (a row: real `location`, `type`,
+  `throughstone: managed`, and `license:` — see below), stamp a Throughstone README from `templates/repo-readme-template.md`, and
   record a short per-repo note (stack, entry points, role) in that README — its living home, which the
   owning `architecture/` docs deepen later (never back into the frozen recon map). Register repos
   **in place** by their real location; never relocate the user's code.
@@ -291,9 +291,13 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   never establishes licensing for code it did not create). Concretely: do **not** run
   `scripts/apply-project-license.sh` against any of these repos — it will refuse one that states
   its own terms, and the ones it would not refuse are exactly the repos that would silently gain a
-  `LICENSE` and a `LICENSING.md` claiming it over code you did not write. The repo's licensing
-  went into the recon map's **Stack Per Repo** row at `inv-3`; that record is the whole of the
-  work here. The license chosen at install time governs this method's own artifacts — the docs hub
+  `LICENSE` and a `LICENSING.md` claiming it over code you did not write. Recording it **is** the
+  work here, in two places with two jobs: the recon map's **Stack Per Repo** row already captured
+  it at `inv-3` as part of the frozen point-in-time snapshot, and this row's `license:` field is
+  the **living** copy that stays current as the repo changes. Copy it across as found — same
+  identifier, same source file, `none stated` where the repo says nothing — rather than
+  re-deriving it, so the two records can't disagree from the day they are written. The license
+  chosen at install time governs this method's own artifacts — the docs hub
   and anything it later creates — not the code being adopted, so a repo whose license differs from
   it is **not a finding**, several adopted repos may carry several different licenses, and none of
   that is reconciled. If the user raises relicensing, it is their act on their repo: say what you

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -371,6 +371,15 @@ All but the last are documentation only; nothing you already produced is rewritt
   at that repo's `LICENSE` / `LICENSING.md` and decide, as its owner, whether they say what you
   intend.
 
+**Repo inventory gains a `license:` field (not adoption-specific).** `registries/repos.yml` rows can
+now record what each repo is licensed under — the bootstrap posture for a repo the method created,
+whatever the repo already says for one registered in place. It exists because a project whose repos
+don't share a single license has nowhere else to show that, and it is a record rather than an
+instruction: the repo's own license file stays authoritative. **Optional, additive,
+review-required** like any registry change, and a missing value reads as "not recorded", so an
+inventory without the field keeps working untouched. Backfill by hand if you want the licensing
+picture in one place; don't let tooling rewrite `repos.yml`, which is project state.
+
 **Session harvest (adoption only).** `RETCON-PROMPT.md` gains its per-session half: an adoption now
 reads each architecture-session template as reference data, drafts every decision from the running
 code, confirms them with you, and writes the clean `architecture/` doc. It reuses what your project

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -30,26 +30,43 @@
 # `managed`. (This per-row token is unrelated to the top-level `throughstone:` key in
 # `.throughstone/manifest.yml`, which versions the method itself — different file and scope, no
 # collision.)
+#
+# `license:` (per row) records what a repo is licensed under, so the inventory can show the
+# licensing picture across every repo at once — something no single LICENSE file can, and the fact
+# that starts mattering as soon as the repos here do not share one license. It is a RECORD, never
+# an instruction: the repo's own license file is authoritative and this line is a copy that can
+# drift, so trust the repo when they disagree and fix the line. For a repo the method CREATES it is
+# the posture from `.throughstone/project-license` (the value init.sh writes below). For a repo
+# REGISTERED IN PLACE — one that existed before this project did — it is whatever that repo already
+# says, written down as found: an identifier and the file it came from (`GPL-2.0 (COPYING)`), or
+# `none stated` when the repo says nothing, which is a fact worth recording rather than a gap to
+# fill. Never set a license for such a repo; see METHOD.md §7 — the method records licensing, it
+# never establishes licensing for code it did not create. A missing value means "not recorded", not
+# "same as everything else", and repos legitimately carrying different licenses is a normal
+# inventory rather than an inconsistency to reconcile.
 
 repos:
   - name: "{{PROJECT}}-docs"
     location: "Code/{{PROJECT}}-docs/"
     type: docs            # docs | service | library | app | infra | tests
     throughstone: managed
+    license: "{{PROJECT_LICENSE}}"
     description: "Documentation hub: architecture, ADRs, standards, registries."
 
   - name: "prompts"
     location: "prompts/"
     type: docs
     throughstone: managed
+    license: "{{PROJECT_LICENSE}}"
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
   # Service / app / library repos get added here as the architecture names them and they
   # are stamped from templates/repo-readme-template.md. Give each new repo `throughstone: managed`
-  # like the rows above. Example:
+  # and a `license:` like the rows above. Example:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service
   #   throughstone: managed
+  #   license: "MIT"
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
   #   description: "..."

--- a/init.sh
+++ b/init.sh
@@ -769,6 +769,14 @@ mkdir -p "$ROOT/.throughstone"
 # even when proprietary projects intentionally have no project LICENSE.
 printf '%s\n' "$PROJECT_LICENSE_ID" > "$DOCS/.throughstone/project-license"
 
+# The repo inventory records what each repo is licensed under, so fill the seed rows with the same
+# posture. These two repos are ones init.sh creates, so the posture IS their license. A repo
+# registered in place later records what that repo already says instead (registries/repos.yml).
+grep -rlF '{{PROJECT_LICENSE}}' . --exclude-dir=.git 2>/dev/null | while read -r f; do
+  PROJECT_LICENSE_ID="$PROJECT_LICENSE_ID" perl -pi -e \
+    's/\Q{{PROJECT_LICENSE}}\E/$ENV{PROJECT_LICENSE_ID}/g' "$f"
+done
+
 # description: fill {{PROJECT_DESCRIPTION}} EVERYWHERE it appears (AGENTS.md + every
 # architecture/planning-session "About" blurb) so no literal placeholder is left dangling.
 # The one-liner is just a seed — the kickoff can later expand any of these from overview.md.

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -133,6 +133,9 @@ run_interactive_case() {
   [ -f "$work/Code/$name-api/LICENSING.md" ]
   grep -Fq "does not replace or alter the project license" \
     "$work/Code/$name-api/LICENSING.md"
+  # The inventory rows record the same posture the helper applies.
+  assert_registry_license "$name" "$work" \
+    "$(cat "$work/Code/$name-docs/.throughstone/project-license")"
   "$work/Code/$name-docs/scripts/apply-project-license.sh" \
     "$work/Code/$name-api" >"$TMP_ROOT/$name-code-license-repeat.out"
 
@@ -219,6 +222,8 @@ run_private_case() {
   grep -Fq "Project-authored content in this repository is proprietary" \
     "$work/Code/$name-api/LICENSING.md"
   grep -Fq "does not grant permission" "$work/Code/$name-api/LICENSING.md"
+  # Proprietary is a posture, not an absence: the inventory records it like any other value.
+  assert_registry_license "$name" "$work" "Proprietary"
 
   assert_maintainer_tests_removed "$name" "$work"
   ! grep -Fq "Copyright holder" "$TMP_ROOT/$name.out"
@@ -420,6 +425,27 @@ run_missing_canonical_license_case() {
     "$TMP_ROOT/$name-helper.out"
   [ -z "$(find "$target" -mindepth 1 -print -quit)" ]
   assert_maintainer_tests_removed "$name" "$work"
+}
+
+# assert_registry_license NAME WORK EXPECTED — the repo inventory records what each repo it
+# created is licensed under, and no placeholder survives bootstrap. The value must match the
+# durable posture: two records that disagree are worse than one.
+assert_registry_license() {
+  local name="$1" work="$2" expected="$3" reg="$2/Code/$1-docs/registries/repos.yml"
+
+  # Whole-line match: the file also carries a commented example row, which is not a record.
+  [ "$(grep -Fxc "    license: \"$expected\"" "$reg")" -eq 2 ] || {
+    echo "FAIL: $name did not record license \"$expected\" on both seed rows of $reg" >&2
+    return 1
+  }
+  if grep -rq '{{PROJECT_LICENSE}}' "$work" --exclude-dir=.git; then
+    echo "FAIL: $name left an unresolved {{PROJECT_LICENSE}} placeholder" >&2
+    return 1
+  fi
+  grep -Fxq "$expected" "$work/Code/$name-docs/.throughstone/project-license" || {
+    echo "FAIL: $name registry license disagrees with the durable posture" >&2
+    return 1
+  }
 }
 
 # run_pre_existing_licensing_case — a repo that already states its own licensing must be refused

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -153,6 +153,11 @@ run_existing_case() {
     "Licensing (as found)"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing is recorded as found, never set here"
+  # The frozen map is the snapshot; the inventory row is the living copy. Both must be asked for,
+  # and asked for as a copy — deriving the row separately is how two records start disagreeing.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "this row's \`license:\` field is"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "Copy it across as found"
+  assert_file_contains "$docs/registries/repos.yml" "\`license:\` (per row) records"
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).


### PR DESCRIPTION
Moved here from #128 after review: this field's motivation is a project whose repos carry *different* licenses, which doesn't arise until a project can adopt code it didn't create. The precedent for a base inventory field written by both front doors — `throughstone: managed` (#101) — is on this line too, and landing it on the 1.7.x line would have cost every existing project a migration item for a field nothing reads yet.

Because the field now lives here, this PR also carries the adoption side that was blocked on it.

## The problem

An adopted system's repos need not share one license, and nothing could show that. A `LICENSE` file states one repo's terms. The install-time posture states what the method's own artifacts use. #127 got each repo's licensing recorded in the recon map — but that map is frozen at confirm, deliberately, because it's a point-in-time snapshot. Nothing held the *living* answer.

## What changed

- **`registries/repos.yml` rows gain `license:`.** `init.sh` fills the two seed rows from the posture via a `{{PROJECT_LICENSE}}` substitution alongside the existing ones — those are repos it creates, so the posture is their license.
- **The per-repo adoption substep records an adopted repo's licensing there**, copied across from the recon map as found: same identifier, same source file, `none stated` where the repo says nothing.
- **The two records have different jobs, and the wording now says so** — the recon map's Stack Per Repo row is the frozen snapshot, the inventory field is the living copy that stays current as the repo changes. The substep **copies rather than re-derives**, so they can't disagree from the day they're written.
- **Record, never instruction:** the repo's own license file stays authoritative and the line is a copy that can drift, a missing value means "not recorded" rather than "same as everything else", and repos carrying different licenses is a normal inventory rather than something to reconcile.

## Verified

- Full maintainer suite 14/14.
- Adoption and greenfield fixtures from a `git archive` of this branch: `check.sh` 0 fail / 0 warn, `links.sh` 0 fail, no `{{PROJECT_LICENSE}}` left in either tree.
- **Greenfield inert:** `repos.yml` and `STEP-index.md` are byte-identical between the two fixtures, so both front doors still write the same inventory.
- Tests pin the seed rows against the posture file (two records that disagree are worse than one), and pin that the substep asks for the copy rather than a re-derivation.

## Follow-up, deliberately not here

`METHOD.md` §7 / `AGENTS.md` / the planning session describe where an in-place repo's licensing gets recorded, and #128 is rewording those same sentences on the base line to be field-free (correct there — 1.7.2 has no such field). Sharpening them to name `license:` belongs in a small follow-up **after** #128 lands and forward-merges, rather than editing the same lines on both branches at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
