### PR TITLE
Stop installing CI into a repo the method didn't create; add a notice-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,26 @@ any project built with it.
   §7's layout paragraph said service repos are stamped from the template full stop, and the
   check-in's README sweep assumed every repo README was stamped by the method at creation — so it
   would have reported an augmented repo, or one whose owner declined the addition, as a gap.
+- **The CI gate could be installed into a repo the method didn't create.**
+  `templates/ci/README.md` and the repo README template both said to drop
+  `templates/ci/code-repo-ci.yml` into a repo's `.github/workflows/ci.yml` when scaffolding it —
+  with no rule for a repo **registered in place**, which has its own CI. That file is deliberately
+  **failing-until-configured**, so landing it in an existing repo either replaces the workflow that
+  gates its merges or adds a second one that fails every build until somebody deletes it. It is
+  now never installed into a registered-in-place repo; what that repo already runs is recorded in
+  the Test Strategy doc instead, and moving it onto the standard gate is a change its owners make
+  deliberately.
+
+### Added
+- **`--notice-only` mode for `scripts/apply-project-license.sh`** — places `LICENSE-THROUGHSTONE`
+  and a companion `LICENSING.md` in a repo the method did *not* create, for the one case such a
+  repo needs it: the method left Throughstone-authored material behind (the `Role in <project>`
+  README section, or a README written from the template for a repo that had none). That material
+  is BSD-3-Clause and needs its notice, but the notice alone in someone else's repo invites the
+  wrong conclusion — so the companion names only what it covers and explicitly disclaims the rest
+  of the repository. It writes no project `LICENSE` and makes no claim about the repo's own code,
+  which is why it is allowed on a target the full mode refuses. Nothing is owed, and nothing is
+  written, when the owners declined the addition.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -132,7 +132,11 @@ place**, the rule keys on whether a README is already there: if it is, **augment
 `Role in {{PROJECT}}` section and nothing else, and never rewrite a section the repo already has;
 if the repo has none, write one from the template. Either way you are writing into the user's
 repo, so propose it before you do (`METHOD.md` §7). Nothing else about a registered-in-place repo
-is scaffolded — it already exists.
+is scaffolded — it already exists, and in particular the CI gate is never installed into one (its
+pipeline is its own). If the README addition is accepted, that leaves Throughstone-authored
+material in the repo, so place its notice with
+`Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <repo-path>`; if it was
+declined, nothing is owed.
 When creating an application-code repo, also apply the license posture recorded at
 bootstrap by running
 `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <new-repo-path>`. The authoritative

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -496,7 +496,16 @@ in a project built from scratch is everything, and in a project that also refere
 not create is exactly that subset. It is not a claim about code the method didn't write. For an
 open-source selection, the docs hub must have
 a matching canonical `LICENSE`, which is copied unchanged to the new repo root. For
-`Proprietary`, the new repo gets no project `LICENSE`. Do not copy `LICENSE-THROUGHSTONE` into
+`Proprietary`, the new repo gets no project `LICENSE`. **A repo registered in place gets neither
+that posture nor the CI gate** — its pipeline is its own, and `templates/ci/code-repo-ci.yml`
+fails until configured, so installing it would replace or break what already gates that repo's
+merges. Record what it runs instead. What such a repo *may* be owed is the notice: where the
+method leaves Throughstone-authored material behind — the `Role in <project>` section, or a README
+written from the template for a repo that had none — run
+`scripts/apply-project-license.sh --notice-only <repo>`, which places `LICENSE-THROUGHSTONE` and a
+`LICENSING.md` that names only what the notice covers and disclaims the rest of the repository. If
+the owners declined the addition, nothing Throughstone-authored is there and nothing is owed. Do
+not copy `LICENSE-THROUGHSTONE` into
 application-code repos that contain no Throughstone-authored material. Repos scaffolded through
 this method do contain the Throughstone-authored README and CI starter, so
 `scripts/apply-project-license.sh` copies `LICENSE-THROUGHSTONE` and writes a visible

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -309,6 +309,16 @@ affect work you do after pulling them.
   method: those are still stamped from the full template.
   **One thing to check:** if you registered an existing repo in place and its README was replaced
   with the template, its previous content is in that repo's git history.
+- **The CI gate is never installed into a repo you registered in place, and the Throughstone
+  notice has its own mode.** `templates/ci/code-repo-ci.yml` fails until configured — right for a
+  new repo, wrong for one that already has CI, where it would replace or duplicate the workflow
+  that gates your merges. It is now for created repos only; record what an in-place repo runs in
+  the Test Strategy doc instead. Separately, where the method leaves Throughstone-authored
+  material in such a repo (the `Role in <project>` README section), place its notice with
+  `scripts/apply-project-license.sh --notice-only <repo>` — it writes `LICENSE-THROUGHSTONE` plus a
+  `LICENSING.md` that disclaims the rest of the repository, and never a project `LICENSE`. **One
+  thing to check:** if you registered a repo in place and dropped the CI template into it, decide
+  with its owners whether that workflow should stay.
 
 Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4, §6 and §7, `AGENTS.md`, `README.md`,
 `inputs/README.md`, `templates/architecture-doc-template.md`, `templates/planning-session.md`,

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# apply-project-license.sh TARGET_REPO — apply the bootstrap-selected project-license posture.
+# apply-project-license.sh [--notice-only] TARGET_REPO — apply the bootstrap-selected
+# project-license posture, or place only the Throughstone notice.
 #
 # The posture file is the durable source of truth, separate from LICENSE, so a missing or
 # extra license file cannot silently change whether the generated project is open-source or
@@ -15,6 +16,13 @@
 # it already uses and record it, never apply. The pre-existing-licensing check below refuses such
 # a target, so pointing this helper at the wrong kind of repo fails loudly instead of writing a
 # license claim over code the method did not author.
+#
+# --notice-only serves the one thing such a repo may still be owed. Where the method leaves
+# Throughstone-authored material behind — a role-and-place section added to an existing README, or
+# a README written from the template for a repo that had none — that material is BSD-3-Clause and
+# needs its notice. This mode places LICENSE-THROUGHSTONE and a LICENSING.md that names only what
+# the notice covers and disclaims everything else. It writes no project LICENSE and makes no claim
+# about the repository's own code, which is why it is allowed on a repo the full mode refuses.
 
 set -euo pipefail
 
@@ -22,11 +30,32 @@ set -euo pipefail
 # Code/<project>-docs/scripts/ after initialization; derive the docs hub without resolving
 # the placeholder in this template checkout.
 DOCS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TARGET="${1:-}"
 POLICY_FILE="$DOCS_ROOT/.throughstone/project-license"
 
+# Flags before or after the target, so callers need not remember an order.
+TARGET=""
+NOTICE_ONLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --notice-only) NOTICE_ONLY=1 ;;
+    -*)
+      echo "apply-project-license.sh: unknown option: $1" >&2
+      echo "usage: $0 [--notice-only] TARGET_REPO" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$TARGET" ]; then
+        echo "apply-project-license.sh: unexpected extra argument: $1" >&2
+        exit 2
+      fi
+      TARGET="$1"
+      ;;
+  esac
+  shift
+done
+
 if [ -z "$TARGET" ]; then
-  echo "usage: $0 TARGET_REPO" >&2
+  echo "usage: $0 [--notice-only] TARGET_REPO" >&2
   exit 2
 fi
 if [ ! -d "$TARGET" ]; then
@@ -78,6 +107,43 @@ copy_if_missing() {
     echo "$label: $target"
   fi
 }
+
+# --notice-only stops here. It never reads the posture, never writes a project LICENSE, and is
+# therefore allowed on a repo that states its own terms — the case the guard below exists to
+# refuse. Its LICENSING.md is deliberately not the one the full mode writes: that one names the
+# project license and asserts it over the repository's content, which would be a claim about code
+# the method did not author.
+if [ "$NOTICE_ONLY" = "1" ]; then
+  if [ ! -f "$DOCS_ROOT/LICENSE-THROUGHSTONE" ]; then
+    echo "apply-project-license.sh: missing Throughstone notice: $DOCS_ROOT/LICENSE-THROUGHSTONE" >&2
+    exit 1
+  fi
+  NOTICE_SUMMARY="$(mktemp "${TMPDIR:-/tmp}/throughstone-notice.XXXXXX")"
+  trap 'rm -f "$NOTICE_SUMMARY"' EXIT
+  cat > "$NOTICE_SUMMARY" <<'EOF'
+# Licensing
+
+This repository was not created by Throughstone; a project that uses Throughstone registered it
+in place. `LICENSE-THROUGHSTONE` covers **only** the Throughstone-authored scaffold material
+retained here — for example a role-and-place section added to the README.
+
+It does not license, alter, or make any claim about anything else in this repository. Everything
+else remains under this repository's own terms, wherever they are stated.
+EOF
+  # Validate both targets before writing either, so a repo is never left half-updated.
+  verify_compatible \
+    "$DOCS_ROOT/LICENSE-THROUGHSTONE" \
+    "$TARGET/LICENSE-THROUGHSTONE" \
+    "Throughstone license"
+  verify_compatible "$NOTICE_SUMMARY" "$TARGET/LICENSING.md" "licensing summary"
+  copy_if_missing \
+    "$DOCS_ROOT/LICENSE-THROUGHSTONE" \
+    "$TARGET/LICENSE-THROUGHSTONE" \
+    "Throughstone license"
+  copy_if_missing "$NOTICE_SUMMARY" "$TARGET/LICENSING.md" "licensing summary"
+  echo "project license: not applied (--notice-only; this repository's licensing is its own)"
+  exit 0
+fi
 
 # Refuse a repo that already states its own licensing, before reading the posture or writing
 # anything. This is the guard against the destructive case: a target with no plain LICENSE but a

--- a/Code/{{PROJECT}}-docs/templates/ci/README.md
+++ b/Code/{{PROJECT}}-docs/templates/ci/README.md
@@ -24,9 +24,16 @@ at `Code/{{PROJECT}}-docs/.github/workflows/method-check.yml`, so in a **multi-r
 
 ## 2. Code-repo tests — `code-repo-ci.yml`  *(template; stamp per repo)*
 
-The test gate for a code repo. When you scaffold a code repo (stamping its README from
-`templates/repo-readme-template.md`), also drop this into that repo's `.github/workflows/ci.yml` and fill in
+The test gate for a code repo the method **creates**. When you scaffold one (stamping its README
+from `templates/repo-readme-template.md`), also drop this into that repo's `.github/workflows/ci.yml` and fill in
 the toolchain + test command for its stack — examples for Node / Python / Go / Rust are inlined.
+
+**Never install it into a repo registered in place.** A repo that existed before this project did
+has its own CI, and this file is deliberately failing-until-configured (below) — so landing it
+there either overwrites the workflow that actually gates their merges, or adds a second one that
+fails every build until somebody deletes it. Record what that repo already runs, in the Test
+Strategy architecture doc, and leave its pipeline alone. Bringing an in-place repo onto this gate
+is a deliberate change its owners make, as its own STEP, not a side effect of adopting the method.
 
 It **fails until configured** on purpose: an unconfigured gate that silently passes is worse than
 none. Replace the `Configure me` step (which `exit 1`s) with your real setup + test command.

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -109,7 +109,11 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    probably lacks, and what to do keys on whether a README is there. **If it has one:** add a
    short `Role in {{PROJECT}}` section and leave every existing section alone — never stamp the
    template over it. **If it has none:** write its README from the template. Either way it is the
-   user's repo, so show them what you intend to add and where, and wait for a yes.
+   user's repo, so show them what you intend to add and where, and wait for a yes. **Its CI is
+   its own** — never install `templates/ci/code-repo-ci.yml` into it; record what it runs in the
+   Test Strategy doc. If the README addition is accepted, run
+   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <repo-path>` to place the
+   Throughstone notice for that retained material; if it was declined, nothing is owed.
    Confirm the repo list with the user — on a first run they're all new; note any
    that already exist (registered and present, by either of the tests above) so you scaffold only
    the new ones.

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -32,9 +32,12 @@
   else's repo; if they decline, that is a complete outcome — the same information already lives
   in the repo's architecture doc and its `registries/repos.yml` row.
 
-  Stamp the CI gate named by the Test Strategy architecture doc too: drop
-  `templates/ci/code-repo-ci.yml` into this repo's `.github/workflows/ci.yml` and fill in its
-  stack's test command (see `templates/ci/README.md`).
+  For a repo this method CREATES, stamp the CI gate named by the Test Strategy architecture doc
+  too: drop `templates/ci/code-repo-ci.yml` into this repo's `.github/workflows/ci.yml` and fill
+  in its stack's test command (see `templates/ci/README.md`). For a repo REGISTERED IN PLACE,
+  never install it — that repo has its own CI, and the template gate fails until configured, so it
+  would either replace what gates their merges or fail every build until removed. Record what the
+  repo already runs and leave its pipeline alone.
 
   For a repo this method CREATES, apply the project license established at bootstrap by running
   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <this-repo-path>`. It copies the

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -479,6 +479,86 @@ run_pre_existing_licensing_case() {
   assert_maintainer_tests_removed "$name" "$work"
 }
 
+# run_notice_only_case — the one thing a repo the method did not create may still be owed. Where
+# the method leaves Throughstone-authored material behind, --notice-only places the notice and a
+# companion that disclaims the rest of the repository. It must work on exactly the target the full
+# mode refuses, and must never write a project LICENSE or a claim about the repository's content.
+run_notice_only_case() {
+  local name="license-notice-only"
+  local work="$TMP_ROOT/$name" target status
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Notice-only test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  local helper="$work/Code/$name-docs/scripts/apply-project-license.sh"
+  target="$work/Code/$name-legacy"
+  mkdir -p "$target"
+  printf 'GPLv2 terms\n' > "$target/COPYING"
+
+  # The full mode refuses this target; the notice mode is defined by being allowed on it.
+  set +e
+  "$helper" "$target" >"$TMP_ROOT/$name-full.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 1 ] || { echo "FAIL: full mode did not refuse the in-place target" >&2; return 1; }
+
+  "$helper" --notice-only "$target" >"$TMP_ROOT/$name-notice.out"
+  cmp -s "$work/Code/$name-docs/LICENSE-THROUGHSTONE" "$target/LICENSE-THROUGHSTONE" || {
+    echo "FAIL: --notice-only did not place the Throughstone notice" >&2
+    return 1
+  }
+  # The whole point: no project LICENSE, and no claim about the repository's own content.
+  [ ! -e "$target/LICENSE" ] || {
+    echo "FAIL: --notice-only wrote a project LICENSE" >&2
+    return 1
+  }
+  grep -Fq "does not license, alter, or make any claim about anything else" "$target/LICENSING.md" || {
+    echo "FAIL: --notice-only companion does not disclaim the rest of the repository" >&2
+    return 1
+  }
+  if grep -Fq "Project-authored content in this repository is licensed under" "$target/LICENSING.md"; then
+    echo "FAIL: --notice-only wrote the project-license claim meant for created repos" >&2
+    return 1
+  fi
+  # The repo's own licensing file is untouched.
+  grep -Fxq "GPLv2 terms" "$target/COPYING" || {
+    echo "FAIL: --notice-only disturbed the target's own licensing file" >&2
+    return 1
+  }
+
+  # Idempotent, and the flag is accepted on either side of the target.
+  "$helper" "$target" --notice-only >"$TMP_ROOT/$name-notice-repeat.out"
+
+  # A differing companion must be refused rather than overwritten.
+  printf 'different summary\n' > "$target/LICENSING.md"
+  set +e
+  "$helper" --notice-only "$target" >"$TMP_ROOT/$name-notice-conflict.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 1 ] || { echo "FAIL: --notice-only overwrote a differing LICENSING.md" >&2; return 1; }
+  grep -Fq "refusing to overwrite different licensing summary" "$TMP_ROOT/$name-notice-conflict.out"
+
+  # An unknown flag is an error, not a silently ignored argument.
+  set +e
+  "$helper" --nonsense "$target" >"$TMP_ROOT/$name-badflag.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 2 ] || { echo "FAIL: unknown option was not rejected" >&2; return 1; }
+
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
 # run_private_mono_case — the single repo retains and explains Throughstone's notice at root
 # without creating a project LICENSE for proprietary code.
 run_private_mono_case() {
@@ -663,6 +743,8 @@ run_missing_canonical_license_case
 # A repo registered in place keeps the licensing its owner set; the helper must refuse it rather
 # than write a license claim over code the method did not author.
 run_pre_existing_licensing_case
+# ...and the one thing such a repo may still be owed, when the method leaves material behind.
+run_notice_only_case
 
 # --- Invalid inputs fail before destructive bootstrap work ---------------------
 # Bad license input and missing license templates are detected before template files,


### PR DESCRIPTION
The last two things the repo README template still ordered unconditionally, both written for a repo the method creates. Same create-vs-registered-in-place split as #126 and #132, but the two halves land in opposite directions — one thing we stop doing, one we start.

## The CI gate — never install it into a repo the method didn't create

`templates/ci/README.md` and the README template's stamp comment both said to drop `templates/ci/code-repo-ci.yml` into a repo's `.github/workflows/ci.yml` when scaffolding it. No rule for a repo **registered in place**, which already has CI.

That file is **deliberately failing-until-configured** — its `Configure me` step runs `exit 1` so an unconfigured gate can't silently pass. Correct for a new repo. Landed in a production repo it either:

- **replaces the workflow that gates their merges**, if their file is at that path, or
- **adds a second gate that fails every build** until someone deletes it.

It is now for created repos only. What an in-place repo runs gets recorded in the Test Strategy doc instead, and bringing it onto the standard gate is a change its owners make deliberately, as its own STEP.

`TODO.md` carries the roadmap item to do that properly: read the repo's existing workflow, show what adopting the standard gate would change, act only on an explicit yes — with the open design axes noted (non-GitHub-Actions CI, running alongside rather than replacing, what the Test Strategy doc records when a repo keeps its own pipeline).

## The Throughstone notice — start placing it, in its own mode

Where the method *does* leave Throughstone-authored material in such a repo — the `Role in <project>` README section from #132, or a README written from the template for a repo that had none — that material is BSD-3-Clause and needs its notice.

The existing path can't place it. It also writes a project `LICENSE` and a `LICENSING.md` asserting that license over the repository's content — the claim about someone else's code that #126 and #128 removed — and since #126 it refuses such a target outright.

So `scripts/apply-project-license.sh` gains **`--notice-only`**: `LICENSE-THROUGHSTONE` plus a companion that names only what the notice covers and disclaims everything else. It writes no project `LICENSE` and makes no claim about the repo's own code, which is why it is allowed on exactly the target the full mode refuses.

The companion matters as much as the notice: a BSD file sitting alone in a GPL repo invites precisely the wrong conclusion. And nothing is owed — nothing is written — when the owners declined the addition.

## Verified

- Full maintainer suite 11/11; fresh generated project `check.sh` 0 fail / 0 warn, `links.sh` 0 fail.
- New test exercises `--notice-only` against the target the full mode refuses (a repo carrying `COPYING`) and asserts: the notice is placed, **no project `LICENSE` is written**, the companion disclaims the rest of the repository, the created-repo project-license claim is **absent**, the repo's own `COPYING` is untouched, re-runs are idempotent with the flag on either side of the target, a differing `LICENSING.md` is refused rather than overwritten, and an unknown flag exits 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
