### PR TITLE
Ask more than one question before deleting a repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,15 @@ any project built with it.
   `scripts/apply-project-license.sh` refuses, arriving by the one path that never calls it.
   `init.sh` now refuses before removing anything, in two cases: a checkout that is not a fresh
   template (the root pointers' sentinel is gone, so this is an already-initialized project), and a
-  directory whose Git history is not the template's own. A template in a plain folder, a cloned or
-  committed template, and the mono-repo empty-origin reuse flow (`git init` plus a remote, nothing
-  committed yet) all initialize exactly as before.
+  directory that already holds work of its own. That second case asks three questions rather than
+  one, because a repository keeps work in more than one place and each of these is invisible to the
+  check that catches the others: commits under `HEAD`; commits on branches or tags `HEAD` is not
+  currently on (`git checkout --orphan` leaves `HEAD` unborn while every earlier commit stays on
+  its branch, so a HEAD-only check reads a live repository as empty); and files staged but never
+  committed. Any one of them refuses. A template in a plain folder, a cloned or committed template,
+  a template staged but not yet committed, and the mono-repo empty-origin reuse flow (`git init`
+  plus a remote, nothing committed yet) all initialize exactly as before, and each refusal now says
+  which check fired.
 - **Declining `registries/` left the docs hub with a broken link on its first run.** A mono-repo
   project can answer no to the repo inventory, and `init.sh` removed the directory — but the docs
   hub `README.md` indexes every directory it ships, and its `registries/` row stayed. So the

--- a/init.sh
+++ b/init.sh
@@ -281,19 +281,46 @@ fi
 # make it here instead.
 #
 # What separates the cases is HISTORY, and it needs no list of template paths. What this refusal
-# protects is commits; a work tree that has none has nothing to lose. So: refuse only where HEAD
-# resolves, and only where HEAD's own AGENTS.md does not carry the sentinel.
+# protects is work its owner cannot get back — and a repository can be holding that in more than
+# one place. Asking git a single question about a single one of them is how the first version of
+# this guard let a live repository through: it asked what HEAD points at, and a repository whose
+# HEAD is unborn is still holding every commit made on its other branches.
+#
+# So ask several independent questions and refuse if ANY of them says yes. None has to be certain
+# on its own; between them they cover the places a repository keeps work that step 3 would delete.
+#   1. HEAD resolves, and HEAD's own AGENTS.md does not carry the sentinel — committed history,
+#      and it is not this template's.
+#   2. HEAD does not resolve, but the repository already holds refs — branches, tags, remote
+#      tracking, a stash. `git checkout --orphan` inside a working repo lands exactly here: no
+#      commit under HEAD, every earlier commit still on the branch it was made on.
+#   3. Nothing is committed anywhere, but files are staged and the staged AGENTS.md is not the
+#      template's — work that so far exists only in the index.
+# Each reads a different store, and each reads the repository rather than the working files, which
+# the extraction just overwrote.
 #   - template in a plain folder            -> not a work tree, proceeds
 #   - template cloned or committed          -> HEAD's AGENTS.md carries the sentinel, proceeds
+#   - template staged, not yet committed     -> the staged AGENTS.md carries it, proceeds
 #   - `git init` + an empty origin, no commit yet, the mono-repo origin-reuse flow in section 4
-#                                           -> no HEAD, proceeds
-#   - extracted over a repo with history    -> HEAD is theirs, refused
-# Read HEAD rather than the working file, which the extraction just overwrote, and rather than the
-# index, which is empty in the origin-reuse flow and would fail an untracked-file test.
-if git -C "$ROOT" rev-parse --verify HEAD >/dev/null 2>&1 \
-   && ! git -C "$ROOT" show HEAD:./AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD'; then
+#                                           -> no HEAD, no refs, nothing staged, proceeds
+#   - extracted over a repo with history    -> refused by 1
+#   - extracted onto an orphan branch       -> refused by 2
+#   - extracted over staged, uncommitted work -> refused by 3
+BOOTSTRAP_GUARD_REASON=""
+if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  if git -C "$ROOT" rev-parse --verify HEAD >/dev/null 2>&1; then
+    git -C "$ROOT" show HEAD:./AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD' \
+      || BOOTSTRAP_GUARD_REASON="its committed history is not this template's"
+  elif git -C "$ROOT" show-ref --quiet 2>/dev/null; then
+    BOOTSTRAP_GUARD_REASON="it holds commits on branches or tags that HEAD is not currently on"
+  elif [ -n "$(git -C "$ROOT" ls-files 2>/dev/null)" ] \
+       && ! git -C "$ROOT" show :./AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD'; then
+    BOOTSTRAP_GUARD_REASON="it has staged files that are not this template's"
+  fi
+fi
+if [ -n "$BOOTSTRAP_GUARD_REASON" ]; then
   echo "init.sh: this template is sitting inside an existing Git repository." >&2
   echo "  $(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null)" >&2
+  echo "  Refusing because $BOOTSTRAP_GUARD_REASON." >&2
   echo "  init.sh is one-time and destructive: it would remove that repository's .git — its whole" >&2
   echo "  history — and in mono-repo layout write a project LICENSE over code it did not author." >&2
   echo "  Extract the template into a fresh, empty folder OUTSIDE this repository and run it there;" >&2

--- a/tests/init-fresh-template-guard.sh
+++ b/tests/init-fresh-template-guard.sh
@@ -9,6 +9,14 @@
 #     generated repo's history, then fail partway through);
 #   - running init on top of an unrelated repo.
 # Both must be refused BEFORE the destructive boundary, leaving any existing history intact.
+#
+# The second footgun needs more than one question asked of git, because a repository holds work in
+# more than one store, and each of these cases is invisible to the check that catches the others:
+#   1. committed history under HEAD       (cases 3, 4, 6)
+#   2. commits on refs HEAD is not on     (case 7 — `git checkout --orphan`, HEAD unborn)
+#   3. work staged but never committed    (case 8 — no HEAD, no refs)
+# Each has a matching must-PROCEED case, because a guard that over-fires is its own outage:
+# 5 (committed template), 5b (git init + empty origin), 6b (template staged, not committed).
 
 set -euo pipefail
 export LC_ALL=C
@@ -156,5 +164,70 @@ if init_once "$shadowed" --layout=mono --registries=yes >"$TMP_ROOT/shadowed.out
 fi
 [ "$(git -C "$shadowed" rev-parse HEAD)" = "$shadowed_commit" ] \
   || { echo "FAIL: init.sh destroyed history in the shadowed-AGENTS.md case" >&2; exit 1; }
+
+# --- 6b. The template staged but not yet committed still initializes. -------------------------
+# Signal 3 below reads the index, so it has to tell "their work is staged" from "the template is
+# staged". Someone who runs `git init` and `git add -A` before initializing is in the second case
+# and must not be refused. Without this, signal 3 could be written as "anything staged" and would
+# break a flow a step short of case 5.
+staged_template="$TMP_ROOT/staged-template"
+copy_template "$staged_template"
+( cd "$staged_template" && git init -q && git add -A )
+init_once "$staged_template" --layout=multi --registries=yes >"$TMP_ROOT/staged-template.out" 2>&1 \
+  || { echo "FAIL: guard blocked a template staged but not yet committed" >&2; cat "$TMP_ROOT/staged-template.out" >&2; exit 1; }
+[ -d "$staged_template/Code/acme-docs" ] || { echo "FAIL: staged-template flow did not initialize" >&2; exit 1; }
+
+# --- 7. An orphan branch over a live repo is refused. -----------------------------------------
+# The hole the HEAD-only guard left. `git checkout --orphan` leaves HEAD unborn while every commit
+# stays on the branch it was made on, so "does HEAD resolve" answers no and the repository reads as
+# empty — and step 3 then deletes .git and all of it. Nothing about this case is visible through
+# HEAD; it is visible through refs, which is why the guard asks more than one question.
+orphaned="$TMP_ROOT/orphaned"
+mkdir -p "$orphaned"
+( cd "$orphaned" && git init -q && printf 'years of work\n' > src.txt && git add -A \
+    && git -c user.name=t -c user.email=t@e commit -qm "existing codebase" )
+orphaned_commit="$(git -C "$orphaned" rev-parse HEAD)"
+( cd "$orphaned" && git checkout -q --orphan throughstone && git rm -rq --cached . && rm -f src.txt )
+git -C "$orphaned" rev-parse --verify HEAD >/dev/null 2>&1 \
+  && { echo "FAIL: test setup wrong — HEAD still resolves, so this is not the orphan case" >&2; exit 1; }
+copy_template "$orphaned"
+if init_once "$orphaned" --layout=mono --registries=yes >"$TMP_ROOT/orphaned.out" 2>&1; then
+  echo "FAIL: init.sh ran on an orphan branch inside a repo that still holds commits" >&2
+  cat "$TMP_ROOT/orphaned.out" >&2
+  exit 1
+fi
+[ -d "$orphaned/.git" ] || { echo "FAIL: init.sh deleted .git in the orphan-branch case" >&2; exit 1; }
+[ "$(git -C "$orphaned" rev-list --all --count)" = "1" ] \
+  || { echo "FAIL: init.sh destroyed commits in the orphan-branch case" >&2; exit 1; }
+# Branch-name agnostic: init.defaultBranch varies by host, so assert that some ref still points at
+# the original commit rather than naming main or master.
+git -C "$orphaned" for-each-ref --format='%(objectname)' | grep -qFx "$orphaned_commit" \
+  || { echo "FAIL: the orphan-branch case lost the branch holding its history" >&2; exit 1; }
+
+# --- 8. Work that exists only in the index is refused. ----------------------------------------
+# A repo whose owner ran `git init` and `git add` but has not committed yet has no HEAD and no refs,
+# so signals 1 and 2 both say nothing. The work is real and unrecoverable once .git goes.
+staged_only="$TMP_ROOT/staged-only"
+mkdir -p "$staged_only"
+( cd "$staged_only" && git init -q && printf 'not committed yet\n' > src.txt && git add -A )
+copy_template "$staged_only"
+if init_once "$staged_only" --layout=mono --registries=yes >"$TMP_ROOT/staged-only.out" 2>&1; then
+  echo "FAIL: init.sh ran on top of staged, uncommitted work" >&2
+  cat "$TMP_ROOT/staged-only.out" >&2
+  exit 1
+fi
+[ -d "$staged_only/.git" ] || { echo "FAIL: init.sh deleted .git in the staged-only case" >&2; exit 1; }
+git -C "$staged_only" ls-files --error-unmatch src.txt >/dev/null 2>&1 \
+  || { echo "FAIL: init.sh dropped staged work before refusing" >&2; exit 1; }
+grep -Fxq "not committed yet" "$staged_only/src.txt" \
+  || { echo "FAIL: init.sh disturbed the staged file's content" >&2; exit 1; }
+
+# --- 9. Every refusal names which check fired. -------------------------------------------------
+# Three signals with one message is a support problem: the user cannot tell whether they hit a
+# stale branch, a stray index, or the wrong folder entirely.
+for out in extracted orphaned staged-only; do
+  grep -Fq "Refusing because" "$TMP_ROOT/$out.out" \
+    || { echo "FAIL: the $out refusal did not say which check fired" >&2; cat "$TMP_ROOT/$out.out" >&2; exit 1; }
+done
 
 echo "init.sh fresh-template guard: PASS"


### PR DESCRIPTION
## The hole

The bootstrap guard decides whether this folder already holds someone's work by asking
git one question: **what does `HEAD` point at?** If git answers, there is history to
protect. If not, the folder has nothing to lose and `init.sh` proceeds — and step 3
removes `.git`.

A repository keeps work in more than one place, and `HEAD` does not see all of it.
`git checkout --orphan` leaves `HEAD` unborn while every commit stays on the branch it
was made on. So git answers "nothing", the guard reads a **live** repository as empty,
and `.git` goes — along with every branch it was holding.

Measured rather than reasoned about: a repo with a committed file, an orphan branch
checked out, the template extracted on top. `exit 0`. `.git` gone. The commit
unrecoverable without a remote.

The same blind spot covers a second case: someone who ran `git init` and `git add` but
has not committed yet has no `HEAD` **and** no refs. The work is real and it is only in
the index.

## The fix

Three independent questions, refusing if **any** says yes. None has to be certain alone:

| | Signal | Catches |
|---|---|---|
| 1 | `HEAD` resolves and its `AGENTS.md` lacks the sentinel | committed history that isn't the template's |
| 2 | `HEAD` unborn, but the repo already holds refs | orphan branch over a live repo |
| 3 | Nothing committed, but files are staged and the staged `AGENTS.md` isn't the template's | work only in the index |

Each reads a different store, and each reads the **repository** rather than the working
files, which the extraction just overwrote. Every refusal now names which check fired —
three signals behind one message leave a user unable to tell a stale branch from a stray
index from the wrong folder.

## Not over-firing

A guard that over-fires is its own outage, and the first version of this guard was
rewritten once for exactly that. Every question that can refuse has a matching case that
must proceed:

- committed template → signal 1 clears it;
- **mono-repo empty-origin reuse** (`git init` + a remote, nothing committed) → no `HEAD`,
  no refs, empty index;
- **template staged but not yet committed** → new case, and the one signal 3 could have
  broken. This pair is the whole difficulty: two repositories with no `HEAD`, one holding
  work and one holding nothing.

## Verification

- `tests/init-fresh-template-guard.sh` now covers **three refusals and three
  proceed-cases**, asserting after every refusal that `.git`, its commits, and its staged
  content are untouched. The orphan case asserts the setup really is unborn-HEAD first, so
  it can't silently degrade into a duplicate of an existing case.
- Each signal, and the reason line, **verified to bite individually** by mutating one at a
  time — dropping signal 2 fails only the orphan case, signal 3 only the staged case,
  signal 1 only the extracted case.
- **Full suite 13/13** at the shipping commit, including `init-mono-origin-reuse.sh` and
  `init-trunk-branch.sh` — the two flows an earlier attempt at this guard broke while
  passing its own new assertions.
- Fixtures from `git archive` of the shipping commit (greenfield multi, mono
  `--registries=no`, proprietary) all `check.sh` 0/0 and `links.sh` clean.
- A project generated from this commit is **byte-identical** to one generated at `main`'s
  tip. The guard runs before any user choice and changes nothing a project ever sees.

Independent of the other open PRs; changelog text extends the existing guard entry rather
than adding a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
