### PR TITLE
Substitute the project's license into the inventory's worked example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,10 @@ error/corruption and re-run paths, not normal operation.
 - **`license:` field on repo inventory rows** (`registries/repos.yml`) — records what each repo is
   licensed under, so the inventory shows the licensing picture across every repo at once, which no
   single `LICENSE` file can and which starts mattering as soon as a project's repos don't share one
-  license. For a repo the method creates it is the bootstrap posture, written by `init.sh` on the
-  seed rows; for an adopted repo it is what that repo already says, recorded as found — an
+  license. For a repo the method creates it is the bootstrap posture, which `init.sh` substitutes
+  into the seed rows **and into the worked example beside them**, so the pattern an agent copies
+  matches the project it is copying it into; for an adopted repo it is what that repo already
+  says, recorded as found — an
   identifier and the file it came from, or `none stated`. It is a record, never an instruction: the
   repo's own license file stays authoritative, a missing value means "not recorded" so existing
   inventories are unaffected, and repos carrying different licenses is a normal inventory rather

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -76,7 +76,7 @@ repos:
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service
   #   throughstone: managed
-  #   license: "MIT"                                       # the posture, as on the rows above
+  #   license: "{{PROJECT_LICENSE}}"                       # the posture, as on the rows above
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
   #   description: "..."
   #

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -198,6 +198,29 @@ run_existing_case() {
   fi
   # The same comment must not claim every repo listed there is stamped from the README template.
   assert_file_contains "$docs/registries/repos.yml" "REGISTERED IN PLACE is listed"
+  # The created-repo example beside it says "the posture, as on the rows above", so it has to BE
+  # the posture — it carries {{PROJECT_LICENSE}}, which init.sh substitutes wherever it appears,
+  # the seed rows included. That example is what an agent copies when it registers a repo, so a
+  # literal identifier there would be copied into every row of a project that chose something
+  # else. This case builds with --license=private, which is why a literal cannot pass by
+  # coincidence: the example must read Proprietary, and MIT — the likeliest thing for someone to
+  # type into an example — must not appear anywhere in the file.
+  assert_file_contains "$docs/registries/repos.yml" "license: \"Proprietary\""
+  if grep -Fq 'license: "MIT"' "$docs/registries/repos.yml"; then
+    echo "FAIL: $name shows MIT in the repo inventory of a project that chose Proprietary" >&2
+    return 1
+  fi
+  if grep -Fq '{{PROJECT_LICENSE}}' "$docs/registries/repos.yml"; then
+    echo "FAIL: $name left the license placeholder unsubstituted in the repo inventory" >&2
+    return 1
+  fi
+  # ...while the in-place example must NOT track the posture. Its whole job is to show a repo
+  # carrying something else, so templating both examples would delete the contrast that makes the
+  # rule legible.
+  if ! grep -Fq 'license: "GPL-2.0 (COPYING)"' "$docs/registries/repos.yml"; then
+    echo "FAIL: $name lost the in-place example that differs from the project posture" >&2
+    return 1
+  fi
   # Mono-repo + adoption is a real combination this test exercises (run_existing_case runs both
   # layouts). The file's mono note says its rows are "folders inside the single repo, not separate
   # repos yet" — true of what the method creates, false of every row an adoption writes, and this


### PR DESCRIPTION
## What this does

The repo inventory carries two worked example rows — one for a repo the method creates, one for
a repo registered in place. They differ in exactly one field, and that difference is the point.

**The created-repo example takes the project's own license.** It uses the `{{PROJECT_LICENSE}}`
placeholder that `init.sh` already substitutes wherever it appears, the seed rows included:

```yaml
#   license: "{{PROJECT_LICENSE}}"    # the posture, as on the rows above
```

So the example shows the license the project chose, and its comment — "the posture, as on the
rows above" — describes what the rows next to it actually say. That example is what an agent
copies when it adds a repo to the inventory, so it has to agree with the rows it points at: a
literal identifier there would propagate into every row of a project that chose something else.

Verified across all four postures:

| `--license` | seed rows | created-repo example | in-place example |
|---|---|---|---|
| `mit` | `"MIT"` | `"MIT"` | `"GPL-2.0 (COPYING)"` |
| `bsd-3` | `"BSD-3-Clause"` | `"BSD-3-Clause"` | `"GPL-2.0 (COPYING)"` |
| `apache-2.0` | `"Apache-2.0"` | `"Apache-2.0"` | `"GPL-2.0 (COPYING)"` |
| `private` | `"Proprietary"` | `"Proprietary"` | `"GPL-2.0 (COPYING)"` |

**The in-place example keeps a literal `GPL-2.0 (COPYING)`.** Its job is to show a repo carrying
terms of its own rather than the project posture, so the two examples have to differ — templating
both would remove the contrast the rule depends on. The test asserts that too, so a later tidy-up
can't quietly collapse them.

## Verification

- Pinned in `tests/init-retcon-mode.sh` rather than a shared test: the `license:` field is
  2.0-only, so a shared test would diverge across branches and conflict on every forward merge.
  That test builds with `--license=private`, so the example must read `Proprietary` and `MIT` must
  not appear anywhere in the inventory.
- Four assertions: the example equals the posture, no `MIT` in the file, no unsubstituted
  placeholder, and the in-place example still differs.
- Bite-checked — each assertion fails when the thing it guards is removed.
- Full suite **15/15**; greenfield BSD-3-Clause and adoption proprietary fixtures built from the
  shipping commit both `check.sh` 0/0 and `links.sh` clean.
- No changelog entry: the `license:` field is itself unreleased, so its existing `Added` bullet now
  simply states that the posture goes into the seed rows and the worked example beside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
