### PR TITLE
Augment a registered-in-place repo's README instead of stamping over it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,23 @@ any project built with it.
   posture into repos it had no business licensing. `METHOD.md` §7, `AGENTS.md`, the planning
   session, the helper's own header, and both licensing banners now say the narrower thing, which
   is what was always true.
+- **"Stamp a README into each repo" had no rule for a repo the method didn't create.**
+  `templates/repo-readme-template.md` said to stamp a copy "into each code repo as it's created",
+  and `METHOD.md` §7 said every repo's README is stamped from it "when the repo is scaffolded" —
+  but §7 also lets a repo be **registered in place**, and such a repo already has a README, usually
+  its most-read file and often linked from outside. Read literally, the instruction says to
+  overwrite it. A repo registered in place is now **augmented** rather than stamped: add only a
+  short `Role in <project>` section naming what the repo is within the system, propose it before
+  writing into a repo the method didn't create, and leave every existing section alone — everything
+  else in the template is something a working repo already documents, better, from having been run.
+  A declined proposal is a complete outcome, since the same information lives in the architecture
+  doc and the `repos.yml` row. The rule keys on whether a README already exists rather than on how
+  the repo got here — where a registered-in-place repo has none, there is nothing to preserve, so
+  its README is written from the full template: that one file, with nothing else about the repo
+  scaffolded, and still proposed first. Two readers of that rule were corrected with it: `METHOD.md`
+  §7's layout paragraph said service repos are stamped from the template full stop, and the
+  check-in's README sweep assumed every repo README was stamped by the method at creation — so it
+  would have reported an augmented repo, or one whose owner declined the addition, as a gap.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -126,7 +126,13 @@ pointers are committed files; see `METHOD.md` §7.) The repos are siblings:
 `registries/repos.yml` is the canonical inventory **and the index to the repos** — each
 entry points to a repo whose **README is its "about"** (what it is, how to set it up; plus an
 `ARCHITECTURE.md` if it has deep internals). **Before working in a repo, read its README
-first** — the same way you read the architecture docs before a design change.
+first** — the same way you read the architecture docs before a design change. A repo the method
+creates is **stamped** from `templates/repo-readme-template.md`. For a repo **registered in
+place**, the rule keys on whether a README is already there: if it is, **augment** — add a short
+`Role in {{PROJECT}}` section and nothing else, and never rewrite a section the repo already has;
+if the repo has none, write one from the template. Either way you are writing into the user's
+repo, so propose it before you do (`METHOD.md` §7). Nothing else about a registered-in-place repo
+is scaffolded — it already exists.
 When creating an application-code repo, also apply the license posture recorded at
 bootstrap by running
 `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <new-repo-path>`. The authoritative

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -466,8 +466,9 @@ Projects are typically **multi-repo**: the workspace folder is *not* itself a re
 inside it, `prompts/` is one repo and each thing under `Code/` (including
 `{{PROJECT}}-docs`) is its own **sibling** repo. Nothing sits "above" those repos except a
 per-machine shell. The `init.sh` wizard sets this up for the first developer; service repos
-aren't created at bootstrap — they're stamped from
-`Code/{{PROJECT}}-docs/templates/repo-readme-template.md` once the architecture names them. (Or choose
+aren't created at bootstrap — the ones this method creates are stamped from
+`Code/{{PROJECT}}-docs/templates/repo-readme-template.md` once the architecture names them, and
+one that already exists is registered in place instead (below). (Or choose
 mono-repo-for-now in the wizard — see *Mono-repo for now* below.) For multi-repo projects,
 `registries/repos.yml` is the canonical inventory. `registries/risks.yml` is the canonical
 accepted risk / tech-debt register: when a risk or debt item is consciously deferred, record it
@@ -478,7 +479,16 @@ check-in report under `reports/` — then add the register row. **Every repo car
 what it is** — its role and the slice of the system it owns — stamped from that template and
 filled in when the repo is scaffolded (with a matching one-line `description` in
 `registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
-its root for its internal design. **Every application-code repo the method *creates* also inherits
+its root for its internal design. **A repo registered in place is *augmented*, not stamped.** Its
+README already exists and is usually its most-read file, so the template is not copied over it:
+add only the missing piece — a short `Role in <project>` section naming what the repo is within
+the system, with a link to its architecture doc — and leave every section the repo already has
+untouched. Propose the text and where it goes before writing into a repo the method didn't create;
+a decline is a complete outcome, since the same information lives in the architecture doc and the
+`repos.yml` row. The rule keys on whether a README already exists, not on how the repo got here:
+where a registered-in-place repo has **no** README there is nothing to preserve, so write it from
+the full template — that creates the one file, and nothing else about the repo is scaffolded,
+still proposed before it is written. **Every application-code repo the method *creates* also inherits
 the license posture established by `init.sh`:** read the authoritative selection from the docs
 hub's `.throughstone/project-license`. That file records the license for **Throughstone-authored
 and method-created material** — this docs hub, `prompts/`, and any repo the method creates — which

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -298,7 +298,18 @@ affect work you do after pulling them.
   changes; the wording around it does, in `METHOD.md` §7, `AGENTS.md`, `README.md`, the planning
   session, and the helper's header. Pull them with the group below. **One thing to check:** if a
   repo of yours was registered in place rather than created by the method, its licensing is its
-  own — record what it actually uses beside its inventory entry rather than assuming the posture.
+  own — record what it actually uses beside its inventory entry rather than assuming the posture.- **A repo you registered in place is augmented, not stamped.** `templates/repo-readme-template.md`
+  told you to stamp a copy into each repo "as it's created", which is the only case it considered —
+  so pointed at a repo that already existed, the instruction reads as "overwrite its README". That
+  repo's README is usually its most-read file. It now gets a short `Role in <project>` section
+  added instead, proposed before anything is written, with every existing section left alone. The
+  rule keys on whether a README is already there, not on how the repo got here: where a registered
+  repo has none, its README is written from the full template — that one file, with nothing else
+  about the repo scaffolded. No change for repos you scaffold through the
+  method: those are still stamped from the full template.
+  **One thing to check:** if you registered an existing repo in place and its README was replaced
+  with the template, its previous content is in that repo's git history.
+
 Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4, §6 and §7, `AGENTS.md`, `README.md`,
 `inputs/README.md`, `templates/architecture-doc-template.md`, `templates/planning-session.md`,
 `templates/repo-readme-template.md`, `runbooks/check-in.md`, and

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -140,10 +140,14 @@ line (to `full` once the area is complete), updates related architecture docs an
 the check-in itself.
 
 Beyond the architecture docs, sweep four things that rot just as quietly:
-- **Repo READMEs** — every code repo has one, its **Overview** still describes what the repo
-  *is*, and the **Setup / Running / Testing** steps still work from a clean checkout. They're
-  stamped once at repo creation and otherwise never re-checked, so they're usually the stalest
-  doc a new contributor or agent hits first (and any `ARCHITECTURE.md` still matches the design).
+- **Repo READMEs** — every code repo still explains what it *is*, and its **Setup / Running /
+  Testing** steps still work from a clean checkout. They are written once and otherwise never
+  re-checked, so they're usually the stalest doc a new contributor or agent hits first (and any
+  `ARCHITECTURE.md` still matches the design). A repo the method **created** carries the full
+  template, so check its **Overview**. A repo **registered in place** owns its own README: check
+  that the `Role in {{PROJECT}}` section still describes the repo's place in the system, and leave
+  the rest to its owners. If that section was declined, or the repo has no README, that is not a
+  gap to close here — the framing lives in its architecture doc and its `repos.yml` row (`METHOD.md` §7).
 - **Interface contract artifacts** — any artifact named by `architecture/*-interface-contracts.md` (OpenAPI /
   GraphQL / protobuf / event schema / JSON Schema / public package interface, etc.) still
   matches what the service, worker, CLI, library, or import/export path actually exposes. A

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -69,7 +69,9 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    of them exist yet, so you scaffold them all — the usual case. Just skip any that are
    **already there:** a repo the architecture names is already there when it has a
    `registries/repos.yml` row **with a filled-in README** (a real role one-liner + Overview, not
-   the template's placeholders), so don't re-create it. This only comes up on a **re-run** (a repo
+   the template's placeholders), so don't re-create it. A repo **registered in place** is likewise
+   already there: it exists, and its README is its own — a thin one, or none, is not a reason to
+   scaffold over it. This only comes up on a **re-run** (a repo
    you scaffolded in an earlier run is already registered) or when the project already has some of
    these repos; if `registries/repos.yml` is absent or has no code-repo rows yet (that first run,
    or a mono-repo), nothing is registered and every named repo scaffolds, exactly as before.
@@ -100,9 +102,17 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    repo's README isn't just stamped — its role one-liner and Overview get filled in** (what
    the repo is and the slice of the system it owns), and the repo gets a row in
    `registries/repos.yml` with a one-line `description`; a repo isn't scaffolded until it can
-   explain itself. Confirm the repo list with the user — on a first run they're all new; note any
-   that already exist (already registered with a filled-in README) so you scaffold only the new
-   ones.
+   explain itself.
+   **A repo registered in place is not scaffolded at all.** Everything above describes creating a
+   repo, and this one already exists — so it is not created, and the license helper is not run on
+   it (above). The one thing it may still be owed is the role-and-place framing its README
+   probably lacks, and what to do keys on whether a README is there. **If it has one:** add a
+   short `Role in {{PROJECT}}` section and leave every existing section alone — never stamp the
+   template over it. **If it has none:** write its README from the template. Either way it is the
+   user's repo, so show them what you intend to add and where, and wait for a yes.
+   Confirm the repo list with the user — on a first run they're all new; note any
+   that already exist (registered and present, by either of the tests above) so you scaffold only
+   the new ones.
 2. **The implementation STEP sequence.** Propose all the target phase's STEPs in dependency order —
    **build or extend what this milestone needs, given what already exists.** On a first run
    nothing is built yet, so scaffolding and the core data layer come first and you build

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -4,11 +4,33 @@
 > defines it, e.g. `{{PROJECT}}-docs/architecture/*-architecture-overview.md`.)
 
 <!--
-  Stamp a copy of this into each code repo as it's created — every repo, including in a
-  multi-repo design, must carry one. Keep the section headings consistent across all repos
-  so the project reads uniformly. Sections that don't apply can be dropped (e.g. no
-  "API / interface" for a library), but keep the order — and never drop the role one-liner
-  above or the Overview below: explaining what the repo *is* is the one non-negotiable part.
+  STAMP this into a repo the method CREATES — every repo, including in a multi-repo design,
+  must carry a README. Keep the section headings consistent across all repos so the project
+  reads uniformly. Sections that don't apply can be dropped (e.g. no "API / interface" for a
+  library), but keep the order — and never drop the role one-liner above or the Overview
+  below: explaining what the repo *is* is the one non-negotiable part.
+
+  AUGMENT a repo REGISTERED IN PLACE — one that existed before this project did — WHEN IT ALREADY
+  HAS A README. The rule keys on whether that file exists, not on how the repo got here: a
+  registered-in-place repo with no README has nothing to preserve, so write its README from this
+  template. That creates the one file; nothing else about such a repo is scaffolded, and it is
+  still offered rather than assumed, since it is the user's repo.
+
+  Where a README does exist it is usually the repo's most-read file, often linked from outside
+  it, so stamping over it destroys work the method did not do. Everything below except the role
+  one-liner and Overview is something a working repo already documents — setup, tests,
+  configuration — written by the people who actually run it; re-deriving those replaces accurate
+  content with inferred content.
+  What such a repo is usually missing is the part this template leads with: its place in a
+  larger system.
+
+  So add only that, as a short `## Role in {{PROJECT}}` section — the role one-liner, two or
+  three sentences on the slice of the system this repo owns, and links to its architecture doc
+  and the docs hub. Never replace, reorder, or rewrite a section the repo already has, and
+  never stamp the Licensing section below into it (that describes a repo the method created).
+  Show the exact text and where it will go, and get agreement before writing into someone
+  else's repo; if they decline, that is a complete outcome — the same information already lives
+  in the repo's architecture doc and its `registries/repos.yml` row.
 
   Stamp the CI gate named by the Test Strategy architecture doc too: drop
   `templates/ci/code-repo-ci.yml` into this repo's `.github/workflows/ci.yml` and fill in its
@@ -27,8 +49,6 @@
   (`LICENSE`, `COPYING`, `NOTICE`, package metadata, vendored third-party terms, or a deliberate
   absence), record that, and leave its licensing alone — including when it differs from the
   bootstrap selection, which governs only this method's own artifacts and the repos it creates.
-  The Licensing section below describes a repo the method created; drop or rewrite it to match
-  reality in a repo it did not.
 -->
 
 ## Overview


### PR DESCRIPTION
Same shape as #126, applied to the other thing the repo README template orders. #126 split the *licensing* act into create-vs-adopt; this splits the *README* act.

## The problem

`templates/repo-readme-template.md` says to stamp a copy "into each code repo as it's created", and `METHOD.md` §7 says every repo's README is stamped from it "when the repo is scaffolded". But §7 also lets a repo be **registered in place** — and that repo already has a README, usually its most-read file and often linked from outside.

Read literally, the instruction says to overwrite it. Unlike the licensing path there is no helper that can refuse: it is one file write.

## What the method actually needs is narrow

The template says so itself — the role one-liner and Overview are "the one non-negotiable part". Everything else in it (Tech stack, Prerequisites, Setup, Running, API, Testing, Configuration, Project structure, Troubleshooting) is what a working repo already documents, written by the people who actually run it. Re-deriving those from a code read replaces accurate content with inferred content.

What such a repo usually *lacks* is the part this template leads with: its place in a larger system.

## What changed

A repo registered in place is **augmented**, not stamped:

- Add a short **`## Role in <project>`** section — the role one-liner, two or three sentences on the slice of the system the repo owns, links to its architecture doc and the docs hub — and nothing else.
- **Never** replace, reorder, or rewrite a section the repo already has.
- **Propose the exact text and where it goes**, and get agreement before writing into a repo the method didn't create.
- **A decline is a complete outcome**, not a gap: the same information already lives in the repo's architecture doc and its `repos.yml` row.
- **The discriminator is whether a README already exists, not how the repo got here.** Where a registered-in-place repo has none, its README is written from the full template — that one file, with nothing else about the repo scaffolded, and still proposed first.

### Second pass, after review

Describing the no-README path *by reference* to the create path ("as usual", "like any other") was the trap: that path also wires the stack, the environment baseline, and the license helper — and the license helper must never run on a repo the method didn't create, which the planning session forbids two paragraphs earlier. Each place now says what actually happens.

The planning session needed more than wording:

- Its registered-in-place branch sat **inside a paragraph whose subject was creating a repo**. It now stands on its own and opens by saying such a repo is not scaffolded at all.
- Its **"already there" test keyed on a repo having a filled-in README** — written for a re-run of a repo the method itself scaffolded, but read literally it sends a registered-in-place repo with a thin README, or none, back through the create flow with the license helper attached. That test now recognizes an in-place repo as already there.

Stated in `templates/repo-readme-template.md`, `METHOD.md` §7, `AGENTS.md`, and `templates/planning-session.md`.

**Also dropped:** the cleanup line #126 added, which told the reader to rewrite the stamped Licensing section in a repo the method didn't create. Under the augment rule that section never lands there, so the line was dead text that additionally implied the template *was* being stamped — contradicting the rule above it. The prohibition now rides the general rule.

## Greenfield impact

None. A repo the method creates is still stamped from the full template, unchanged.

## Verified

Full maintainer suite 11/11. Documentation only — no tooling or template-output change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
