### PR TITLE
Check the repo README template in an adoption-generated project

### DIFF
--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -206,6 +206,30 @@ run_existing_case() {
   assert_file_contains "$docs/registries/repos.yml" \
     "as its own repo, at its own \`location\`, and stays there"
 
+  # 5b. The repo README template, in an ADOPTION-generated project.
+  # `RETCON-PROMPT.md` states these rules for the resolver and is pinned above, but the template's
+  # own comment is the file an agent has open while writing into someone's repo — it is what the
+  # resolver, METHOD.md §7 and the planning session all point at by name. Every existing assertion
+  # on that comment reads a project generated with the default mode, so on the path where these
+  # rules decide what happens to a repo the method did not create, nothing checked that the file
+  # shipped carrying them. That is not the same guarantee: the docs hub an adoption produces is
+  # assembled by the same installer but selected for by a different flag, and the rules are base
+  # text, so a forward merge is free to erode them here without failing a greenfield assertion.
+  local readme_tpl="$docs/templates/repo-readme-template.md"
+  # Stamp what the method creates; augment what it registers, keyed on whether a README exists.
+  assert_file_contains "$readme_tpl" "STAMP this into a repo the method CREATES"
+  assert_file_contains "$readme_tpl" "## Role in $name"
+  # The no-README path writes the template minus Licensing — that section describes a created repo,
+  # and adoption is precisely where a repo with no README gets one written from this file.
+  assert_file_contains "$readme_tpl" "every section except **Licensing**"
+  # CI is never installed into a repo the method did not create.
+  assert_file_contains "$readme_tpl" "never install it — that repo has its own CI"
+  # The notice is owed where Throughstone-authored material landed, and only there. Substituted,
+  # so an unsubstituted template cannot satisfy it.
+  assert_file_contains "$readme_tpl" \
+    "Code/$name-docs/scripts/apply-project-license.sh --notice-only <this-repo-path>"
+  assert_file_contains "$readme_tpl" "is in the repo and nothing is owed"
+
   # 6. The bootstrap hand-off explains adoption, not the greenfield interview.
   #    Key on a distinctive phrase, not the substring "retcon" (which may sit inside the slug).
   assert_file_contains "$TMP_ROOT/$name.out" "ADOPT your existing codebase"


### PR DESCRIPTION
The rules for a repo the method did not create — augment rather than stamp, write the template
*minus its Licensing section* where there is no README, never install the CI gate, place the
Throughstone notice only where material actually landed — are all stated in
`templates/repo-readme-template.md`. That comment is the file an agent has open while writing into
someone's repo; `RETCON-PROMPT.md`, `METHOD.md` §7 and the planning session all point at it by name.

Every assertion on that comment reads a project generated with the **default mode**
(`init-license-validation.sh` and `init-inplace-repo-rules.sh` both). So on the one path where
these rules decide what happens to a repository the method did not create, nothing checked that
the file shipped carrying them.

## Why this is not a duplicate of the greenfield checks

An adoption's docs hub is assembled by the same installer but selected for by a different flag, and
every one of these rules is **base text carried across on merges** — so a future resolution is free
to erode them on this line without failing anything a greenfield run asserts. This is the file that
exists to catch exactly that: it already pins three sentences for the same stated reason, recorded
in its own comments as a standing forward-merge risk.

The risk is not hypothetical. The forward merge that just landed had four conflicted paths, and
resolving one of them the obvious way (`git checkout --ours`) silently dropped a fix from the other
branch — caught only because a test happened to cover it.

## What's here

Six assertions inside `run_existing_case`, which already builds an adoption project in **both**
layouts:

| rule | assertion |
|---|---|
| stamp what the method creates | `STAMP this into a repo the method CREATES` |
| augment what it registers | `## Role in <slug>` (substituted) |
| no-README path drops Licensing | `every section except **Licensing**` |
| CI never installed in place | `never install it — that repo has its own CI` |
| notice where material landed | `Code/<slug>-docs/scripts/apply-project-license.sh --notice-only <this-repo-path>` |
| nothing owed when declined | `is in the repo and nothing is owed` |

The notice invocation is matched against the **substituted** path — the raw placeholder would pass
on a template that never got substituted.

## Verification

- Full suite **15/15**.
- Each assertion verified to bite: removing one rule at a time from the template and re-running
  makes the suite name that rule. Confirmed for the Licensing carve-out, the CI rule, and the
  notice invocation.
- Tests only — one file, 24 added lines, no behavior change in either mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
