### PR TITLE
Name the inventory field that holds an in-place repo's licensing

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -164,8 +164,8 @@ for open-source projects, and creates no project `LICENSE` for proprietary proje
 copies `LICENSE-THROUGHSTONE` because the standard generated repo retains Throughstone-authored
 README and CI scaffolding, and writes `LICENSING.md` to make those scopes explicit.
 **Run it only on a repo you create.** A repo **registered in place** — one that existed before
-this project did — keeps whatever licensing its owner set: read it, record it as found beside
-that repo's `registries/repos.yml` entry, and leave it alone. The method records licensing; it never
+this project did — keeps whatever licensing its owner set: read it, record it as found in that
+repo's `registries/repos.yml` `license:` field, and leave it alone. The method records licensing; it never
 establishes licensing for code it did not create (`METHOD.md` §7), so do not apply the posture
 to such a repo, and do not treat a difference between it and the bootstrap selection as
 something to reconcile. The helper refuses a target that already states its own licensing.

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -504,9 +504,10 @@ this method do contain the Throughstone-authored README and CI starter, so
 **The method records licensing; it never establishes licensing for code it did not create.** A
 repo **registered in place** (below) existed before the method reached it, so it already has an
 owner and a licensing status — a `LICENSE`, a `COPYING`, a `NOTICE`, vendored third-party terms,
-or a deliberate absence. Read what it uses and **record** it as found — in the repo inventory
-entry that describes it, and wherever the architecture docs cover it; never apply a posture to
-it. A divergence from the
+or a deliberate absence. Read what it uses and **record** it as found — in its
+`registries/repos.yml` `license:` field (an identifier and the file it came from, or `none
+stated`), and wherever the architecture docs cover it; never apply a posture to it. A divergence
+from the
 `init.sh` selection is not an error to fix: that selection governs the method's own artifacts and
 the repos it creates, and several in-place repos may legitimately carry several different
 licenses. Choosing or changing a license for an existing repo is its owner's act, taken

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -91,8 +91,8 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    `LICENSING.md` to make clear that notice is not the application-code license. **Run it only on
    repos you create** — a repo **registered in place**, which existed before this project did,
    keeps the licensing its owner set (`METHOD.md` §7: the method records licensing, it never
-   establishes licensing for code it did not create). Record what such a repo uses where its
-   inventory entry describes it and move on; the helper refuses it. Repository
+   establishes licensing for code it did not create). Record what such a repo uses in its
+   `registries/repos.yml` `license:` field and move on; the helper refuses it. Repository
    visibility is separate: when adding a remote for each code repo, choose private or public
    deliberately rather than inferring it from the license. Publishing a proprietary repo makes
    its source visible without granting open-source reuse rights, so call that out explicitly.

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -158,6 +158,14 @@ run_existing_case() {
   assert_file_contains "$docs/RETCON-PROMPT.md" "this row's \`license:\` field is"
   assert_file_contains "$docs/RETCON-PROMPT.md" "Copy it across as found"
   assert_file_contains "$docs/registries/repos.yml" "\`license:\` (per row) records"
+  # The three places that tell a reader to record an in-place repo's licensing must name the field
+  # that holds it. They are deliberately field-free on the 1.7.x line, where no such field exists,
+  # so a later forward-merge can quietly reintroduce the vaguer wording here.
+  assert_file_contains "$docs/METHOD.md" \
+    "\`registries/repos.yml\` \`license:\` field (an identifier"
+  assert_file_contains "$docs/AGENTS.md" "repo's \`registries/repos.yml\` \`license:\` field"
+  assert_file_contains "$docs/templates/planning-session.md" \
+    "\`registries/repos.yml\` \`license:\` field and move on"
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).


### PR DESCRIPTION
The follow-up promised in #130, now that #128 has landed and forward-merged.

## Why it was split

`METHOD.md` §7, `AGENTS.md` and `templates/planning-session.md` each tell a reader to record the licensing of a repo **registered in place**. #128 phrased that as "beside the inventory entry" — correct on the 1.7.x line, which has no field to name. Here `registries/repos.yml` rows carry `license:` (#130), so the instruction can say exactly where the value goes and what shape it takes.

Editing the same three sentences on both branches at once would have guaranteed a conflict, so the base line took the field-free wording and this sharpens it after the merge.

## What changed

- The three instructions name `registries/repos.yml`'s `license:` field, and §7 names the shape: an identifier and the file it came from, or `none stated`.
- Three assertions pin them. The forward merge that just happened is exactly how this wording gets quietly reverted — `main` will keep carrying the field-free sentences, and a future merge resolves toward them without anyone noticing.

## Verified

- Full maintainer suite 14/14.
- The assertions bite: reverting only the prose (keeping the test) fails the suite; restoring it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
