### PR TITLE
Refuse to bootstrap over a repository this method did not create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,29 @@ any project built with it.
   maintainer test enforces it.
 
 ### Fixed
+- **`init.sh` would destroy an existing repository it was run inside, and had no guard at all.**
+  Extract the download into your own repo and run it there — a natural thing to do, and more so
+  since `METHOD.md` §7 began letting a repo be **registered in place**, which gives a user with an
+  existing repo every reason to be holding the template near it. In multi-repo layout that
+  **deleted the repository's `.git`** outright: no longer a repository, no replacement commit,
+  nothing to recover without a remote. In mono-repo layout it replaced the history with a bootstrap
+  commit, wrote a project `LICENSE` next to whatever terms the repo already stated, and added a
+  `LICENSING.md` asserting that license over the whole repository — the exact claim
+  `scripts/apply-project-license.sh` refuses, arriving by the one path that never calls it.
+  `init.sh` now refuses before removing anything, in two cases: a checkout that is not a fresh
+  template (the root pointers' sentinel is gone, so this is an already-initialized project), and a
+  directory whose Git history is not the template's own. A template in a plain folder, a cloned or
+  committed template, and the mono-repo empty-origin reuse flow (`git init` plus a remote, nothing
+  committed yet) all initialize exactly as before.
+- **Declining `registries/` left the docs hub with a broken link on its first run.** A mono-repo
+  project can answer no to the repo inventory, and `init.sh` removed the directory — but the docs
+  hub `README.md` indexes every directory it ships, and its `registries/` row stayed. So the
+  generated project failed `scripts/links.sh` before anyone had touched it. The row is now removed
+  with the directory. Related, in the same configuration: the rules for a repo **registered in
+  place** named the `repos.yml` row flatly as the place a declined README's information still
+  lives, which is a promise a project without an inventory cannot keep. `METHOD.md` §7, the repo
+  README template, and the check-in's README sweep now lead with the architecture doc and treat the
+  row as conditional on the project keeping one.
 - **`11-interface-contracts.md` punctuation drift.** Its go-ahead paragraph had ASCII hyphens where
   every sibling file had em dashes — identical wording otherwise. Now byte-identical to the rest.
 - **Lifting a document into `architecture/` could fail the check that guards it.**
@@ -96,6 +119,32 @@ any project built with it.
   now never installed into a registered-in-place repo; what that repo already runs is recorded in
   the Test Strategy doc instead, and moving it onto the standard gate is a change its owners make
   deliberately.
+- **Four create-only instructions didn't say where they stop.** The rules for a repo **registered
+  in place** are settled — augment its README rather than stamp it, never install the CI gate,
+  never apply the project license, place the Throughstone notice only where the method's own
+  material landed — but each was stated in the file that *defines* it and not in every file an
+  agent has open while doing the work. Four such sites, all of them leaves:
+  - The **repo README template** ended its in-place licensing rule at "do NOT run
+    `apply-project-license.sh`" and never mentioned `--notice-only` — which is exactly what the
+    repo is owed once the README addition the same template orders two paragraphs earlier is
+    accepted. Read as written it forbade the call. On the branch where the owners **decline**,
+    doing nothing was the right outcome, so it gave a correct result half the time and left no
+    trace the other half.
+  - **A repo with no README** is written from the template, and nothing told that path to leave
+    out the **Licensing** section, which describes a repo the method created. Reachable and false
+    rather than merely unhelpful: in a repo that already has its own `LICENSING.md`,
+    `--notice-only` correctly refuses the differing file and writes neither it nor the notice — so
+    the repo was left with a brand-new README asserting a `LICENSE-THROUGHSTONE` that isn't there.
+    That section is now dropped on that path, as it already was when augmenting.
+  - **`templates/ci/code-repo-ci.yml`** — the file actually being copied, and the last thing read
+    before the copy — still said "stamp this into each code repo". Nothing contradicted it and the
+    caveat sat one hop away in the two files that point at it, but the failure mode is replacing
+    the workflow that gates someone's merges.
+  - **`registries/repos.yml`**'s comment sits at the point where an agent writes a repo row, and
+    said repos listed there "are stamped from `templates/repo-readme-template.md`" full stop —
+    false for the registered-in-place row directly beneath it.
+
+  A new maintainer test pins all four in the generated project.
 
 ### Added
 - **`--notice-only` mode for `scripts/apply-project-license.sh`** — places `LICENSE-THROUGHSTONE`

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -484,11 +484,12 @@ README already exists and is usually its most-read file, so the template is not 
 add only the missing piece — a short `Role in <project>` section naming what the repo is within
 the system, with a link to its architecture doc — and leave every section the repo already has
 untouched. Propose the text and where it goes before writing into a repo the method didn't create;
-a decline is a complete outcome, since the same information lives in the architecture doc and the
-`repos.yml` row. The rule keys on whether a README already exists, not on how the repo got here:
+a decline is a complete outcome, since the same information lives in the architecture doc — and in
+the `repos.yml` row where the project keeps an inventory, which a mono-repo project may not. The rule keys on whether a README already exists, not on how the repo got here:
 where a registered-in-place repo has **no** README there is nothing to preserve, so write it from
-the full template — that creates the one file, and nothing else about the repo is scaffolded,
-still proposed before it is written. **Every application-code repo the method *creates* also inherits
+the template — every section but Licensing, which describes a repo the method created and is left
+out here as it is when augmenting. That creates the one file, and nothing else about the repo is
+scaffolded, still proposed before it is written. **Every application-code repo the method *creates* also inherits
 the license posture established by `init.sh`:** read the authoritative selection from the docs
 hub's `.throughstone/project-license`. That file records the license for **Throughstone-authored
 and method-created material** — this docs hub, `prompts/`, and any repo the method creates — which

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -31,8 +31,9 @@ repos:
     type: docs
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
-  # Service / app / library repos get added here as the architecture names them and they
-  # are stamped from templates/repo-readme-template.md. Example:
+  # Service / app / library repos get added here as the architecture names them. A repo the method
+  # CREATES is stamped from templates/repo-readme-template.md; a repo REGISTERED IN PLACE is listed
+  # here like any other but scaffolded in none of these ways — see METHOD.md §7. Example:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -147,7 +147,8 @@ Beyond the architecture docs, sweep four things that rot just as quietly:
   template, so check its **Overview**. A repo **registered in place** owns its own README: check
   that the `Role in {{PROJECT}}` section still describes the repo's place in the system, and leave
   the rest to its owners. If that section was declined, or the repo has no README, that is not a
-  gap to close here — the framing lives in its architecture doc and its `repos.yml` row (`METHOD.md` §7).
+  gap to close here — the framing lives in its architecture doc, and in its `repos.yml` row where
+  the project keeps an inventory (`METHOD.md` §7).
 - **Interface contract artifacts** — any artifact named by `architecture/*-interface-contracts.md` (OpenAPI /
   GraphQL / protobuf / event schema / JSON Schema / public package interface, etc.) still
   matches what the service, worker, CLI, library, or import/export path actually exposes. A

--- a/Code/{{PROJECT}}-docs/templates/ci/code-repo-ci.yml
+++ b/Code/{{PROJECT}}-docs/templates/ci/code-repo-ci.yml
@@ -7,6 +7,12 @@
 # README from templates/repo-readme-template.md), then fill in the toolchain + test command for that
 # repo's stack. The job below FAILS on purpose until you do — an unconfigured gate that silently
 # passes is worse than none. Replace the final step with one of the examples (or your own).
+#
+# Only into a repo the method CREATES. Never into a repo REGISTERED IN PLACE: that repo has its own
+# CI, and because this file fails until configured, landing it there either replaces the workflow
+# that gates their merges or fails every build until somebody deletes it. Record what that repo
+# already runs, in the Test Strategy architecture doc, and leave its pipeline alone
+# (templates/ci/README.md §2, METHOD.md §7).
 
 name: ci
 

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -13,7 +13,11 @@
   AUGMENT a repo REGISTERED IN PLACE — one that existed before this project did — WHEN IT ALREADY
   HAS A README. The rule keys on whether that file exists, not on how the repo got here: a
   registered-in-place repo with no README has nothing to preserve, so write its README from this
-  template. That creates the one file; nothing else about such a repo is scaffolded, and it is
+  template — every section except **Licensing**, which describes a repo the method created and is
+  dropped here for the same reason it is never added when augmenting: no project `LICENSE` is
+  applied to such a repo, so that section would describe files it does not have. `--notice-only`
+  (below) writes the only licensing statement the method puts in such a repo.
+  That creates the one file; nothing else about such a repo is scaffolded, and it is
   still offered rather than assumed, since it is the user's repo.
 
   Where a README does exist it is usually the repo's most-read file, often linked from outside
@@ -30,7 +34,8 @@
   never stamp the Licensing section below into it (that describes a repo the method created).
   Show the exact text and where it will go, and get agreement before writing into someone
   else's repo; if they decline, that is a complete outcome — the same information already lives
-  in the repo's architecture doc and its `registries/repos.yml` row.
+  in the repo's architecture doc, and in its `registries/repos.yml` row where the project keeps
+  an inventory.
 
   For a repo this method CREATES, stamp the CI gate named by the Test Strategy architecture doc
   too: drop `templates/ci/code-repo-ci.yml` into this repo's `.github/workflows/ci.yml` and fill
@@ -52,6 +57,16 @@
   (`LICENSE`, `COPYING`, `NOTICE`, package metadata, vendored third-party terms, or a deliberate
   absence), record that, and leave its licensing alone — including when it differs from the
   bootstrap selection, which governs only this method's own artifacts and the repos it creates.
+
+  What such a repo may still be owed is the notice. If the README addition above was accepted —
+  a `Role in {{PROJECT}}` section, or a README written from this template for a repo that had
+  none — that material is Throughstone-authored, so run
+  `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <this-repo-path>`. It
+  places `LICENSE-THROUGHSTONE` and a `LICENSING.md` naming only what the notice covers, writes
+  no project `LICENSE`, and makes no claim about the rest of the repository — which is why it is
+  allowed here when the plain invocation above is not. If the addition was declined, nothing
+  Throughstone-authored is in the repo and nothing is owed: a notice pointing at absent material
+  only misleads a later reader.
 -->
 
 ## Overview

--- a/init.sh
+++ b/init.sh
@@ -253,6 +253,55 @@ preflight_git_commit
 command -v gh      >/dev/null 2>&1 || echo "Note: 'gh' not found — GitHub repo creation is unavailable, but manual remote URLs still work."
 command -v python3 >/dev/null 2>&1 || echo "Note: 'python3' not found — the later setup-workspace.sh will use its plain-shell fallback."
 
+# --- 0c. Fresh-template guard -----------------------------------------------
+# init.sh is a one-time bootstrap that crosses a destructive boundary below (it removes .git and
+# template-only files). It must run from a fresh, unpacked template checkout — never a second time
+# in an already-initialized project (a re-run would delete a mono repo's history, then fail), and
+# never on top of a repository it did not create. Both refusals happen here, before anything is
+# removed.
+#
+# First: the root pointers (AGENTS.md / CLAUDE.md) carry a THROUGHSTONE-TEMPLATE-GUARD block that
+# step 3 strips during initialization. It is a stable sentinel because it contains no {{PROJECT}}
+# token, so — unlike the docs-hub directory name — placeholder substitution never rewrites it. Its
+# absence means this is not a fresh template.
+if ! grep -qlF 'THROUGHSTONE-TEMPLATE-GUARD' "$ROOT/AGENTS.md" "$ROOT/CLAUDE.md" 2>/dev/null; then
+  echo "init.sh: this does not look like a fresh Throughstone template checkout." >&2
+  echo "  init.sh is one-time and destructive (it removes .git and template-only files), so it will" >&2
+  echo "  not run on an already-initialized project or an unrelated repo — that would delete history." >&2
+  echo "  If you are starting over, re-download the template into a fresh, empty folder and run it there." >&2
+  exit 2
+fi
+
+# Second, and the half that covers *someone else's* repository. The sentinel above proves these
+# files came from the template; it does not prove the template is the only thing here. Extracted
+# INTO an existing repository it is still present and still reads "fresh", while the destructive
+# step below removes that repository's .git — its entire history — and, in mono layout, re-inits and
+# writes a project LICENSE plus a LICENSING.md asserting it over code this method did not author.
+# That is the claim scripts/apply-project-license.sh refuses outright; nothing should be able to
+# make it here instead.
+#
+# What separates the cases is HISTORY, and it needs no list of template paths. What this refusal
+# protects is commits; a work tree that has none has nothing to lose. So: refuse only where HEAD
+# resolves, and only where HEAD's own AGENTS.md does not carry the sentinel.
+#   - template in a plain folder            -> not a work tree, proceeds
+#   - template cloned or committed          -> HEAD's AGENTS.md carries the sentinel, proceeds
+#   - `git init` + an empty origin, no commit yet, the mono-repo origin-reuse flow in section 4
+#                                           -> no HEAD, proceeds
+#   - extracted over a repo with history    -> HEAD is theirs, refused
+# Read HEAD rather than the working file, which the extraction just overwrote, and rather than the
+# index, which is empty in the origin-reuse flow and would fail an untracked-file test.
+if git -C "$ROOT" rev-parse --verify HEAD >/dev/null 2>&1 \
+   && ! git -C "$ROOT" show HEAD:./AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD'; then
+  echo "init.sh: this template is sitting inside an existing Git repository." >&2
+  echo "  $(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null)" >&2
+  echo "  init.sh is one-time and destructive: it would remove that repository's .git — its whole" >&2
+  echo "  history — and in mono-repo layout write a project LICENSE over code it did not author." >&2
+  echo "  Extract the template into a fresh, empty folder OUTSIDE this repository and run it there;" >&2
+  echo "  a repo that already exists is referenced where it sits (METHOD.md §7), never moved into" >&2
+  echo "  the workspace. Nothing was changed." >&2
+  exit 2
+fi
+
 say "Throughstone — setup"
 
 # --- 1. Questions (flags/env pre-answer; otherwise prompt) -------------------
@@ -735,7 +784,14 @@ fi
 # --- 4. Prune optional pieces -----------------------------------------------
 # runbooks/ is kept: it now ships method-level runbooks (check-in, collaboration) that
 # AGENTS.md and METHOD.md reference.
-[ "$KEEP_REGISTRIES" = "0" ] && rm -rf "$DOCS/registries" && echo "  pruned registries/"
+if [ "$KEEP_REGISTRIES" = "0" ]; then
+  rm -rf "$DOCS/registries"
+  # The docs hub README indexes every directory it ships, so pruning the directory without
+  # pruning its row leaves a link to a file that is not there — which scripts/links.sh reports
+  # as a hard failure on the generated project's very first run. Drop the row with the directory.
+  perl -ni -e 'print unless m{^\| \[`registries/`\]}' "$DOCS/README.md"
+  echo "  pruned registries/"
+fi
 
 # Replace the visible ADR authority marker, not arbitrary prose. Solo records the default
 # single-author posture; team records the selected acceptance authority for future handoffs.

--- a/tests/init-fresh-template-guard.sh
+++ b/tests/init-fresh-template-guard.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for init.sh's fresh-template guard.
+#
+# init.sh is a one-time, destructive bootstrap (it removes .git and template-only files). It must
+# refuse to run unless it is a fresh template checkout — detected by the THROUGHSTONE-TEMPLATE-GUARD
+# sentinel in the root pointers, which init strips during setup. This catches two footguns:
+#   - re-running init inside an already-initialized project (a mono re-run would delete the
+#     generated repo's history, then fail partway through);
+#   - running init on top of an unrelated repo.
+# Both must be refused BEFORE the destructive boundary, leaving any existing history intact.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-fresh-guard-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — build an init.sh fixture from HEAD, then overlay current worktree changes so
+# this test covers uncommitted bootstrap edits (same helper as the sibling init tests).
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+init_once() { # DIR EXTRA_ARGS...
+  local dir="$1"; shift
+  ( cd "$dir" && ./init.sh \
+      --non-interactive --slug=acme --desc="Guard test" \
+      --license=private --collab=solo --remotes=no "$@" )
+}
+
+# --- 1. A fresh template initializes normally (the guard must not over-fire). -----------------
+fresh="$TMP_ROOT/fresh"
+copy_template "$fresh"
+init_once "$fresh" --layout=mono --registries=yes >"$TMP_ROOT/fresh.out" 2>&1 \
+  || { echo "FAIL: guard blocked a fresh template checkout" >&2; cat "$TMP_ROOT/fresh.out" >&2; exit 1; }
+commits_before="$(git -C "$fresh" rev-list --count HEAD 2>/dev/null || echo 0)"
+[ "$commits_before" -ge 1 ] || { echo "FAIL: fresh init did not create a mono repo" >&2; exit 1; }
+
+# --- 2. Re-running init in that initialized project is refused, non-destructively. ------------
+if init_once "$fresh" --layout=mono --registries=yes >"$TMP_ROOT/rerun.out" 2>&1; then
+  echo "FAIL: init.sh re-ran inside an already-initialized project" >&2
+  cat "$TMP_ROOT/rerun.out" >&2
+  exit 1
+fi
+grep -Fq "does not look like a fresh Throughstone template checkout" "$TMP_ROOT/rerun.out" \
+  || { echo "FAIL: re-run refusal did not print the fresh-template message" >&2; cat "$TMP_ROOT/rerun.out" >&2; exit 1; }
+commits_after="$(git -C "$fresh" rev-list --count HEAD 2>/dev/null || echo 0)"
+[ "$commits_after" = "$commits_before" ] \
+  || { echo "FAIL: re-run destroyed the generated repo's history ($commits_before -> $commits_after)" >&2; exit 1; }
+[ -d "$fresh/Code/acme-docs" ] || { echo "FAIL: re-run mutated the initialized project" >&2; exit 1; }
+
+# --- 3. Running init on top of an unrelated repo (no sentinel) is refused before destruction. --
+unrelated="$TMP_ROOT/unrelated"
+mkdir -p "$unrelated"
+cp -p "$ROOT/init.sh" "$unrelated/init.sh"
+( cd "$unrelated" && git init -q && printf 'hi\n' > keep.txt && git add -A \
+    && git -c user.name=t -c user.email=t@e commit -qm "pre-existing" )
+unrelated_commit="$(git -C "$unrelated" rev-parse HEAD)"
+if init_once "$unrelated" --layout=mono --registries=yes >"$TMP_ROOT/unrelated.out" 2>&1; then
+  echo "FAIL: init.sh ran on top of an unrelated repo" >&2
+  cat "$TMP_ROOT/unrelated.out" >&2
+  exit 1
+fi
+[ -d "$unrelated/.git" ] && [ "$(git -C "$unrelated" rev-parse HEAD)" = "$unrelated_commit" ] \
+  || { echo "FAIL: init.sh damaged an unrelated repo before refusing" >&2; exit 1; }
+[ -f "$unrelated/keep.txt" ] || { echo "FAIL: init.sh removed unrelated files before refusing" >&2; exit 1; }
+
+# --- 4. The WHOLE template extracted into an existing repo is refused. ------------------------
+# Case 3 drops init.sh alone, so there is no AGENTS.md and the sentinel check catches it. The
+# mistake people actually make is extracting the whole download into their repo — and then the
+# sentinel is present, says "fresh", and the destructive step removes THEIR .git. METHOD.md §7
+# lets a repo be registered in place, so a user who already has one has every reason to be holding
+# the template near it. Mono layout is the worst shape (it re-inits and writes a project LICENSE
+# plus a LICENSING.md asserting it over their code), so test that one.
+extracted="$TMP_ROOT/extracted"
+mkdir -p "$extracted"
+( cd "$extracted" && git init -q && printf 'GPLv2 terms\n' > COPYING && printf 'ours\n' > src.txt \
+    && git add -A && git -c user.name=t -c user.email=t@e commit -qm "existing codebase" )
+extracted_commit="$(git -C "$extracted" rev-parse HEAD)"
+copy_template "$extracted"          # the download, unpacked on top of their repo
+if init_once "$extracted" --layout=mono --registries=yes >"$TMP_ROOT/extracted.out" 2>&1; then
+  echo "FAIL: init.sh ran inside an existing repo with the template extracted into it" >&2
+  cat "$TMP_ROOT/extracted.out" >&2
+  exit 1
+fi
+grep -Fq "sitting inside an existing Git repository" "$TMP_ROOT/extracted.out" \
+  || { echo "FAIL: refusal did not name the reason" >&2; cat "$TMP_ROOT/extracted.out" >&2; exit 1; }
+[ "$(git -C "$extracted" rev-parse HEAD)" = "$extracted_commit" ] \
+  || { echo "FAIL: init.sh destroyed the existing repo's history before refusing" >&2; exit 1; }
+# Nothing written. Assert on paths only init creates — Code/ and prompts/ ship with the template,
+# so the extraction alone leaves them and testing those would pass no matter what init did.
+for must_be_absent in LICENSING.md .throughstone Code/acme-docs; do
+  [ ! -e "$extracted/$must_be_absent" ] \
+    || { echo "FAIL: init.sh wrote $must_be_absent into an existing repo before refusing" >&2; exit 1; }
+done
+[ -d "$extracted/Code/{{PROJECT}}-docs" ] \
+  || { echo "FAIL: init.sh renamed the template docs hub before refusing" >&2; exit 1; }
+grep -Fxq "GPLv2 terms" "$extracted/COPYING" \
+  || { echo "FAIL: init.sh disturbed the existing repo's own licensing file" >&2; exit 1; }
+
+# --- 5. A template that is its own checkout still initializes (the guard must not over-fire). --
+# Clone or download, the template may itself be a work tree. What separates it from case 4 is the
+# INDEX: its own AGENTS.md is tracked, sentinel and all. Without this case the fix in 4 could be
+# written as "refuse inside any work tree", which would break every cloned template.
+checkout="$TMP_ROOT/checkout"
+copy_template "$checkout"
+( cd "$checkout" && git init -q && git add -A \
+    && git -c user.name=t -c user.email=t@e commit -qm "throughstone template" )
+init_once "$checkout" --layout=multi --registries=yes >"$TMP_ROOT/checkout.out" 2>&1 \
+  || { echo "FAIL: guard blocked a template that is its own git checkout" >&2; cat "$TMP_ROOT/checkout.out" >&2; exit 1; }
+[ -d "$checkout/Code/acme-docs" ] || { echo "FAIL: template checkout did not initialize" >&2; exit 1; }
+
+# --- 5b. `git init` + an empty origin, nothing committed, still initializes. ------------------
+# The mono-repo origin-reuse flow (section 4 of init.sh): the user creates an empty repo on their
+# host, runs `git init` in the template folder and points origin at it, then initializes. That is a
+# work tree with no commits and an untracked AGENTS.md — indistinguishable from case 4 by tracking,
+# and completely different by history. Guarding on "is AGENTS.md tracked" breaks this flow; guarding
+# on HEAD does not, which is why the guard reads HEAD.
+empty_origin="$TMP_ROOT/empty-origin"
+copy_template "$empty_origin"
+( cd "$empty_origin" && git init -q && git remote add origin "$TMP_ROOT/empty-origin.git" )
+git init --bare -q "$TMP_ROOT/empty-origin.git"
+init_once "$empty_origin" --layout=mono --registries=yes >"$TMP_ROOT/empty-origin.out" 2>&1 \
+  || { echo "FAIL: guard blocked the empty-root-origin reuse flow" >&2; cat "$TMP_ROOT/empty-origin.out" >&2; exit 1; }
+[ -d "$empty_origin/Code/acme-docs" ] || { echo "FAIL: empty-origin flow did not initialize" >&2; exit 1; }
+
+# --- 6. A repo that tracks an AGENTS.md of its own is still refused. --------------------------
+# The sentinel must be read from the index, not the working file the extraction just overwrote.
+# Testing the working file would pass here and delete their history.
+shadowed="$TMP_ROOT/shadowed"
+mkdir -p "$shadowed"
+( cd "$shadowed" && git init -q && printf 'our own agent notes\n' > AGENTS.md \
+    && git add -A && git -c user.name=t -c user.email=t@e commit -qm "existing codebase" )
+shadowed_commit="$(git -C "$shadowed" rev-parse HEAD)"
+copy_template "$shadowed"
+if init_once "$shadowed" --layout=mono --registries=yes >"$TMP_ROOT/shadowed.out" 2>&1; then
+  echo "FAIL: init.sh ran inside a repo carrying its own tracked AGENTS.md" >&2
+  exit 1
+fi
+[ "$(git -C "$shadowed" rev-parse HEAD)" = "$shadowed_commit" ] \
+  || { echo "FAIL: init.sh destroyed history in the shadowed-AGENTS.md case" >&2; exit 1; }
+
+echo "init.sh fresh-template guard: PASS"

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for the create-vs-registered-in-place split in a generated project.
+#
+# METHOD.md §7 lets a repo be REGISTERED IN PLACE — referenced where it already sits instead of
+# created under Code/. Almost everything the method does to a repo it creates is wrong for one it
+# did not: stamping the README over the repo's most-read file, installing a failing-until-configured
+# CI gate over the workflow that gates their merges, applying a project license to code the method
+# never wrote. None of that is mechanically checkable — it is prose an agent reads and acts on — so
+# what this test pins is that each instruction ships next to the work it governs. The rule is
+# useless in METHOD.md alone if the file an agent has open while scaffolding still says otherwise.
+#
+# Every assertion reads the GENERATED project, not the template, and matches the SUBSTITUTED form:
+# an assertion written against {{PROJECT}} would pass on a template that never got substituted.
+#
+# Keep every needle to ONE line. `grep -F` reads a newline in the pattern as OR, not as a multi-line
+# match, so a needle spanning a wrap silently becomes "either half" — which passes on text that
+# says neither thing in full.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-inplace-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — build an init.sh fixture from HEAD, then overlay current worktree
+# changes so this test covers uncommitted bootstrap edits.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+# assert_contains FILE NEEDLE MESSAGE — the generated file must state the rule.
+assert_contains() {
+  local file="$1" needle="$2" message="$3"
+  grep -Fq "$needle" "$file" || {
+    echo "FAIL: $message" >&2
+    echo "       expected in $file: $needle" >&2
+    return 1
+  }
+}
+
+# assert_absent FILE NEEDLE MESSAGE — the superseded unconditional wording must be gone. Without
+# this the old sentence could be reinstated alongside the new one and every positive assertion
+# would still pass, which is how a rule ends up stated two ways in one file.
+assert_absent() {
+  local file="$1" needle="$2" message="$3"
+  if grep -Fq "$needle" "$file"; then
+    echo "FAIL: $message" >&2
+    echo "       still present in $file: $needle" >&2
+    return 1
+  fi
+}
+
+run_case() {
+  local name="inplace-rules"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Registered-in-place rule test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  local docs="$work/Code/$name-docs"
+  local readme_tpl="$docs/templates/repo-readme-template.md"
+  local ci_workflow="$docs/templates/ci/code-repo-ci.yml"
+  local ci_readme="$docs/templates/ci/README.md"
+  local repos="$docs/registries/repos.yml"
+
+  # --- The README. Stamp what the method creates; augment what it registers, keyed on whether the
+  # file exists. The substituted section name doubles as the placeholder check.
+  assert_contains "$readme_tpl" "STAMP this into a repo the method CREATES" \
+    "repo README template lost the stamp rule for a created repo"
+  assert_contains "$readme_tpl" "## Role in $name" \
+    "repo README template does not name the substituted augment section"
+  # A repo with no README gets the template minus Licensing — that section describes a created repo,
+  # and pointing a repo the method did not license at files it does not have is the same defect the
+  # augment branch already forbids.
+  assert_contains "$readme_tpl" "every section except **Licensing**" \
+    "repo README template does not drop Licensing when writing a missing README"
+  assert_contains "$docs/METHOD.md" "every section but Licensing" \
+    "METHOD.md §7 does not drop Licensing when writing a missing README"
+  assert_absent "$docs/METHOD.md" "the full template — that creates the one file" \
+    "METHOD.md §7 still orders the full template for a repo the method did not create"
+
+  # --- CI. The gate fails until configured, so there is no safe way to land it in a running repo.
+  # The rule belongs on the artifact being copied, not only in the files that point at it.
+  assert_contains "$ci_workflow" "Never into a repo REGISTERED IN PLACE" \
+    "CI workflow template does not carry the never-install rule"
+  assert_contains "$ci_readme" "Never install it into a repo registered in place" \
+    "CI README does not carry the never-install rule"
+  assert_contains "$readme_tpl" "never install it — that repo has its own CI" \
+    "repo README template does not carry the never-install rule"
+
+  # --- The project license and the notice. The method records licensing; it never establishes it
+  # for code it did not create — but where its own material lands, the notice is owed.
+  assert_contains "$readme_tpl" \
+    "Code/$name-docs/scripts/apply-project-license.sh --notice-only <this-repo-path>" \
+    "repo README template does not tell an in-place repo to place the notice"
+  assert_contains "$readme_tpl" "is in the repo and nothing is owed" \
+    "repo README template does not keep the notice off a declined repo"
+
+  # --- The inventory. This comment sits at the point where an agent writes a repo row, so it is
+  # read more often than the header block above it.
+  assert_contains "$repos" "a repo REGISTERED IN PLACE is listed" \
+    "repo inventory comment does not distinguish a registered-in-place repo"
+  assert_absent "$repos" "as the architecture names them and they" \
+    "repo inventory comment still says every repo listed here is stamped"
+
+  # Nothing above may pass on an unsubstituted template.
+  ! grep -R '{{PROJECT}}' "$readme_tpl" "$ci_workflow" "$ci_readme" "$repos" >/dev/null || {
+    echo "FAIL: generated files still carry the {{PROJECT}} placeholder" >&2
+    return 1
+  }
+}
+
+# run_pruned_registries_case — a mono-repo project can decline registries/ entirely, and the rules
+# above have to survive that. Two ways they did not. The docs hub README indexes every directory it
+# ships, so pruning the directory but not its row left a link to a file that is not there — a hard
+# links.sh failure on the generated project's first run, before anyone had touched it. And the
+# rules named the repos.yml row flatly as the place a declined README's information still lives,
+# which is a promise this configuration cannot keep.
+run_pruned_registries_case() {
+  local name="inplace-pruned"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Pruned registries test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=mono \
+      --registries=no \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  local docs="$work/Code/$name-docs"
+  [ ! -d "$docs/registries" ] || { echo "FAIL: --registries=no did not prune registries/" >&2; return 1; }
+
+  # The generated project must be link-clean the moment it exists.
+  ( cd "$docs" && ./scripts/links.sh ) >"$TMP_ROOT/$name-links.out" 2>&1 || {
+    echo "FAIL: generated project has broken links with registries/ pruned" >&2
+    grep -E "FAIL\]" "$TMP_ROOT/$name-links.out" >&2
+    return 1
+  }
+  assert_absent "$docs/README.md" '| [`registries/`](registries/README.md) |' \
+    "docs hub README still indexes a directory that was pruned"
+
+  # The declined-README fallback must not promise a row this project has no file to hold.
+  assert_contains "$docs/METHOD.md" "where the project keeps an inventory" \
+    "METHOD.md §7 still names the repos.yml row unconditionally as the declined-README fallback"
+  assert_contains "$docs/templates/repo-readme-template.md" "where the project keeps" \
+    "repo README template still names the repos.yml row unconditionally"
+  assert_contains "$docs/runbooks/check-in.md" 'and in its `repos.yml` row where' \
+    "check-in README sweep still names the repos.yml row unconditionally"
+}
+
+run_case
+run_pruned_registries_case
+
+echo "init.sh registered-in-place repo rules: PASS"

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -556,6 +556,26 @@ run_notice_only_case() {
   set -e
   [ "$status" -eq 2 ] || { echo "FAIL: unknown option was not rejected" >&2; return 1; }
 
+  # The notice is only placed if an instruction tells an agent to place it. Of the files that
+  # state the in-place licensing rule, this template is the one an agent has open while doing the
+  # work that creates the obligation — it is where the README addition is ordered, and the only
+  # place all three per-repo actions are stated together. It said "do NOT run it" and stopped,
+  # which is right on the declined branch and silently wrong on the accepted one, so nothing
+  # surfaced the gap. Asserted against the SUBSTITUTED path: the raw placeholder would pass on a
+  # template that never got substituted.
+  local repo_readme="$work/Code/$name-docs/templates/repo-readme-template.md"
+  grep -Fq "Code/$name-docs/scripts/apply-project-license.sh --notice-only <this-repo-path>" \
+    "$repo_readme" || {
+    echo "FAIL: repo README template does not tell an in-place repo to place the notice" >&2
+    return 1
+  }
+  # The other half of the branch. A declined addition leaves nothing Throughstone-authored in the
+  # repo, so losing this half would put a notice on a repo that holds no material it covers.
+  grep -Fq "is in the repo and nothing is owed" "$repo_readme" || {
+    echo "FAIL: repo README template does not keep the notice off a declined repo" >&2
+    return 1
+  }
+
   assert_maintainer_tests_removed "$name" "$work"
 }
 


### PR DESCRIPTION
`METHOD.md` §7 lets a repo be **registered in place** — referenced where it already sits rather
than created under `Code/`. The rules that follow are settled: augment its README rather than stamp
it, never install the CI gate, never apply the project license, place the Throughstone notice only
where the method's own material landed. This finishes the job in the two places it was still
unfinished — the door the user comes through, and the files an agent has open while working.

## The door

Extract the download into your own repository and run it there. Natural enough on its own, and more
so now that a repo can be registered in place: a user who has one has every reason to be holding
the template near it. Nothing stopped that, and there was no guard of any kind.

Measured, not reasoned about:

| layout | result |
|---|---|
| multi (default) | `.git` **deleted outright** — no longer a repository, no replacement commit, nothing to recover without a remote |
| mono | history replaced with one bootstrap commit; an MIT `LICENSE` written beside their GPL `COPYING`; a `LICENSING.md` reading *"Project-authored content in this repository is licensed under MIT."* |

That last file is the point. It is the precise claim this line of work removed everywhere else, and
the claim `apply-project-license.sh` refuses on sight — its pre-existing-licensing check exists for
exactly that target. The guard went on the door the *agent* uses. This is the door the *user* uses,
and it wrote those files directly without ever calling the helper.

`init.sh` now refuses before removing anything, in two cases: a checkout that is not a fresh
template (the root pointers' sentinel is gone, so this is an already-initialized project), and a
directory whose Git history is not the template's own — which is what covers someone else's repo,
because the sentinel travels with an extracted template and goes on reading "fresh".

History is the distinguishing fact, not tracking, and testing it needs no list of template paths:
refuse where `HEAD` resolves and `HEAD`'s own `AGENTS.md` does not carry the sentinel.

| case | behavior |
|---|---|
| template in a plain folder | not a work tree — proceeds |
| cloned or committed template | sentinel at `HEAD` — proceeds |
| `git init` + empty origin, nothing committed (mono-repo origin reuse) | no `HEAD` — proceeds |
| extracted over a repo with history | refused, nothing written |
| …over a repo tracking its own `AGENTS.md` | refused (why it reads `HEAD`, not the working file the extraction overwrote) |

The third row is why the test is `HEAD` and not the index: an untracked-file test refuses that
supported flow. The full suite is what said so — the targeted bite check passed either way.

## The instructions

Four leaf sites stated a create-only instruction with no rule for a repo the method did not create.
Each is stated correctly in the file that *defines* it; none of these is that file.

- **The repo README template** ended its in-place licensing rule at "do NOT run
  `apply-project-license.sh`" and never mentioned `--notice-only` — exactly what the repo is owed
  once the README addition the same template orders two paragraphs earlier is accepted. Read as
  written it forbade the call; on the branch where the owners decline, doing nothing was right, so
  it gave a correct result half the time and left no trace the other half.
- **A repo with no README** is written from the template, and nothing told that path to leave out
  the Licensing section, which describes a repo the method created. Reachable and false, not merely
  unhelpful: in a repo that already has its own `LICENSING.md`, `--notice-only` correctly refuses
  the differing file and writes neither it nor the notice — so the repo was left with a brand-new
  README asserting a `LICENSE-THROUGHSTONE` that is not there.
- **`templates/ci/code-repo-ci.yml`** — the file actually being copied — still said "stamp this
  into each code repo". Nothing contradicted it and the caveat sat one hop away, but the failure
  mode is replacing the workflow that gates someone's merges.
- **`registries/repos.yml`**'s comment sits where an agent writes a repo row and said repos listed
  there "are stamped from `templates/repo-readme-template.md`" full stop — false for the
  registered-in-place row directly beneath it.

## Verification

- Full suite **13/13** (`init-fresh-template-guard.sh` and `init-inplace-repo-rules.sh` are new).
- Guard matrix driven end-to-end outside the suite, all five rows above.
- Instruction assertions read a **generated project** and match the **substituted** form, with
  negative assertions so a superseded sentence cannot be reinstated beside its replacement. Each
  bites: reverting one file at a time with the tests kept fails with that file's message.
- Generated project: `check.sh` 0 fail / 0 warn, `links.sh` 0 fail.
- Greenfield-inert: against `main` with identical arguments, generated output differs in exactly the
  four documentation files above, every change inside a registered-in-place branch.
  `prompts/STEP-index.md` byte-identical. The guard changes no supported path's output at all.

## Merge note

Trialled in a scratch clone against the sibling PR. **Four conflicted paths** — `init.sh`,
`tests/init-fresh-template-guard.sh`, `CHANGELOG.md`, `registries/repos.yml`.

**Do not resolve with `git checkout --ours`.** That takes whole files, and `init.sh` carries a
base-side change (removing the docs hub README's `registries/` row when the directory is pruned)
in a *different* region from the conflict. Taking the file wholesale silently drops it and
reintroduces a `links.sh` failure in every generated project that declines the inventory. Verified:
resolved that way the suite goes 14/15, caught by `init-inplace-repo-rules.sh`.

Resolve per hunk instead:

- `init.sh`, `tests/init-fresh-template-guard.sh`, `registries/repos.yml` — keep `retcon`'s side of
  each conflict hunk (its wording is the branch-appropriate one; `main`'s copies deliberately never
  mention adoption), and leave every auto-merged hunk alone.
- `CHANGELOG.md` — keep **both** sides. `retcon`'s entries are adoption-framed; `main`'s adds the
  pruned-`registries/` entry, which is not duplicated anywhere.

Resolved that way the merged state is **15/15**, with the adoption fixture `check.sh` 0/0 and links
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
