### PR TITLE
Leave an adopted repo's CI alone; place the notice only if material landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,16 @@ error/corruption and re-run paths, not normal operation.
     What decides this is whether a README is already there, not that the repo was adopted: where a
     repo has none, adoption offers to write one from the template — that one file, since adopting
     a repo scaffolds nothing else in it.
+  - **Your CI is left alone, and the Throughstone notice follows what was actually added.**
+    Adoption never installs Throughstone's CI workflow into a repo you already have — that gate
+    fails until configured, so in a running system it would either replace the workflow gating your
+    merges or redden every build until someone removed it. What each repo already runs was recorded
+    in the recon map and is written up by the Test Strategy session; moving a repo onto the
+    standard gate stays a decision you make later. And the Throughstone notice is placed only where
+    Throughstone-authored material actually landed: if you accepted the `Role in <project>` README
+    section, the repo gets `LICENSE-THROUGHSTONE` plus a `LICENSING.md` scoped to that material and
+    disclaiming everything else — never a project `LICENSE`. If you declined, nothing was added, so
+    nothing is claimed.
   - **Your repos' licensing is recorded, never set.** Adoption registers every repo where it already
     sits, so each one's licensing stays its owner's: the recon map records what each repo actually
     says — the identifier and the file it came from, `none stated` where nothing does, plus vendored

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -302,6 +302,19 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   writing into a repo they own. **A no is a complete answer, not a gap:** the same information is
   already in the recon map, the repo's `architecture/` doc, and its `repos.yml` row, so record
   that the repo documents itself and move on.
+  **Never install CI into an adopted repo.** `templates/ci/code-repo-ci.yml` is the gate for a repo
+  the method creates, and it is failing-until-configured by design — so dropping it into a running
+  system either replaces the workflow that gates their merges or fails every build until someone
+  deletes it. These repos already have CI; the recon map's **Tests & CI** section recorded what
+  each one runs, and session `1.12` writes that up. Bringing a repo onto the standard gate is a
+  change its owners decide on later, not a side effect of adoption.
+  **Place the Throughstone notice only if something Throughstone-authored landed.** If the README
+  addition was accepted, that section is BSD-3-Clause scaffold material, so run
+  `scripts/apply-project-license.sh --notice-only <repo-path>` — it writes `LICENSE-THROUGHSTONE`
+  and a `LICENSING.md` scoped to that material, disclaiming the rest of the repo, and never a
+  project `LICENSE`. Do **not** run the helper without that flag; it will refuse, and correctly.
+  If the user declined the README addition, nothing Throughstone-authored is in the repo and
+  nothing is owed — placing a notice for absent material would only confuse a later reader.
   **Never license an adopted repo.** Every repo here is registered in place, so its licensing is
   its owner's and the method only records it (`METHOD.md` §7: the method records licensing; it
   never establishes licensing for code it did not create). Concretely: do **not** run

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -169,6 +169,13 @@ run_existing_case() {
   # here would pass on a template that never got substituted.
   assert_file_contains "$docs/RETCON-PROMPT.md" "\`## Role in $name\` section"
   assert_file_contains "$docs/RETCON-PROMPT.md" "wait for a yes"
+  # CI is the one thing adoption must never install: the shipped gate fails until configured, so
+  # in a running system it either replaces the real gate or reddens every build.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "Never install CI into an adopted repo"
+  # The notice follows the README decision rather than the repo: owed only if material landed, and
+  # placeable only through the mode that writes no project LICENSE.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "\`scripts/apply-project-license.sh --notice-only <repo-path>\`"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "nothing Throughstone-authored is in the repo and"
   # The three places that tell a reader to record an in-place repo's licensing must name the field
   # that holds it. They are deliberately field-free on the 1.7.x line, where no such field exists,
   # so a later forward-merge can quietly reintroduce the vaguer wording here.


### PR DESCRIPTION
The adoption half of #134. Both rules are stated directly here rather than left to the template comment, since this is the path that actually points at someone's production repo.

## CI is never installed

`templates/ci/code-repo-ci.yml` is the gate for a repo the method **creates**, and it is failing-until-configured by design. Dropped into a running system it either replaces the workflow that gates their merges or fails every build until someone deletes it.

Adopted repos already have CI. The recon map's **Tests & CI** section recorded what each one runs, and session `1.12` writes that up — so the information is captured without touching anything. Moving a repo onto the standard gate stays a decision its owners make later.

## The notice follows the README decision, not the repo

If the `Role in <project>` section from #133 was **accepted**, that section is BSD-3-Clause scaffold material and the repo is owed its notice — placed with `scripts/apply-project-license.sh --notice-only <repo-path>` (#134), so no project `LICENSE` is written and nothing is claimed about the repo's own code.

Running the helper **without** the flag is called out explicitly as wrong: it refuses, and correctly, since it would otherwise assert the project's license over code the method never authored.

If the addition was **declined**, nothing Throughstone-authored is in the repo, so nothing is owed. Placing a notice for absent material would only mislead a later reader.

## Verified

- Full maintainer suite 14/14.
- Fresh adoption fixture from a `git archive` of this branch: `check.sh` 0 fail / 0 warn, `links.sh` 0 fail.
- Three assertions pin the parts that fail silently: the CI prohibition, the exact `--notice-only` invocation, and the declined-means-nothing-owed branch (the one an agent is most likely to "helpfully" fill in).

## Depends on

`--notice-only` lands in #134 on the base line. Nothing here breaks before that forward-merges — the instruction names a mode that doesn't exist yet on this branch, exactly as earlier adoption work named the base rules it rides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
