### PR TITLE
Augment an adopted repo's README instead of stamping over it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,17 @@ error/corruption and re-run paths, not normal operation.
     warning then follows the gap: the doc's `Coverage:` line says what is missing, how big it is, and
     what it means for someone building on it (never a bare "deferred"), and a genuinely risky gap gets
     a `risks.yml` row the periodic check-in re-surfaces.
+  - **Your repos' READMEs are added to, never overwritten.** A repo you already have has a README,
+    usually its most-read file, so adoption does not stamp the Throughstone template over it.
+    Everything in that template except the role one-liner is something a running system already
+    documents — setup, tests, configuration — written by the people who operate it. What such a
+    repo usually lacks is what adoption is producing: its place in the system. So it offers exactly
+    that, a short `Role in <project>` section, shows you the text and where it would go, and waits
+    for your yes. Declining is a complete answer — the same information is in the recon map, the
+    repo's architecture doc, and its inventory row — and nothing else in the README is touched.
+    What decides this is whether a README is already there, not that the repo was adopted: where a
+    repo has none, adoption offers to write one from the template — that one file, since adopting
+    a repo scaffolds nothing else in it.
   - **Your repos' licensing is recorded, never set.** Adoption registers every repo where it already
     sits, so each one's licensing stays its owner's: the recon map records what each repo actually
     says — the identifier and the file it came from, `none stated` where nothing does, plus vendored

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -282,10 +282,26 @@ Resolve each in turn — the **lowest-open `asset-N`** (Status ≠ `Done`); mark
 asset is recorded. Reading one asset at a time keeps even a 20-repo system legible.
 
 - **Per repo** — register it in `registries/repos.yml` (a row: real `location`, `type`,
-  `throughstone: managed`, and `license:` — see below), stamp a Throughstone README from `templates/repo-readme-template.md`, and
-  record a short per-repo note (stack, entry points, role) in that README — its living home, which the
-  owning `architecture/` docs deepen later (never back into the frozen recon map). Register repos
+  `throughstone: managed`, and `license:` — see below) and **augment** its README (below).
+  Record a short per-repo note (stack, entry points, role) in the repo's `architecture/` docs and
+  its inventory row as they are written — never back into the frozen recon map. Register repos
   **in place** by their real location; never relocate the user's code.
+  **Where a README already exists, augment it; never stamp over it.** The rule keys on whether
+  that file is there, not on the fact that the repo was adopted — where an adopted repo has **no**
+  README there is nothing to preserve, so offer to write one from the template. That is the one
+  file; adopting a repo scaffolds nothing else in it. Most do have one, though, and it is usually
+  the repo's most-read file — so `templates/repo-readme-template.md` is **not** copied in
+  (`METHOD.md` §7: a repo registered in place is augmented, not stamped). Everything in that
+  template except the role one-liner is something a running system already documents — setup,
+  tests, configuration — written by the people who operate it; re-deriving it from your code read
+  would replace what is accurate with what is inferred. What these repos usually lack is the one
+  thing adoption is producing: the repo's place in the system. So add exactly that, as a short
+  `## Role in {{PROJECT}}` section — the one-liner, two or three sentences on the slice of the
+  system this repo owns, and links to its `architecture/` doc and the docs hub — and change
+  nothing else. **Show the user the exact text and where it will go, and wait for a yes** before
+  writing into a repo they own. **A no is a complete answer, not a gap:** the same information is
+  already in the recon map, the repo's `architecture/` doc, and its `repos.yml` row, so record
+  that the repo documents itself and move on.
   **Never license an adopted repo.** Every repo here is registered in place, so its licensing is
   its owner's and the method only records it (`METHOD.md` §7: the method records licensing; it
   never establishes licensing for code it did not create). Concretely: do **not** run

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -158,6 +158,17 @@ run_existing_case() {
   assert_file_contains "$docs/RETCON-PROMPT.md" "this row's \`license:\` field is"
   assert_file_contains "$docs/RETCON-PROMPT.md" "Copy it across as found"
   assert_file_contains "$docs/registries/repos.yml" "\`license:\` (per row) records"
+  # An adopted repo's README is the user's most-read file and there is no helper that can refuse
+  # an overwrite — it is one file write — so both halves are pinned: never stamp, and the bounded
+  # thing that may be added instead, only with a yes.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "Where a README already exists, augment it; never stamp over it"
+  # ...and that the no-README case is not left to inference.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "offer to write one from the template"
+  # Substituted, like every other {{PROJECT}} in the shipped file — asserting the raw placeholder
+  # here would pass on a template that never got substituted.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "\`## Role in $name\` section"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "wait for a yes"
   # The three places that tell a reader to record an in-place repo's licensing must name the field
   # that holds it. They are deliberately field-free on the 1.7.x line, where no such field exists,
   # so a later forward-merge can quietly reintroduce the vaguer wording here.


### PR DESCRIPTION
The adoption half of #132, which splits **stamp** (a repo the method creates) from **augment** (a repo registered in place). This is the reader-side instruction that makes it concrete, and it states the rule directly rather than relying on the template comment being read — an adopted repo's README is one file write away from being overwritten, and unlike the licensing path there is no helper that can refuse.

## The problem

The per-repo substep told the harvest to *"stamp a Throughstone README from `templates/repo-readme-template.md`, and record a short per-repo note (stack, entry points, role) in that README — its living home"*.

Both halves were written for a repo the method creates. Aimed at a repo the user already owns:

- the first **overwrites their most-read file**;
- the second **rewrites content the repo already documents**, and documents better — its setup and entry points were written by the people who run it.

## What changed

- **Augment, don't stamp.** Add a short **`## Role in <project>`** section — the one-liner, two or three sentences on the slice of the system the repo owns, links to its `architecture/` doc and the docs hub — and change nothing else. That is the part an existing repo usually lacks, and the part adoption is producing anyway.
- **Writing into the user's repo waits for a yes**, with the exact text and its position shown first.
- **A no is a complete answer, not a gap** — the same information is already in the recon map, the repo's architecture doc, and its `repos.yml` row, so the repo is recorded as documenting itself.
- **What decides this is whether a README is already there**, not that the repo was adopted — where a repo has none, adoption offers to write one from the template. Stated that way round rather than as an exception, so the case can't be read as forbidden, and stated as what happens rather than as "the full template, as for a new repo": adopting a repo scaffolds nothing else in it.
- **The per-repo note is retargeted** — for an adopted repo the living home for stack and entry-point detail is the architecture docs and the inventory row, not a README that already covers them.

## Verified

- Full maintainer suite 14/14.
- Fresh adoption fixture from a `git archive` of this branch: `check.sh` 0 fail / 0 warn, `links.sh` 0 fail, the rule present in the generated docs hub with `{{PROJECT}}` substituted (`## Role in adr3`).
- Three assertions pin the prohibition, the bounded thing that may be added instead, and the wait-for-a-yes — the substituted form, so a template that never got substituted can't pass them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
