### PR TITLE
Let the augment-vs-stamp upgrade note start its own line

### DIFF
--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -298,7 +298,8 @@ affect work you do after pulling them.
   changes; the wording around it does, in `METHOD.md` §7, `AGENTS.md`, `README.md`, the planning
   session, and the helper's header. Pull them with the group below. **One thing to check:** if a
   repo of yours was registered in place rather than created by the method, its licensing is its
-  own — record what it actually uses beside its inventory entry rather than assuming the posture.- **A repo you registered in place is augmented, not stamped.** `templates/repo-readme-template.md`
+  own — record what it actually uses beside its inventory entry rather than assuming the posture.
+- **A repo you registered in place is augmented, not stamped.** `templates/repo-readme-template.md`
   told you to stamp a copy into each repo "as it's created", which is the only case it considered —
   so pointed at a repo that already existed, the instruction reads as "overwrite its README". That
   repo's README is usually its most-read file. It now gets a short `Role in <project>` section


### PR DESCRIPTION
## What's wrong

`UPDATING-THROUGHSTONE.md` is what someone reads when upgrading: a list of what changed
and what to check. In the **1.7.2 migration** list, one item never started its own line.
The previous item ended `…rather than assuming the posture.` and the next bullet ran on
immediately after it, on the same line:

```
  own — record what it actually uses beside its inventory entry rather than assuming the posture.- **A repo you registered in place is augmented, not stamped.** `templates/repo-readme-template.md`
```

Markdown only opens a list item when the marker starts a line. It doesn't here, so the
entire note rendered *inside* the preceding item, behind a literal `.-`, and its
**One thing to check** advice looked like it belonged to the license-posture change.

Nothing the text says is wrong — it is simply hidden. It also happens to be the note for
the README rule, which is the change an upgrader most needs to notice, buried in the item
about `.throughstone/project-license`.

## The fix

A newline. The list is tight elsewhere in this section (no blank lines between items), so
the item is separated the same way its neighbours are.

## Scope

- Swept **both** lines for the same defect anywhere else in any Markdown file — this was
  the only occurrence, and `retcon`'s copy of this section is already correct.
- **No changelog entry.** The `### 1.7.2 migration` section is not present at `v1.7.1`, so
  this text has never appeared in a release; there is no shipped behaviour to log a fix
  against. This also keeps the change off the changelog lines other open work touches.
- Full suite: **13/13**.
- One file, one line split in two. No script, no template, no generated project state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Forward merge into `retcon` — trialled, and it needs a hand-resolution

Trialled in a scratch clone: **one conflict**, in this file. It is structural, not textual.
`retcon` has no `### 1.7.2 migration` section at all — that content was folded into
`### 2.0 migration`, where the same bullet already stands on its own line correctly. So git
sees `main` editing a block `retcon` removed, and presents it as the whole section arriving
against an empty side.

**Resolve to `retcon`'s side — drop the incoming block.** Verified: the resolved file is
byte-identical to `retcon`'s current copy, and the resolved tree is byte-identical to
`retcon`'s tree. The fix is a **no-op on `retcon`**, because `retcon` was already right.

Resolving it the other way, or "taking both", re-injects a `### 1.7.2 migration` section that
`retcon` deliberately dropped — about ninety lines duplicating what the 2.0 section already
says.
