### PR TITLE
Check the README the method wrote, not just the one it augmented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ any project built with it.
   lives, which is a promise a project without an inventory cannot keep. `METHOD.md` §7, the repo
   README template, and the check-in's README sweep now lead with the architecture doc and treat the
   row as conditional on the project keeping one.
+- **The check-in's README sweep had no case for the README the method writes into a repo it did
+  not create.** Where a repo **registered in place** has no README, the method writes one from the
+  full template — that is the settled rule. The sweep in `runbooks/check-in.md` knew only two
+  kinds: a repo the method created (check its Overview) and one registered in place, which "owns
+  its own README" (check its `Role in <project>` section). A written-from-template README is
+  neither. It has no `Role in <project>` heading — that section exists only on the augment path —
+  so the sweep either reported its absence as a gap, proposing a second write into a repo the
+  method didn't create, or filed the file under "declined" and stopped checking the one README
+  there the method is answerable for. The sweep now branches on the same thing the writing rule
+  branches on — whether a README was already there — and checks a written-from-template one the
+  way a created repo's is checked. A declined addition is still not a gap to close.
 - **`11-interface-contracts.md` punctuation drift.** Its go-ahead paragraph had ASCII hyphens where
   every sibling file had em dashes — identical wording otherwise. Now byte-identical to the rest.
 - **Lifting a document into `architecture/` could fail the check that guards it.**

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -144,11 +144,15 @@ Beyond the architecture docs, sweep four things that rot just as quietly:
   Testing** steps still work from a clean checkout. They are written once and otherwise never
   re-checked, so they're usually the stalest doc a new contributor or agent hits first (and any
   `ARCHITECTURE.md` still matches the design). A repo the method **created** carries the full
-  template, so check its **Overview**. A repo **registered in place** owns its own README: check
-  that the `Role in {{PROJECT}}` section still describes the repo's place in the system, and leave
-  the rest to its owners. If that section was declined, or the repo has no README, that is not a
-  gap to close here — the framing lives in its architecture doc, and in its `repos.yml` row where
-  the project keeps an inventory (`METHOD.md` §7).
+  template, so check its **Overview**. For a repo **registered in place** this keys on the same
+  thing the writing rule keyed on — whether a README was already there. **One that had one** owns
+  it: check only that the `Role in {{PROJECT}}` section still describes the repo's place in the
+  system, and leave the rest to its owners. **One that had none** carries a README the method
+  wrote from the template, so that file is Throughstone-authored like a created repo's — check its
+  **Overview** the same way, and still scaffold nothing else there. If the addition was declined,
+  or the repo has no README, that is not a gap to close here — the framing lives in its
+  architecture doc, and in its `repos.yml` row where the project keeps an inventory
+  (`METHOD.md` §7).
 - **Interface contract artifacts** — any artifact named by `architecture/*-interface-contracts.md` (OpenAPI /
   GraphQL / protobuf / event schema / JSON Schema / public package interface, etc.) still
   matches what the service, worker, CLI, library, or import/export path actually exposes. A

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -90,6 +90,7 @@ run_case() {
   local ci_workflow="$docs/templates/ci/code-repo-ci.yml"
   local ci_readme="$docs/templates/ci/README.md"
   local repos="$docs/registries/repos.yml"
+  local check_in="$docs/runbooks/check-in.md"
 
   # --- The README. Stamp what the method creates; augment what it registers, keyed on whether the
   # file exists. The substituted section name doubles as the placeholder check.
@@ -106,6 +107,18 @@ run_case() {
     "METHOD.md §7 does not drop Licensing when writing a missing README"
   assert_absent "$docs/METHOD.md" "the full template — that creates the one file" \
     "METHOD.md §7 still orders the full template for a repo the method did not create"
+  # The check-in reads that rule back months later, so it needs the same two branches. A sweep that
+  # knows only "augmented" looks for a Role section the write-from-template path never produces,
+  # and either reports its absence as a gap — writing into the repo a second time — or files the
+  # file under "declined" and stops checking the one README there the method is answerable for.
+  assert_contains "$check_in" "check only that the \`Role in $name\` section" \
+    "check-in README sweep does not scope the Role-section check to an augmented repo"
+  assert_contains "$check_in" "**One that had none** carries a README the method" \
+    "check-in README sweep has no branch for a README the method wrote for an in-place repo"
+  assert_contains "$check_in" "**Overview** the same way, and still scaffold nothing else there" \
+    "check-in README sweep does not check that written README the way a created repo's is checked"
+  assert_absent "$check_in" "A repo **registered in place** owns its own README" \
+    "check-in README sweep still says every in-place repo owns its own README"
 
   # --- CI. The gate fails until configured, so there is no safe way to land it in a running repo.
   # The rule belongs on the artifact being copied, not only in the files that point at it.
@@ -132,7 +145,7 @@ run_case() {
     "repo inventory comment still says every repo listed here is stamped"
 
   # Nothing above may pass on an unsubstituted template.
-  ! grep -R '{{PROJECT}}' "$readme_tpl" "$ci_workflow" "$ci_readme" "$repos" >/dev/null || {
+  ! grep -R '{{PROJECT}}' "$readme_tpl" "$ci_workflow" "$ci_readme" "$repos" "$check_in" >/dev/null || {
     echo "FAIL: generated files still carry the {{PROJECT}} placeholder" >&2
     return 1
   }


### PR DESCRIPTION
## The gap

`METHOD.md` §7, `templates/repo-readme-template.md`, `AGENTS.md` and
`templates/planning-session.md` all settle the same rule: a repo **registered in place**
is *augmented* rather than stamped, and the rule keys on whether a README is already
there — where such a repo has **none**, its README is written from the full template.

The periodic check-in's README sweep (`runbooks/check-in.md`) never learned the second
half. It branched two ways:

- a repo the method **created** carries the full template → check its **Overview**;
- a repo **registered in place** "owns its own README" → check that its
  `Role in <project>` section still describes the repo's place, and leave the rest to
  its owners.

A written-from-template README is neither. The file is Throughstone-authored, not its
owners'. And it has no `Role in <project>` heading — a from-template README is
`# <repo-name>`, a blockquote one-liner, then `## Overview`; the `## Role in <project>`
section exists only on the augment path. The fallback did not catch it either: it covers
a declined addition, or a repo that still has no README, and neither is true here.

## What that costs

The sweep either reports the missing heading as a gap and proposes adding one — a second
write into a repo the method did not create, duplicating the role one-liner already at
the top of the file — or reads the repo as having declined and stops checking the one
README there the method is actually answerable for.

Reporting an existing README as a gap is the same defect this sweep was corrected for
once already; this moves it from the augmented case to the written one.

## The fix

The sweep now branches on the same fact the writing rule branches on — whether a README
was already there:

- **already there, augmented** → check only the `Role in <project>` section, leave the
  rest to its owners (unchanged);
- **not there, so the method wrote it** → that file is Throughstone-authored like a
  created repo's, so check its **Overview** the same way, and still scaffold nothing else;
- **declined, or still no README** → not a gap to close here (unchanged).

The declined branch now reads "the addition" rather than "that section", since the offer
covers a whole README as well as a section.

## Verification

None of this is mechanically checkable, so `tests/init-inplace-repo-rules.sh` pins it in
the **generated** project against the **substituted** form: two positive assertions for
the new branch, one scoping the `Role in <project>` check to the augmented case, and a
negative assertion so the superseded sentence cannot be reinstated beside its
replacement. `check-in.md` joins that test's `{{PROJECT}}` placeholder guard.

- Each of the four assertions verified to bite, one at a time, by mutating only that
  needle in the prose.
- Full suite at the shipping commit: **13/13**.
- Fixtures built from `git archive` of the shipping commit — greenfield multi,
  mono `--registries=no`, and proprietary — all `scripts/check.sh` 0 fail / 0 warn and
  `scripts/links.sh` clean.
- Greenfield-inert: a project generated from this commit differs from one generated at
  `main`'s tip in exactly one file, `runbooks/check-in.md`. Everything else is
  byte-identical.

Docs-only plus one test; no script, no generated project state, nothing for an existing
project to migrate beyond pulling `runbooks/check-in.md` (already in the 1.7.2 migration
group in `UPDATING-THROUGHSTONE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
