### PR TITLE
Look for a repo's licensing where the method says licensing lives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,25 @@ any project built with it.
   a template staged but not yet committed, and the mono-repo empty-origin reuse flow (`git init`
   plus a remote, nothing committed yet) all initialize exactly as before, and each refusal now says
   which check fired.
+- **The licensing backstop only looked at root filenames, so it missed most of the places the
+  method itself says licensing lives.** `scripts/apply-project-license.sh` refuses a target that
+  already states its own terms — the guard against handing a repo the method did not create a
+  project `LICENSE` and a `LICENSING.md` asserting it over the whole repository. It checked root
+  filenames (`COPYING`, `NOTICE`, `LICENSE.md`, …) and nothing else, while `METHOD.md` §7, the
+  repo README template, and the recon map template all tell an agent that licensing also lives in
+  **package metadata** and **vendored third-party terms**. So a GPL-3.0 npm package, an AGPL Rust
+  crate, an Apache `pyproject.toml`, a monorepo licensing per package, and a vendored source tree
+  all sailed past it: measured, each took the project's `LICENSE` plus a `LICENSING.md` naming the
+  wrong license over someone else's code. The check now reads all three places — root filenames,
+  the same names in nested trees, and a populated `license` field in root package metadata
+  (`package.json` including the legacy array form, `pyproject.toml`, `setup.cfg`, `Cargo.toml`,
+  `composer.json`, `*.gemspec`, `build.gradle`, `pom.xml`). Installed dependency trees
+  (`node_modules/`, `.venv/`, `site-packages/`, `target/`, `vendor/bundle`) are skipped: those
+  carry somebody else's licenses and say nothing about this repo, and a repo the method **did**
+  create may well have them by the time the helper runs. It answers only "does this repo say
+  anything about its licensing", never "which license", and it stays a backstop rather than the
+  control — a repo that states nothing is indistinguishable from one just created, so the rule
+  that the helper runs only on a repo the method creates is still what governs.
 - **Declining `registries/` left the docs hub with a broken link on its first run.** A mono-repo
   project can answer no to the repo inventory, and `init.sh` removed the directory — but the docs
   hub `README.md` indexes every directory it ships, and its `registries/` row stayed. So the

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -15,7 +15,12 @@
 # licensing status, and setting a license for it is that owner's act, not the method's: read what
 # it already uses and record it, never apply. The pre-existing-licensing check below refuses such
 # a target, so pointing this helper at the wrong kind of repo fails loudly instead of writing a
-# license claim over code the method did not author.
+# license claim over code the method did not author. It looks wherever METHOD.md §7 says licensing
+# lives — root files, nested trees, package metadata — but it can only catch a repo that SAYS
+# something. METHOD.md §7 counts "a deliberate absence" as a licensing status too, and a repo that
+# states nothing is indistinguishable from one just created. So this is a backstop against a
+# misdirected invocation, not the control: the rule that this is run only on a repo the method
+# creates is the control, and where that is unclear the answer is to ask (METHOD.md §7).
 #
 # --notice-only serves the one thing such a repo may still be owed. Where the method leaves
 # Throughstone-authored material behind — a role-and-place section added to an existing README, or
@@ -63,23 +68,74 @@ if [ ! -d "$TARGET" ]; then
   exit 2
 fi
 
-# find_pre_existing_licensing TARGET — list root-level licensing files this helper never writes.
-# Reads: TARGET's root directory entries.
+# find_pre_existing_licensing TARGET — list evidence that TARGET already states its own licensing.
+# Reads: TARGET's root entries, its nested trees, and its root package metadata.
 # Writes: nothing (prints one path per line).
-# Returns: 0 always; empty output means the target carries no such file.
+# Returns: 0 always; empty output means the target says nothing about its licensing.
 #
-# A repo the method creates carries none of these, so this is inert on the path the helper is
-# for. A repo that predates the method may carry any of them — COPYING for a GPL project, NOTICE
-# for a project with attribution obligations, LICENSE.md/LICENSE-<id> for the many projects that
-# name the file differently. Plain LICENSE is deliberately not listed: verify_compatible already
-# rejects a differing one, and an identical one is this helper's own idempotent re-run.
+# A repo the method creates carries none of this, so it is inert on the path the helper is for. A
+# repo that predates the method may carry any of it, and it looks in three places because that is
+# where METHOD.md §7, the repo README template, and the recon map template all tell an agent to
+# read: "a LICENSE, a COPYING, a NOTICE, package metadata, vendored third-party terms".
+#
+#   1. Root filenames — COPYING for a GPL project, NOTICE for attribution obligations,
+#      LICENSE.md / LICENSE-<id> for the many projects that name the file differently.
+#   2. The same names further down — a monorepo licenses per package (packages/*/LICENSE), and a
+#      vendored tree carries the terms it arrived under. Depth-limited and pruned of the
+#      directories that hold installed dependencies rather than the repo's own code.
+#   3. A license field in root package metadata. Plenty of repos state their license only there.
+#
+# Plain root LICENSE is deliberately still not listed: verify_compatible already rejects a
+# differing one, and an identical one is this helper's own idempotent re-run.
+#
+# It answers "does this repo say anything about its licensing", never "which license" — a backstop
+# for an invocation the prose already forbids, not a detector. Anything it reports is a refusal,
+# so it errs toward refusing: being wrong here costs a question, and being wrong the other way
+# writes a license claim over code the method did not author.
 find_pre_existing_licensing() {
-  find "$1" -mindepth 1 -maxdepth 1 \
-    \( -iname 'COPYING*' -o -iname 'COPYRIGHT*' -o -iname 'NOTICE*' \
-       -o -iname 'LICENCE*' -o -iname 'LICENSE.*' -o -iname 'LICENSE-*' \
-       -o -iname 'LICENSES' \) \
-    ! -name 'LICENSE-THROUGHSTONE' \
-    -print 2>/dev/null | LC_ALL=C sort
+  local target="$1"
+  {
+    find "$target" -mindepth 1 -maxdepth 1 \
+      \( -iname 'COPYING*' -o -iname 'COPYRIGHT*' -o -iname 'NOTICE*' \
+         -o -iname 'LICENCE*' -o -iname 'LICENSE.*' -o -iname 'LICENSE-*' \
+         -o -iname 'LICENSES' \) \
+      ! -name 'LICENSE-THROUGHSTONE' \
+      -print 2>/dev/null
+
+    # Nested licensing. -prune drops installed dependency trees — those are somebody else's copies
+    # rather than a statement about this repo, and a repo the method DID create can be carrying
+    # them by the time this runs. It keeps deliberately vendored source trees, which are exactly
+    # the "vendored third-party terms" METHOD.md §7 names. The prune must be able to see a
+    # directory to skip it, so this find starts at the root and the root's own files are dropped
+    # afterwards (they belong to the first find, which deliberately ignores a plain LICENSE).
+    find "$target" -maxdepth 4 \
+      \( -name '.git' -o -name 'node_modules' -o -name '.venv' -o -name 'venv' \
+         -o -name 'site-packages' -o -name 'target' -o -path '*/vendor/bundle' \) -prune \
+      -o \( -iname 'COPYING' -o -iname 'COPYING.*' -o -iname 'LICENSE' -o -iname 'LICENCE' \
+            -o -iname 'LICENSE.*' -o -iname 'LICENCE.*' \) \
+         ! -name 'LICENSE-THROUGHSTONE' -print 2>/dev/null \
+      | while IFS= read -r found; do
+          [ "$(dirname "$found")" = "$target" ] || printf '%s\n' "$found"
+        done
+
+    # A license field in root package metadata. Matched loosely on purpose: any of these files
+    # carrying a populated license key is a repo saying something about its terms.
+    local manifest
+    for manifest in "$target"/package.json "$target"/pyproject.toml "$target"/setup.cfg \
+                    "$target"/Cargo.toml "$target"/composer.json "$target"/*.gemspec \
+                    "$target"/build.gradle "$target"/pom.xml; do
+      [ -f "$manifest" ] || continue
+      # Two shapes: a key/value pair (JSON quotes the key, so allow a quote before the separator;
+      # TOML and Gradle use `=`; npm's legacy form is a `licenses` array), and an XML <license>
+      # element for pom.xml. A populated value is required, so an empty license field reads as
+      # saying nothing.
+      if grep -Eiq \
+        '(^|[^A-Za-z_-])licen[cs]es?["'"'"']?[[:space:]]*[:=][^[:alnum:]]*[[:alnum:]]|<licen[cs]es?[[:space:]>]' \
+           "$manifest" 2>/dev/null; then
+        printf '%s\n' "$manifest"
+      fi
+    done
+  } | LC_ALL=C sort -u
 }
 
 # verify_compatible SOURCE TARGET LABEL — reject an existing target with different content.

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -479,6 +479,117 @@ run_pre_existing_licensing_case() {
   assert_maintainer_tests_removed "$name" "$work"
 }
 
+# run_licensing_evidence_case — the guard above tests root filenames, which is where the method's
+# OWN prose says licensing is only partly kept. METHOD.md §7, the repo README template, and the
+# recon map template all tell an agent to read "a LICENSE, a COPYING, a NOTICE, package metadata,
+# vendored third-party terms". A guard that reads only root filenames misses two of those, and the
+# repos it misses are ordinary: a JavaScript or Rust package whose license lives in its manifest,
+# and a monorepo that licenses per package. Each of those would take the project's LICENSE and a
+# LICENSING.md asserting it over the whole repository.
+#
+# Both directions matter. A guard that refuses everything would break the path the helper exists
+# for — a repo the method just created, which may already be carrying installed dependencies with
+# licenses of their own — so the must-proceed table is as load-bearing as the must-refuse one.
+run_licensing_evidence_case() {
+  local name="license-evidence"
+  local work="$TMP_ROOT/$name"
+  local helper target status written label rel body
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Licensing evidence test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+  helper="$work/Code/$name-docs/scripts/apply-project-license.sh"
+
+  # build_target LABEL RELPATH BODY — a bare repo stating its terms exactly one way.
+  build_target() {
+    target="$TMP_ROOT/$name-target"
+    rm -rf "$target"
+    mkdir -p "$target/$(dirname "$2")"
+    printf '%s\n' "$3" > "$target/$2"
+  }
+
+  # Each of these is a repo saying something about its licensing. None has a root licensing
+  # FILENAME, so every one of them passed the original guard.
+  while IFS='|' read -r label rel body; do
+    [ -n "$label" ] || continue
+    build_target "$label" "$rel" "$body"
+    set +e
+    "$helper" "$target" >"$TMP_ROOT/$name-$label.out" 2>&1
+    status=$?
+    set -e
+    [ "$status" -eq 1 ] || {
+      echo "FAIL: helper did not refuse a repo stating its license via $label" >&2
+      return 1
+    }
+    grep -Fq "target already states its own licensing" "$TMP_ROOT/$name-$label.out" || {
+      echo "FAIL: refusal for $label did not name the rule" >&2
+      return 1
+    }
+    grep -Fq "$(basename "$rel")" "$TMP_ROOT/$name-$label.out" || {
+      echo "FAIL: refusal for $label did not name the evidence it found" >&2
+      return 1
+    }
+    for written in LICENSE LICENSE-THROUGHSTONE LICENSING.md; do
+      [ ! -e "$target/$written" ] || {
+        echo "FAIL: helper wrote $written into a repo stating its license via $label" >&2
+        return 1
+      }
+    done
+  done <<'EVIDENCE'
+npm-manifest|package.json|{"name":"svc","license":"GPL-3.0"}
+npm-legacy-array|package.json|{"name":"svc","licenses":[{"type":"MIT"}]}
+composer-manifest|composer.json|{"name":"acme/svc","license":"LGPL-2.1"}
+cargo-manifest|Cargo.toml|license = "AGPL-3.0"
+pyproject-manifest|pyproject.toml|license = "Apache-2.0"
+setupcfg-manifest|setup.cfg|license = MPL-2.0
+gemspec-manifest|svc.gemspec|Gem::Specification.new { |s| s.license = "MPL-2.0" }
+gradle-manifest|build.gradle|license = 'EPL-2.0'
+maven-manifest|pom.xml|<project><licenses><license><name>Apache-2.0</name></license></licenses></project>
+monorepo-package|packages/api/LICENSE|GNU General Public License v3
+vendored-tree|third_party/zlib/LICENSE|zlib License
+EVIDENCE
+
+  # The other direction. A repo the method creates says nothing about its licensing, and must
+  # still be served — including one that already has dependencies installed, whose licenses belong
+  # to somebody else and say nothing about this repo. A guard that refuses these is an outage on
+  # the only path this helper is for.
+  while IFS='|' read -r label rel body; do
+    [ -n "$label" ] || continue
+    build_target "$label" "$rel" "$body"
+    set +e
+    "$helper" "$target" >"$TMP_ROOT/$name-$label.out" 2>&1
+    status=$?
+    set -e
+    [ "$status" -eq 0 ] || {
+      echo "FAIL: helper refused a repo that states no licensing of its own ($label)" >&2
+      cat "$TMP_ROOT/$name-$label.out" >&2
+      return 1
+    }
+    [ -f "$target/LICENSE" ] || {
+      echo "FAIL: helper did not apply the project license for $label" >&2
+      return 1
+    }
+  done <<'NOEVIDENCE'
+manifest-without-license|package.json|{"name":"svc","version":"1.0.0"}
+manifest-empty-license|package.json|{"name":"svc","license":""}
+manifest-license-file-key|package.json|{"name":"svc","licenseFile":"docs/terms.txt"}
+installed-dependency|node_modules/left-pad/LICENSE|MIT License
+plain-source-file|src/main.js|export const x = 1;
+NOEVIDENCE
+
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
 # run_notice_only_case — the one thing a repo the method did not create may still be owed. Where
 # the method leaves Throughstone-authored material behind, --notice-only places the notice and a
 # companion that disclaims the rest of the repository. It must work on exactly the target the full
@@ -763,6 +874,8 @@ run_missing_canonical_license_case
 # A repo registered in place keeps the licensing its owner set; the helper must refuse it rather
 # than write a license claim over code the method did not author.
 run_pre_existing_licensing_case
+# ...including the two places a repo states its terms that are not a root filename at all.
+run_licensing_evidence_case
 # ...and the one thing such a repo may still be owed, when the method leaves material behind.
 run_notice_only_case
 


### PR DESCRIPTION
## The gap

`scripts/apply-project-license.sh` refuses a target that already states its own terms. That
refusal is the backstop against the destructive case — handing a repo the method did not
create a project `LICENSE` plus a `LICENSING.md` asserting it over the whole repository.

It looked at **root filenames only**: `COPYING*`, `NOTICE*`, `LICENSE.*`, `LICENSE-*`,
`LICENCE*`, `LICENSES`. But three shipped files define the method's own notion of licensing
more broadly than that:

- `METHOD.md` §7 — "a `LICENSE`, a `COPYING`, a `NOTICE`, **vendored third-party terms**, or a
  deliberate absence"
- the repo README template — "read what the repo uses (`LICENSE`, `COPYING`, `NOTICE`,
  **package metadata**, vendored third-party terms…)"
- the recon map template — "plus the `license` field in its **package metadata**
  (`package.json`, `pyproject.toml`, `Cargo.toml`, `*.gemspec`, …), and note vendored
  third-party trees"

Two of the five places an agent is told to read were places the guard never looked. Neither is
exotic — a JavaScript, Rust or Python package states its license in its manifest, and a
monorepo states it per package.

## Measured, not reasoned about

Run against real repo shapes, every one **proceeded** and took an MIT `LICENSE`:

| repo states its license in | before | after |
|---|---|---|
| `package.json` `"license": "GPL-3.0"` | proceeded | refused |
| `Cargo.toml` `license = "AGPL-3.0"` | proceeded | refused |
| `pyproject.toml` `license = "Apache-2.0"` | proceeded | refused |
| `*.gemspec` `s.license = "MPL-2.0"` | proceeded | refused |
| `packages/api/LICENSE` (monorepo) | proceeded | refused |
| `third_party/zlib/LICENSE` (vendored) | proceeded | refused |

The GPL-3.0 npm package ended up with `LICENSING.md` reading *"Project-authored content in
this repository is licensed under MIT."*

## The fix

The check now reads all three places: root filenames, the same names in nested trees, and a
populated `license` field in root package metadata — `package.json` (including npm's legacy
`licenses` array), `pyproject.toml`, `setup.cfg`, `Cargo.toml`, `composer.json`, `*.gemspec`,
`build.gradle`, and `pom.xml`'s `<licenses>` element.

**The other direction is load-bearing.** This helper exists for repos the method *creates*, and
one of those may already have dependencies installed — whose licenses belong to somebody else
and say nothing about this repo. Installed trees are skipped (`node_modules`, `.venv`, `venv`,
`site-packages`, `target`, `vendor/bundle`); deliberately vendored *source* is not, because
that is the case `METHOD.md` §7 names.

It answers only "does this repo say anything about its licensing", never "which license" — a
backstop, not a detector. Everything it finds is a refusal, so it errs toward refusing: wrong
in that direction costs a question, wrong in the other writes a license claim over code the
method did not author.

The header now also states what it *cannot* do. A repo that states nothing is indistinguishable
from one just created, so the rule that this runs only on a repo the method creates remains the
control, and where that is unclear the answer is to ask.

## Verification

- `tests/init-license-validation.sh` gains two tables: **11 shapes that must be refused**
  (each asserting the refusal names the evidence and that nothing was written) and **5 that
  must still be served** (manifest with no license key, empty license value, a `licenseFile`
  key, an installed dependency tree, plain source).
- **Three independent bite checks**, each failing a different assertion: reverting the whole
  function fails `npm-manifest`; dropping only the nested search fails `monorepo-package`;
  dropping only the skip list fails `installed-dependency`.
- Full suite **13/13** at the shipping commit.
- Fixtures built from `git archive` of the shipping commit under **Apache-2.0, BSD-3-Clause and
  proprietary** postures — deliberately not MIT — all `check.sh` 0/0 and `links.sh` clean.
- A generated project differs from one built at `main`'s tip in exactly one file, the helper.
- End-to-end against the helper as it ships in the Apache project: all six shapes refused, the
  three false-positive shapes served, and `--notice-only` still succeeds on every one of them
  without writing a project `LICENSE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
