### PR TITLE
Stop adoption from writing the project's license over code it did not create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,22 @@ error/corruption and re-run paths, not normal operation.
   maintainer test enforces it.
 
 ### Fixed
+- **`init.sh` would destroy an existing repository it was run inside.** Extract the download into
+  your own repo and run it — the mistake adoption invites, since `--mode=existing` is aimed at the
+  one population that has a repository — and the fresh-template guard saw the template's own
+  sentinel, agreed it was fresh, and continued past the destructive boundary. In multi-repo layout
+  that **deleted the repository's `.git`** outright; in mono-repo layout it replaced the history
+  with a bootstrap commit, wrote a project `LICENSE` next to whatever terms the repo already
+  stated, and added a `LICENSING.md` asserting that license over the whole repository — the exact
+  claim `scripts/apply-project-license.sh` refuses, arriving by the one path that never calls it.
+  The guard now also refuses a directory whose Git history is not the template's own, before
+  anything is removed, and says where the code is meant to stay instead. A template in a plain
+  folder, a cloned template, and the mono-repo empty-origin reuse flow (`git init` plus a remote,
+  nothing committed yet) all initialize exactly as before.
+- **Adoption's "run this from a fresh directory" notice only appeared when the mode was chosen at
+  the prompt.** It lived inside the interactive branch, so `--mode=existing` and `INIT_MODE` — the
+  two paths most likely to be scripted, and no less able to be run from the wrong place — printed
+  nothing. It is now said once, however the mode arrived.
 - **`11-interface-contracts.md` punctuation drift.** Its go-ahead paragraph had ASCII hyphens where
   every sibling file had em dashes — identical wording otherwise. Now byte-identical to the rest.
 - **Lifting a document into `architecture/` could fail the check that guards it.**

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -14,7 +14,10 @@
 # keep `location` and `remote` distinct: a clone URL goes in `remote`, never folded into `location`.
 #
 # Mono-repo-for-now: the entries below are folders inside the single repo, not separate repos
-# yet — this inventory describes the post-split (multi-repo) target.
+# yet — this inventory describes the post-split (multi-repo) target. That applies to the rows the
+# method creates. A row for a repo REGISTERED IN PLACE is not one of them: that repo already exists
+# as its own repo, at its own `location`, and stays there — it is not a folder in this one and not
+# waiting on a split. A mono-repo project that adopts an existing codebase holds both kinds at once.
 #
 # Teams: give each repo a `remote:` field (any cloneable git URL). scripts/setup-workspace.sh clones from
 # it, and the STEP-number reservation in runbooks/collaboration.md relies on a shared remote
@@ -60,13 +63,27 @@ repos:
     license: "{{PROJECT_LICENSE}}"
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
-  # Service / app / library repos get added here as the architecture names them and they
-  # are stamped from templates/repo-readme-template.md. Give each new repo `throughstone: managed`
-  # and a `license:` like the rows above. Example:
+  # Service / app / library repos get added here as the architecture names them. A repo the method
+  # CREATES is stamped from templates/repo-readme-template.md; a repo REGISTERED IN PLACE is listed
+  # here like any other but scaffolded in none of these ways — see METHOD.md §7. Give every repo
+  # `throughstone: managed`. `license:` is the one field that differs by which kind it is: a repo
+  # the method creates takes the project posture, like the rows above; a repo registered in place
+  # takes whatever that repo itself already says, copied as found — never the posture, and never a
+  # value you picked for it. One example of each:
+  #
+  # Created by the method — a Code/* sibling, carrying the project posture:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service
   #   throughstone: managed
-  #   license: "MIT"
+  #   license: "MIT"                                       # the posture, as on the rows above
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
+  #   description: "..."
+  #
+  # Registered in place — its real location, and its own licensing recorded as found:
+  # - name: "legacy-billing"
+  #   location: "/srv/src/legacy-billing/"
+  #   type: service
+  #   throughstone: managed
+  #   license: "GPL-2.0 (COPYING)"                         # what THAT repo says; `none stated` if nothing
   #   description: "..."

--- a/init.sh
+++ b/init.sh
@@ -277,6 +277,37 @@ if ! grep -qlF 'THROUGHSTONE-TEMPLATE-GUARD' "$ROOT/AGENTS.md" "$ROOT/CLAUDE.md"
   exit 2
 fi
 
+# Second half of the same guard, and the half that covers *someone else's* repo. The sentinel above
+# proves these files came from the template; it does not prove the template is the only thing here.
+# Extracted INTO an existing repository it is still present and still reads "fresh", while the
+# destructive step below removes that repository's .git — its entire history — and, in mono layout,
+# re-inits and writes a project LICENSE plus a LICENSING.md asserting it over code this method did
+# not author. That is the claim scripts/apply-project-license.sh refuses outright; nothing should be
+# able to make it here instead. Adoption makes this the likely mistake rather than an exotic one:
+# --mode=existing is aimed at the one population that has a repository to run it inside.
+#
+# What separates the cases is HISTORY, and it needs no list of template paths. What this refusal
+# protects is commits; a work tree that has none has nothing to lose. So: refuse only where HEAD
+# resolves, and only where HEAD's own AGENTS.md does not carry the sentinel.
+#   - template in a plain folder            -> not a work tree, proceeds
+#   - template cloned or committed          -> HEAD's AGENTS.md carries the sentinel, proceeds
+#   - `git init` + an empty origin, no commit yet, the mono-repo origin-reuse flow in section 4
+#                                           -> no HEAD, proceeds
+#   - extracted over a repo with history    -> HEAD is theirs, refused
+# Read HEAD rather than the working file, which the extraction just overwrote, and rather than the
+# index, which is empty in the origin-reuse flow and would fail an untracked-file test.
+if git -C "$ROOT" rev-parse --verify HEAD >/dev/null 2>&1 \
+   && ! git -C "$ROOT" show HEAD:./AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD'; then
+  echo "init.sh: this template is sitting inside an existing Git repository." >&2
+  echo "  $(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null)" >&2
+  echo "  init.sh is one-time and destructive: it would remove that repository's .git — its whole" >&2
+  echo "  history — and in mono-repo layout write a project LICENSE over code it did not author." >&2
+  echo "  Your code is never moved into Throughstone. Extract the template into a fresh, empty" >&2
+  echo "  folder OUTSIDE this repository and run it there; the agent registers your repos in place" >&2
+  echo "  afterwards, where they already live. Nothing was changed." >&2
+  exit 2
+fi
+
 say "Throughstone — setup"
 
 # --- 1. Questions (flags/env pre-answer; otherwise prompt) -------------------
@@ -308,15 +339,22 @@ else
   while :; do
     case "$(ask 'Choose 1 or 2' '1')" in
       1) MODE=new; break ;;
-      2) MODE=existing
-         echo
-         echo "  Adopting an existing codebase: keep running this from the downloaded Throughstone"
-         echo "  folder (a fresh directory), NOT from inside your existing repo. Your code stays"
-         echo "  where it is — the agent registers your repos in place later and never rewrites them."
-         break ;;
+      2) MODE=existing; break ;;
       *) echo "  -> choose 1 for a new project or 2 for an existing codebase." ;;
     esac
   done
+fi
+
+# Said once, however the mode arrived. It used to sit inside the interactive branch above, so the
+# two paths most likely to be scripted — --mode=existing and INIT_MODE — never printed it, and they
+# are no less able to be run from the wrong directory. The work-tree guard in 0c is what actually
+# refuses that; this is the part that says where the code is supposed to stay, which the guard
+# cannot infer.
+if [ "$MODE" = "existing" ]; then
+  echo
+  echo "  Adopting an existing codebase: run this from the downloaded Throughstone folder (a fresh"
+  echo "  directory), NOT from inside your existing repo. Your code stays where it is — the agent"
+  echo "  registers your repos in place later and never rewrites or relocates them."
 fi
 
 # Project slug — validated kebab-case whether supplied or prompted.

--- a/tests/init-fresh-template-guard.sh
+++ b/tests/init-fresh-template-guard.sh
@@ -82,4 +82,79 @@ fi
   || { echo "FAIL: init.sh damaged an unrelated repo before refusing" >&2; exit 1; }
 [ -f "$unrelated/keep.txt" ] || { echo "FAIL: init.sh removed unrelated files before refusing" >&2; exit 1; }
 
+# --- 4. The WHOLE template extracted into an existing repo is refused. ------------------------
+# Case 3 drops init.sh alone, so there is no AGENTS.md and the sentinel check catches it. The
+# mistake people actually make is extracting the whole download into their repo — and then the
+# sentinel is present, says "fresh", and the destructive step removes THEIR .git. Adoption makes
+# this the likely error rather than an exotic one: --mode=existing is aimed at exactly the people
+# who have a repository to run it inside. Mono layout is the worst shape (it re-inits and writes a
+# project LICENSE plus a LICENSING.md asserting it over their code), so test that one.
+extracted="$TMP_ROOT/extracted"
+mkdir -p "$extracted"
+( cd "$extracted" && git init -q && printf 'GPLv2 terms\n' > COPYING && printf 'ours\n' > src.txt \
+    && git add -A && git -c user.name=t -c user.email=t@e commit -qm "existing codebase" )
+extracted_commit="$(git -C "$extracted" rev-parse HEAD)"
+copy_template "$extracted"          # the download, unpacked on top of their repo
+if init_once "$extracted" --mode=existing --layout=mono --registries=yes >"$TMP_ROOT/extracted.out" 2>&1; then
+  echo "FAIL: init.sh ran inside an existing repo with the template extracted into it" >&2
+  cat "$TMP_ROOT/extracted.out" >&2
+  exit 1
+fi
+grep -Fq "sitting inside an existing Git repository" "$TMP_ROOT/extracted.out" \
+  || { echo "FAIL: refusal did not name the reason" >&2; cat "$TMP_ROOT/extracted.out" >&2; exit 1; }
+[ "$(git -C "$extracted" rev-parse HEAD)" = "$extracted_commit" ] \
+  || { echo "FAIL: init.sh destroyed the existing repo's history before refusing" >&2; exit 1; }
+# Nothing written. Assert on paths only init creates — Code/ and prompts/ ship with the template,
+# so the extraction alone leaves them and testing those would pass no matter what init did.
+for must_be_absent in LICENSING.md .throughstone Code/acme-docs; do
+  [ ! -e "$extracted/$must_be_absent" ] \
+    || { echo "FAIL: init.sh wrote $must_be_absent into an existing repo before refusing" >&2; exit 1; }
+done
+[ -d "$extracted/Code/{{PROJECT}}-docs" ] \
+  || { echo "FAIL: init.sh renamed the template docs hub before refusing" >&2; exit 1; }
+grep -Fxq "GPLv2 terms" "$extracted/COPYING" \
+  || { echo "FAIL: init.sh disturbed the existing repo's own licensing file" >&2; exit 1; }
+
+# --- 5. A template that is its own checkout still initializes (the guard must not over-fire). --
+# Clone or download, the template may itself be a work tree. What separates it from case 4 is the
+# INDEX: its own AGENTS.md is tracked, sentinel and all. Without this case the fix in 4 could be
+# written as "refuse inside any work tree", which would break every cloned template.
+checkout="$TMP_ROOT/checkout"
+copy_template "$checkout"
+( cd "$checkout" && git init -q && git add -A \
+    && git -c user.name=t -c user.email=t@e commit -qm "throughstone template" )
+init_once "$checkout" --mode=existing --layout=multi --registries=yes >"$TMP_ROOT/checkout.out" 2>&1 \
+  || { echo "FAIL: guard blocked a template that is its own git checkout" >&2; cat "$TMP_ROOT/checkout.out" >&2; exit 1; }
+[ -d "$checkout/Code/acme-docs" ] || { echo "FAIL: template checkout did not initialize" >&2; exit 1; }
+
+# --- 5b. `git init` + an empty origin, nothing committed, still initializes. ------------------
+# The mono-repo origin-reuse flow (section 4 of init.sh): the user creates an empty repo on their
+# host, runs `git init` in the template folder and points origin at it, then initializes. That is a
+# work tree with no commits and an untracked AGENTS.md — indistinguishable from case 4 by tracking,
+# and completely different by history. Guarding on "is AGENTS.md tracked" breaks this flow; guarding
+# on HEAD does not, which is why the guard reads HEAD.
+empty_origin="$TMP_ROOT/empty-origin"
+copy_template "$empty_origin"
+( cd "$empty_origin" && git init -q && git remote add origin "$TMP_ROOT/empty-origin.git" )
+git init --bare -q "$TMP_ROOT/empty-origin.git"
+init_once "$empty_origin" --mode=new --layout=mono --registries=yes >"$TMP_ROOT/empty-origin.out" 2>&1 \
+  || { echo "FAIL: guard blocked the empty-root-origin reuse flow" >&2; cat "$TMP_ROOT/empty-origin.out" >&2; exit 1; }
+[ -d "$empty_origin/Code/acme-docs" ] || { echo "FAIL: empty-origin flow did not initialize" >&2; exit 1; }
+
+# --- 6. A repo that tracks an AGENTS.md of its own is still refused. --------------------------
+# The sentinel must be read from the index, not the working file the extraction just overwrote.
+# Testing the working file would pass here and delete their history.
+shadowed="$TMP_ROOT/shadowed"
+mkdir -p "$shadowed"
+( cd "$shadowed" && git init -q && printf 'our own agent notes\n' > AGENTS.md \
+    && git add -A && git -c user.name=t -c user.email=t@e commit -qm "existing codebase" )
+shadowed_commit="$(git -C "$shadowed" rev-parse HEAD)"
+copy_template "$shadowed"
+if init_once "$shadowed" --mode=existing --layout=mono --registries=yes >"$TMP_ROOT/shadowed.out" 2>&1; then
+  echo "FAIL: init.sh ran inside a repo carrying its own tracked AGENTS.md" >&2
+  exit 1
+fi
+[ "$(git -C "$shadowed" rev-parse HEAD)" = "$shadowed_commit" ] \
+  || { echo "FAIL: init.sh destroyed history in the shadowed-AGENTS.md case" >&2; exit 1; }
+
 echo "init.sh fresh-template guard: PASS"

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -184,11 +184,39 @@ run_existing_case() {
   assert_file_contains "$docs/AGENTS.md" "repo's \`registries/repos.yml\` \`license:\` field"
   assert_file_contains "$docs/templates/planning-session.md" \
     "\`registries/repos.yml\` \`license:\` field and move on"
+  # The header states the field correctly; this is the comment at the point where a row is actually
+  # written, and every adopted repo's row is written there. It used to say "a `license:` like the
+  # rows above" — and the rows above carry the install-time posture, so an agent registering a
+  # GPL repo was being shown MIT as the pattern. Both halves pinned: the instruction, and a
+  # worked in-place example, since an example is what gets copied.
+  assert_file_contains "$docs/registries/repos.yml" \
+    "takes whatever that repo itself already says, copied as found"
+  assert_file_contains "$docs/registries/repos.yml" "license: \"GPL-2.0 (COPYING)\""
+  if grep -Fq "a \`license:\` like the rows above" "$docs/registries/repos.yml"; then
+    echo "FAIL: $name still points an in-place repo's license: at the project posture" >&2
+    return 1
+  fi
+  # The same comment must not claim every repo listed there is stamped from the README template.
+  assert_file_contains "$docs/registries/repos.yml" "REGISTERED IN PLACE is listed"
+  # Mono-repo + adoption is a real combination this test exercises (run_existing_case runs both
+  # layouts). The file's mono note says its rows are "folders inside the single repo, not separate
+  # repos yet" — true of what the method creates, false of every row an adoption writes, and this
+  # inventory holds both kinds at once. Scoped now, and pinned because the note reads perfectly
+  # sensible on its own and only goes wrong next to a registered-in-place row.
+  assert_file_contains "$docs/registries/repos.yml" \
+    "as its own repo, at its own \`location\`, and stays there"
 
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).
   assert_file_contains "$TMP_ROOT/$name.out" "ADOPT your existing codebase"
   ! grep -Fq "interview you, propose a roadmap" "$TMP_ROOT/$name.out"
+
+  # 7. Where the user's code stays is said on EVERY path into adoption. This run is the flag path
+  #    (--mode=existing, non-interactive) — the one that used to print nothing, because the notice
+  #    lived inside the interactive prompt's branch. The work-tree guard refuses running from
+  #    inside their repo; only this says where the code is meant to stay instead.
+  assert_file_contains "$TMP_ROOT/$name.out" "NOT from inside your existing repo"
+  assert_file_contains "$TMP_ROOT/$name.out" "never rewrites or relocates them"
 }
 
 # run_existing_env_case — the same fork via the INIT_MODE env var instead of the flag.


### PR DESCRIPTION
Two ways the same mistake reached a user's existing repository. One of them took their history
with it.

## Run from inside their repo

Extract the download into your own repository and run it there. Not an exotic slip —
`--mode=existing` is aimed at the one population that has a repository to run it inside, and
putting the tool where the work is, is the ordinary instinct.

The fresh-template guard did not stop it. It tests one thing: the `THROUGHSTONE-TEMPLATE-GUARD`
sentinel in the root pointers. Extracted into someone's repo the sentinel comes along, still reads
"fresh", and init continues past the destructive boundary. Its own comment claims it refuses "an
already-initialized project **or an unrelated repo**"; it only ever detected the first. The test
file said the same in its header and covered `init.sh` dropped in *alone*, where `AGENTS.md` is
absent and the sentinel check catches it — not the whole template extracted, which is what people
download.

What that cost, measured rather than reasoned about:

| layout | result |
|---|---|
| multi (default) | `.git` **deleted outright** — no longer a repository, no replacement commit, nothing to recover without a remote |
| mono | history replaced with one bootstrap commit; their `README.md` gone; an MIT `LICENSE` written beside their GPL `COPYING`; a `LICENSING.md` reading *"Project-authored content in this repository is licensed under MIT."* |

That last file is the point. It is the precise claim the first two findings of this line of work
removed, and the claim `apply-project-license.sh` refuses on sight — its pre-existing-licensing
check exists for exactly that target. The guard went on the door the *agent* uses. This is the door
the *user* uses, and it wrote those files directly without ever calling the helper.

**The fix.** The guard now also refuses a directory whose Git history is not the template's own,
before anything is removed. The distinguishing fact is history, not tracking, and it needs no list
of template paths: refuse where `HEAD` resolves and `HEAD`'s own `AGENTS.md` does not carry the
sentinel.

| case | behavior |
|---|---|
| template in a plain folder | not a work tree — proceeds |
| cloned or committed template | sentinel at `HEAD` — proceeds |
| `git init` + empty origin, nothing committed (mono-repo origin reuse) | no `HEAD` — proceeds |
| extracted over a repo with history | refused, nothing written |
| …over a repo tracking its own `AGENTS.md` | refused (this is why it reads `HEAD`, not the working file the extraction overwrote) |

The third row is why the test is `HEAD` and not the index: an untracked-file test refuses that
supported flow. The full suite is what said so — the bite check passed either way.

## Say where the code stays, on every path in

The notice telling a user to run from a fresh directory sat inside the interactive prompt's branch,
so `--mode=existing` and `INIT_MODE` printed nothing. The guard refuses the wrong directory; only
this says where the code is meant to stay instead, which the guard cannot infer. Said once now,
however the mode arrived.

## The inventory

`registries/repos.yml`'s header says the right thing about `license:` — for a repo registered in
place it is whatever that repo already says, recorded as found. The comment at the point where a
row is written said *"Give each new repo `throughstone: managed` and a `license:` like the rows
above"*, and the rows above carry the install-time posture, as did the worked example. Three
`MIT`s on screen while an agent registers a GPL repo.

Under adoption every code repo's row is written beneath that comment, and two of its three
instructions are correct for those repos — add a row, `throughstone: managed` — with nothing
marking the third as the one that inverts. The header states it correctly twenty lines up, which is
not where the agent is looking. Same failure as above, in the inventory rather than the repo, and
less visible: a wrong `LICENSE` file is seen by that repo's owners; a wrong row in a docs hub they
never read is not.

The comment now splits by which kind of repo the row describes, and the examples show one of each,
with `none stated` named for a repo that says nothing. The example is what gets copied, so an
unlabeled one is an instruction whether or not it was meant as one. It also stopped claiming every
repo listed there is stamped from the README template, which is false for every row an adoption
writes.

## Verification

- Full suite **14/14**. Both new assertions bite: reverting `init.sh` and keeping the tests fails
  with the extracted-into-a-repo case and the missing notice; restored, both pass.
- Guard matrix driven end-to-end outside the suite, all five rows above.
- Adoption and greenfield fixtures built from this ref: `check.sh` 0 fail / 0 warn, `links.sh` 0
  fail.
- Greenfield-inert: against `retcon` with identical arguments, generated output differs in exactly
  one file — this `repos.yml` comment — and `prompts/STEP-index.md` is byte-identical. The guard
  changes no supported path's output.

## Merge note

Trialled in a scratch clone against the sibling PR. **Four conflicted paths** — `init.sh`,
`tests/init-fresh-template-guard.sh`, `CHANGELOG.md`, `registries/repos.yml`.

**Do not resolve with `git checkout --ours`.** That takes whole files, and `init.sh` carries a
base-side change (removing the docs hub README's `registries/` row when the directory is pruned)
in a *different* region from the conflict. Taking the file wholesale silently drops it and
reintroduces a `links.sh` failure in every generated project that declines the inventory. Verified:
resolved that way the suite goes 14/15, caught by `init-inplace-repo-rules.sh`.

Resolve per hunk instead:

- `init.sh`, `tests/init-fresh-template-guard.sh`, `registries/repos.yml` — keep `retcon`'s side of
  each conflict hunk (its wording is the branch-appropriate one; `main`'s copies deliberately never
  mention adoption), and leave every auto-merged hunk alone.
- `CHANGELOG.md` — keep **both** sides. `retcon`'s entries are adoption-framed; `main`'s adds the
  pruned-`registries/` entry, which is not duplicated anywhere.

Resolved that way the merged state is **15/15**, with the adoption fixture `check.sh` 0/0 and links
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
