### PR TITLE
Default the project-type question to private, not open source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ any project built with it.
   fixing a gap once one is found. No effect on a repo the method creates, which is settled and
   unchanged.
 
+- **The interactive project-type question now defaults to private / proprietary.** It defaulted to
+  open source, so pressing Enter past it — and Enter again at the license menu, which pre-selects
+  the first entry — stood a project up under MIT without the user ever naming a license. That is
+  the wrong direction for a default to fail in: publishing code under a license nobody chose is not
+  undone by editing a file afterwards, while a project that starts proprietary can be opened by its
+  owner whenever they decide to. An open-source posture is now reached only by typing `1`, which
+  matches what `--non-interactive` already required (an explicit `--license`, no default) and the
+  private default already used for repository visibility. Nothing else changes: both answers behave
+  exactly as before once given, `--license` is unaffected, and no generated project is rewritten.
+
 ### Fixed
 - **`init.sh` would destroy an existing repository it was run inside, and had no guard at all.**
   Extract the download into your own repo and run it there — a natural thing to do, and more so

--- a/init.sh
+++ b/init.sh
@@ -67,14 +67,21 @@ validate_trunk_branch() {
 # Proprietary is a project-license posture, not a GitHub visibility setting. Open-source
 # projects choose a concrete permissive license template; proprietary projects intentionally
 # skip project LICENSE creation later.
+#
+# The default is PRIVATE / PROPRIETARY, and it is the conservative answer rather than the common
+# one. Pressing Enter past this question must not grant the world a license to the user's code:
+# publishing is a deliberate act with consequences that are hard to take back, while a project
+# that starts proprietary can be opened later by its owner at any time. So an open-source posture
+# is only ever reached by typing 1 — the same reason --non-interactive refuses to run without an
+# explicit --license, and the same direction as the private default for repository visibility.
 choose_license_interactively() {
   local project_type license_input
 
   while :; do
     echo "Is this project open source or private/proprietary?"
     echo "  1) Open source"
-    echo "  2) Private / proprietary"
-    project_type="$(ask 'Choose 1 or 2' '1')"
+    echo "  2) Private / proprietary   (default)"
+    project_type="$(ask 'Choose 1 or 2' '2')"
     case "$project_type" in
       1) break ;;
       2)

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -720,6 +720,46 @@ run_private_case \
   bash -c \
   "printf '2\n' | ./init.sh --slug=license-private --desc='License validation test' --layout=multi --collab=solo --remotes=no"
 
+# Pressing Enter past the project-type question must land on proprietary, never on an
+# open-source posture. Publishing someone's code under a license they never chose is not
+# recoverable by editing a file afterwards, while a project that starts proprietary can be
+# opened by its owner whenever they decide to. That makes the DEFAULT itself the thing under
+# test, so this case asserts it directly and says what broke — the shared helper's bare
+# assertions would fail this silently, which is no use to whoever reverts the default by
+# accident later.
+private_default_work="$TMP_ROOT/license-private-default"
+copy_template "$private_default_work"
+(
+  cd "$private_default_work"
+  printf '\n' | ./init.sh \
+    --slug=license-private-default \
+    --desc="License validation test" \
+    --layout=multi --collab=solo --remotes=no
+) >"$TMP_ROOT/license-private-default.out" 2>&1 || {
+  echo "FAIL: accepting the default project type did not complete a bootstrap" >&2
+  tail -5 "$TMP_ROOT/license-private-default.out" >&2
+  exit 1
+}
+private_default_posture="$private_default_work/Code/license-private-default-docs/.throughstone/project-license"
+[ -f "$private_default_posture" ] || {
+  echo "FAIL: accepting the default project type wrote no license posture at all" >&2
+  exit 1
+}
+[ "$(cat "$private_default_posture")" = "Proprietary" ] || {
+  echo "FAIL: pressing Enter at the project-type question chose '$(cat "$private_default_posture")'," >&2
+  echo "      not Proprietary — the default must never grant an open-source license" >&2
+  exit 1
+}
+for unexpected in \
+  "$private_default_work/Code/license-private-default-docs/LICENSE" \
+  "$private_default_work/prompts/LICENSE"; do
+  [ ! -e "$unexpected" ] || {
+    echo "FAIL: the default project type created a project LICENSE at $unexpected" >&2
+    exit 1
+  }
+done
+assert_maintainer_tests_removed "license-private-default" "$private_default_work"
+
 run_private_case \
   "license-private-flag" \
   ./init.sh \


### PR DESCRIPTION
## The problem

The interactive bootstrap asks "open source or private/proprietary?" and pre-selected
**open source**. The license menu behind it pre-selects its first entry, MIT. So two presses
of Enter stood a project up under MIT without the user ever naming a license.

That is the wrong direction for a default to fail in. Publishing code under a license nobody
chose is not undone by editing a file afterwards; a project that starts proprietary can be
opened by its owner whenever they decide to.

## The change

The project-type question now defaults to `2) Private / proprietary`, labelled as the default
in the menu. An open-source posture is reached only by typing `1`.

This is the direction the rest of the installer already took: `--non-interactive` refuses to
run without an explicit `--license` and has no default, and repository visibility already
defaults to private.

Numbering is unchanged — `1` is still open source, `2` still proprietary — so any existing
script or muscle memory that pipes `2` keeps working.

## What does not change

Both answers behave exactly as before once given. `--license` and `INIT_LICENSE` are untouched.
No generated project is rewritten. Verified against the shipping commit:

| interactive input | posture | project `LICENSE` |
|---|---|---|
| *(Enter)* | Proprietary | no |
| `2` | Proprietary | no |
| `1`, `1` | MIT | yes |
| `1`, `3` | Apache-2.0 | yes |

`--non-interactive` without `--license` still exits 2. A project generated with an explicit
`--license` is **byte-identical** to one generated at `main`'s tip.

## Verification

- New regression case asserts the posture directly and **names what broke**, rather than using
  the shared private-case helper — that helper's bare `[ ]` assertions under `set -e` fail
  silently, which is no use to whoever reverts this default by accident later. Reverting it now
  reports: `pressing Enter at the project-type question chose 'MIT', not Proprietary`.
- Bite-checked by reverting the default: suite fails, with that message.
- Full suite **13/13** at the shipping commit.

## Release line

Ships as part of **1.7.2** (decided; not deferred to 1.8). The `[Unreleased]` entry sits under
`Changed` and will be folded into the 1.7.2 section when that release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
