### PR TITLE
Give the Test Strategy session somewhere to record an existing pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ any project built with it.
   the rules don't reach, explicitly not as a substitute for following them where they do or for
   fixing a gap once one is found. No effect on a repo the method creates, which is settled and
   unchanged.
-
 - **The interactive project-type question now defaults to private / proprietary.** It defaulted to
   open source, so pressing Enter past it — and Enter again at the license menu, which pre-selects
   the first entry — stood a project up under MIT without the user ever naming a license. That is
@@ -52,6 +51,20 @@ any project built with it.
   exactly as before once given, `--license` is unaffected, and no generated project is rewritten.
 
 ### Fixed
+- **The record that justifies leaving an in-place repo's CI alone had nowhere to go.** The rules
+  are settled: the starter gate in `templates/ci/code-repo-ci.yml` fails until configured, so it is
+  never installed into a repo the method did not create — and four files (`METHOD.md` §7,
+  `templates/ci/README.md`, the repo README template, and the upgrade notes) all say to record what
+  that repo's pipeline runs **in the Test Strategy architecture doc** instead. The Test Strategy
+  session was never told to record it and had no slot in its output to record it into, so the
+  record they promise was left to an agent to invent a home for or skip. Skipped, the resulting doc
+  describes only the repos the method created — which reads, to anyone later, as though the others
+  have no CI at all, the exact opposite of why they were left alone. Session 12 now covers it in
+  its CI-gates decision and carries an **Existing pipelines** output section (one row per repo
+  registered in place: what its CI runs, where it's configured), with a note that a repo registered
+  after the session first ran is added by editing the doc and bumping its version rather than
+  re-running the session. The section is omitted when a project has no such repo, which is every
+  project built from scratch.
 - **`init.sh` would destroy an existing repository it was run inside, and had no guard at all.**
   Extract the download into your own repo and run it there — a natural thing to do, and more so
   since `METHOD.md` §7 began letting a repo be **registered in place**, which gives a user with an

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/12-test-strategy.md
@@ -57,6 +57,17 @@ where the pieces have to work *together*.
    wiring this up ships in `templates/ci/` (a method-integrity workflow that runs
    `scripts/check.sh`, plus a per-repo test workflow to fill in) — see `templates/ci/README.md`.
    Include the contract-validation gates chosen in the Interface Contracts architecture doc where they apply.
+   **A repo registered in place already has CI, and keeps it.** The starter gate is for repos this
+   method creates; it is never installed into one that existed beforehand, because it fails until
+   configured, so landing it there either replaces the workflow that gates their merges or breaks
+   every build until somebody deletes it (`METHOD.md` §7, `templates/ci/README.md`). What this
+   session owes such a repo is the **record**: what its pipeline runs today and where that is
+   configured. Write it down here rather than leaving it out — a Test Strategy doc that describes
+   only the repos the method created reads, to anyone later, as though the others have no CI at
+   all, which is the opposite of why they were left alone. Bringing one onto the standard gate is
+   a change its owners decide on, as its own STEP, not a side effect of adopting the method.
+   A repo registered in place after this session first ran is added the same way, by editing this
+   doc and bumping its version (`METHOD.md` §6) — the session does not need re-running for it.
 7. **Coverage tooling and reporting.** For each real implementation language, choose the
    coverage tool and where its report appears. Default durable coverage/test summaries to
    `reports/test-results/` in the docs hub for meaningful runs such as check-ins, releases,
@@ -104,6 +115,9 @@ Write `architecture/12-test-strategy.md` — the Test Strategy architecture doc 
 - **Test data & isolation**, **mocking strategy**
 - **System/e2e testing** (and its home in a multi-repo setup)
 - **CI gates** — what blocks merge / deploy
+- **Existing pipelines** — one row per repo **registered in place**: repo | what its CI runs today |
+  where it's configured | notes. These are recorded, never replaced. Omit the section when the
+  project has no such repo, which is the usual case for a project built from scratch
 - **Coding standards** — link the per-language file(s) in `coding-standards/` that apply
 
 When durable Markdown summaries are written, start them from

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -46,9 +46,13 @@ copy_template() {
 }
 
 # assert_contains FILE NEEDLE MESSAGE — the generated file must state the rule.
+#
+# `--` before the needle: a needle that starts with "-" (a Markdown list item, say) is otherwise
+# read by grep as an option bundle, and grep exits non-zero on the usage error — so the assertion
+# fails no matter what the file says, and a bite check on it proves nothing.
 assert_contains() {
   local file="$1" needle="$2" message="$3"
-  grep -Fq "$needle" "$file" || {
+  grep -Fq -- "$needle" "$file" || {
     echo "FAIL: $message" >&2
     echo "       expected in $file: $needle" >&2
     return 1
@@ -60,7 +64,7 @@ assert_contains() {
 # would still pass, which is how a rule ends up stated two ways in one file.
 assert_absent() {
   local file="$1" needle="$2" message="$3"
-  if grep -Fq "$needle" "$file"; then
+  if grep -Fq -- "$needle" "$file"; then
     echo "FAIL: $message" >&2
     echo "       still present in $file: $needle" >&2
     return 1
@@ -128,6 +132,17 @@ run_case() {
     "CI README does not carry the never-install rule"
   assert_contains "$readme_tpl" "never install it — that repo has its own CI" \
     "repo README template does not carry the never-install rule"
+  # Four files send that repo's existing pipeline to the Test Strategy session to be recorded. The
+  # session had no instruction to record it and no slot in its output to record it into, so the
+  # record they promise had nowhere to land — and a Test Strategy doc listing only the repos the
+  # method created reads as though the others have no CI, which is the reverse of why they were
+  # left alone. Both halves pinned: the instruction, and the output row it writes into.
+  assert_contains "$docs/templates/architecture-sessions/12-test-strategy.md" \
+    "**A repo registered in place already has CI, and keeps it.**" \
+    "the Test Strategy session does not tell you to record an in-place repo's pipeline"
+  assert_contains "$docs/templates/architecture-sessions/12-test-strategy.md" \
+    "- **Existing pipelines** — one row per repo **registered in place**" \
+    "the Test Strategy session has no output slot for an in-place repo's pipeline"
 
   # --- The project license and the notice. The method records licensing; it never establishes it
   # for code it did not create — but where its own material lands, the notice is owed.


### PR DESCRIPTION
## The gap

The CI rules are settled: `templates/ci/code-repo-ci.yml` fails until configured, so it is never
installed into a repo the method did not create — landing it there either replaces the workflow
that gates their merges or breaks every build until somebody deletes it.

Four files say so, and all four send the reader to the same place for what to do instead:

- `METHOD.md` §7 — "Record what it runs instead."
- `templates/ci/README.md` §2 — "Record what that repo already runs, **in the Test Strategy
  architecture doc**"
- `templates/repo-readme-template.md` — "Record what the repo already runs and leave its pipeline
  alone."
- `UPDATING-THROUGHSTONE.md` — "record what an in-place repo runs in the Test Strategy doc instead"

The Test Strategy session was never told to. Its decisions are about designing CI for something
being built; its output listed **CI gates — what blocks merge / deploy** and nothing else. So the
record four files promise had no instruction behind it and no slot to land in — an agent either
invented a home or dropped it.

Dropped is the dangerous outcome, and the quiet one. The resulting doc describes only the repos
the method created, which reads to anyone later as though the others have **no CI at all** — the
exact opposite of why they were left alone.

## The fix

Session 12's CI-gates decision now covers the case, and its output gains an **Existing pipelines**
section: one row per repo registered in place — what its CI runs, where it's configured.

It also answers the question the four files never did: a repo registered *after* the session first
ran is added by **editing the doc and bumping its version** (`METHOD.md` §6), not by re-running a
STEP-1 architecture session for one repo. That was the practical reason the record had nowhere to
go in the greenfield-plus-registered-in-place case, where there is no adoption harvest to carry it.

**Greenfield-inert in substance.** With no in-place repos the section is omitted and the decision
reads as background. The CI-gates item was *extended* rather than a new numbered item added,
because the output section references "decision 9" by number and renumbering would break it.

## Verification

- Two assertions in `tests/init-inplace-repo-rules.sh` — the instruction, and the output slot it
  writes into — against the substituted form in a generated project. Each **bitten individually**.
- Full suite **13/13**; session skeleton contract still passes (17 templates).
- Fixtures from `git archive` of the shipping commit under Apache-2.0 and proprietary-mono
  `--registries=no`, both `check.sh` 0/0 and `links.sh` clean, both carrying instruction and slot.
- A generated project differs from one built at `main`'s tip in exactly one file, `12-test-strategy.md`.

## Two incidental fixes, called out because one is a trap

**`assert_contains` / `assert_absent` now pass `--` before the needle.** A needle beginning with
`-` — a Markdown list item, say — was read by `grep` as an option bundle. `grep` exited non-zero on
the usage error, so the assertion failed *regardless of what the file contained*. The first new
assertion here hit exactly that: it would have shipped as a permanently-red check that no bite test
could distinguish from a real failure. Caught because the very first run failed with a `grep` usage
line above the FAIL. Verified by reverting the `--`: the assertion breaks again with the file
correct.

**Removed a stray blank line** I introduced earlier between two entries in the changelog's
`Changed` list, which made that one item render loose among tight ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Forward merge into `retcon` — trialled

**One conflict, `CHANGELOG.md`, and it resolves by keeping BOTH sides.** It is positional, not a
disagreement: both branches touch the first bullet under `### Fixed`. `retcon` already carries two
`init.sh` entries there by design — its own adoption-flavoured wording plus `main`'s base one,
which arrived through an earlier forward merge — and this PR adds a third, unrelated entry at the
same spot.

Resolution: keep `retcon`'s two adoption entries, then append this PR's CI-record entry. Verified
after resolving that all four entries are present exactly once and none is duplicated, and the
merged `retcon` suite is **15/15**.

Taking one side would silently drop either the adoption entries or this one.

Also trialled against #145 (the inventory example row) pending on `retcon`: no interaction, they
touch different files.
