### PR TITLE
Ask when the created-vs-registered-in-place rules don't settle a case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ any project built with it.
   reading a session file now finds the work list under one name instead of learning a per-file name.
   `METHOD.md` §4 records the skeleton as part of the contract for adding a session, and a new
   maintainer test enforces it.
+- **Where the create-vs-registered-in-place rules don't settle a case, the answer is now to ask
+  rather than to improvise.** Everything the method does to a repo — stamp or augment its README,
+  install CI or leave its pipeline alone, apply the project license or record what it already
+  says, place the Throughstone notice or owe nothing — splits on whether the method created that
+  repo. Those rules enumerate the cases the method has met, and a real project produces ones they
+  don't reach: a repo the method created that another team has since taken over, a README that is
+  half boilerplate, a repo whose own files disagree about its license, a notice
+  `--notice-only` refuses to place after the README text has already landed. `METHOD.md` §7 and
+  the repo README template now close with the same fallback — where it is genuinely unclear which
+  side of that line a repo sits on, or what a rule means for it, **ask, and write nothing into
+  that repo until there is an answer**. Not writing is recoverable; writing into a repo the method
+  did not create is the failure those rules exist to prevent. It is stated as a fallback for cases
+  the rules don't reach, explicitly not as a substitute for following them where they do or for
+  fixing a gap once one is found. No effect on a repo the method creates, which is settled and
+  unchanged.
 
 ### Fixed
 - **`init.sh` would destroy an existing repository it was run inside, and had no guard at all.**

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -525,6 +525,19 @@ deliberately by them — never a side effect of adding the method to it. So
 `scripts/apply-project-license.sh` is run **only on a repo the method creates**; it refuses a
 target that already states its own licensing.
 
+**When the rules above don't settle it, ask.** They cover the cases the method has met: a repo it
+creates, and one registered in place that has a README, has none, or whose owners decline the
+addition. A real project produces ones they don't obviously reach — a repo the method created that
+another team has since taken over, a README that is half boilerplate, a repo whose own files
+disagree about its license, a notice `scripts/apply-project-license.sh --notice-only` refuses to
+place after the README text has already landed. Where it is genuinely unclear which side of the
+created / registered-in-place line a repo sits on, or what a rule above means for it, **stop and
+ask, and write nothing into that repo until you have an answer**. Not writing is recoverable;
+writing into a repo the method did not create is the failure this section exists to prevent, and
+the question costs one message. This is a fallback for a case the rules don't reach — not an
+alternative to reading them where they do settle it, and not a reason to leave a gap in them
+unfixed once one is found.
+
 **Where a repo lives — created as a sibling, or registered in place.** By default a repo is
 **created as a `Code/*` sibling** under the workspace root, and its `registries/repos.yml`
 `location:` is that workspace-relative sibling path — the layout `init.sh` and the scaffolding

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -67,6 +67,13 @@
   allowed here when the plain invocation above is not. If the addition was declined, nothing
   Throughstone-authored is in the repo and nothing is owed: a notice pointing at absent material
   only misleads a later reader.
+
+  EVERYTHING ABOVE SPLITS ON ONE QUESTION: did this method create this repo, or did the repo get
+  here first? Where that is genuinely unclear, or where the answer doesn't settle what to do with
+  this repo's README, CI, license, or notice, ASK THE USER AND WRITE NOTHING UNTIL THEY ANSWER
+  (`METHOD.md` §7). The question costs one message; the wrong write lands in a repo this method
+  does not own. That is a fallback for a case these rules don't reach, not a substitute for
+  following them where they do.
 -->
 
 ## Overview

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -131,6 +131,23 @@ run_case() {
   assert_absent "$repos" "as the architecture names them and they" \
     "repo inventory comment still says every repo listed here is stamped"
 
+  # --- The fallback. Every rule above enumerates cases, and three rounds of review each turned up
+  # one nobody had enumerated. What an agent does with the next such case is the thing worth
+  # pinning: ask, and write nothing meanwhile. It has to ship in the file being read at the moment
+  # of the write, not only in the file that defines it.
+  assert_contains "$docs/METHOD.md" "**When the rules above don't settle it, ask.**" \
+    "METHOD.md §7 has no fallback for a case the create-vs-in-place rules do not reach"
+  assert_contains "$docs/METHOD.md" \
+    "ask, and write nothing into that repo until you have an answer" \
+    "METHOD.md §7's fallback does not say to hold off writing while asking"
+  assert_contains "$readme_tpl" \
+    "ASK THE USER AND WRITE NOTHING UNTIL THEY ANSWER" \
+    "repo README template does not carry the ask-when-unclear fallback"
+  # The fallback must not read as permission to stop maintaining the rules themselves — that is how
+  # a catch-all turns into a reason to leave the next gap unfixed.
+  assert_contains "$docs/METHOD.md" "not a reason to leave a gap in them" \
+    "METHOD.md §7's fallback does not rule itself out as a substitute for fixing the rules"
+
   # Nothing above may pass on an unsubstituted template.
   ! grep -R '{{PROJECT}}' "$readme_tpl" "$ci_workflow" "$ci_readme" "$repos" >/dev/null || {
     echo "FAIL: generated files still carry the {{PROJECT}} placeholder" >&2


### PR DESCRIPTION
## Why

Everything the method does to a repo splits on one question: **did it create this repo, or
did the repo get here first?** Stamp its README or augment it. Install CI or leave its
pipeline alone. Apply the project license or record what the repo already says. Place the
Throughstone notice or owe nothing.

Those rules enumerate the cases the method has met. A real project produces ones they don't
reach:

- a repo the method created that another team has since taken over;
- a README that is half boilerplate;
- a repo whose own files disagree about its license;
- a notice `--notice-only` refuses to place **after** the README text has already landed —
  a real, currently unhandled case: the helper exits non-zero and no shipped instruction
  says what to do next.

Today an agent meeting one of those improvises, and the direction it can improvise in is
writing into a repo this method does not own.

## What changes

`METHOD.md` §7 and `templates/repo-readme-template.md` now close with the same fallback:
where it is genuinely unclear which side of that line a repo sits on, or what a rule means
for it, **ask, and write nothing into that repo until there is an answer.** Not writing is
recoverable; the wrong write is the failure those rules exist to prevent, and the question
costs one message.

**Two places on purpose.** §7 defines it; the template carries it because that is the file
open at the moment of the write. Every review round so far has found defects in files that
*read* a rule rather than state it, so a rule that only lives in the definition is a rule
that gets missed.

**Two things the wording rules out, deliberately.** It is not an alternative to reading the
rules where they do settle a case — the enumerated paths stay the answer. And it is not a
reason to leave a gap unfixed once one is found, which is how a catch-all quietly becomes
the reason nobody fixes the next one. That second clause is pinned by its own assertion, so
it can't be trimmed away later without the suite noticing.

**Scoped to the created-vs-in-place question**, not to READMEs and licensing generally.
Creating repos in greenfield is settled and high-volume; nothing on that path reaches the
fallback, so it does not turn into a question per repo.

## Verification

- Four assertions in `tests/init-inplace-repo-rules.sh` against the **substituted** form in a
  **generated** project — the heading, the write-nothing-meanwhile clause, the template's
  copy, and the anti-catch-all clause. Each **verified to bite individually** by mutating one
  needle at a time.
- Full suite **13/13** at the shipping commit.
- Fixtures from `git archive` of the shipping commit (greenfield multi, mono
  `--registries=no`, proprietary) all `check.sh` 0/0 and `links.sh` clean.
- A generated project differs from one built at `main`'s tip in exactly the two intended
  files, `METHOD.md` and `templates/repo-readme-template.md`, and neither carries a leftover
  placeholder.
- Changelog entry filed under **Changed**, which keeps it clear of the `Fixed` lines the
  other open PRs touch.

Independent of #139, #140 and #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
