### PR TITLE
Say once that an in-place repo keeps what it has, instead of once per artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,10 +155,10 @@ any project built with it.
   the project's `LICENSE` and a `LICENSING.md` asserting that license over the entire repository,
   written from an answer given at install time about code the method never authored. The helper now
   refuses such a target before writing anything, and `METHOD.md` §7 states the rule the refusal
-  enforces — **the method records licensing; it never establishes licensing for code it did not
-  create** — with `AGENTS.md`, the planning session, and the repo README template all pointing at
-  it. A repo the method creates carries none of those files, so nothing about scaffolding a new
-  repo changes.
+  enforces — **a repo the method did not create keeps what it already has**, licensing along with
+  its README and its CI — with `AGENTS.md`, the planning session, and the repo README template all
+  pointing at it. A repo the method creates carries none of those files, so nothing about
+  scaffolding a new repo changes.
 - **`.throughstone/project-license` was described more broadly than it acts.** It was called "the
   project-license posture" and "the authoritative selection" everywhere, but it only ever governs
   **Throughstone-authored and method-created material** — the docs hub, `prompts/`, and any repo

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -149,10 +149,11 @@ copies `LICENSE-THROUGHSTONE` because the standard generated repo retains Throug
 README and CI scaffolding, and writes `LICENSING.md` to make those scopes explicit.
 **Run it only on a repo you create.** A repo **registered in place** — one that existed before
 this project did — keeps whatever licensing its owner set: read it, record it as found beside
-that repo's `registries/repos.yml` entry, and leave it alone. The method records licensing; it never
-establishes licensing for code it did not create (`METHOD.md` §7), so do not apply the posture
-to such a repo, and do not treat a difference between it and the bootstrap selection as
-something to reconcile. The helper refuses a target that already states its own licensing.
+that repo's `registries/repos.yml` entry, and leave it alone. A repo the method did not create
+keeps what it already has — its README, its CI, and its licensing alike (`METHOD.md` §7) — so do
+not apply the posture to such a repo, and do not treat a difference between it and the bootstrap
+selection as something to reconcile. The helper refuses a target that already states its own
+licensing.
 `scripts/setup-workspace.sh` sets up a new developer's machine (clones the siblings, writes
 the root pointers). From the workspace root, `./doctor.sh status`, `./doctor.sh check`, and
 `./doctor.sh links` are thin shortcuts to the docs hub's `scripts/status.sh`,

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -479,51 +479,56 @@ check-in report under `reports/` — then add the register row. **Every repo car
 what it is** — its role and the slice of the system it owns — stamped from that template and
 filled in when the repo is scaffolded (with a matching one-line `description` in
 `registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
-its root for its internal design. **A repo registered in place is *augmented*, not stamped.** Its
-README already exists and is usually its most-read file, so the template is not copied over it:
-add only the missing piece — a short `Role in <project>` section naming what the repo is within
-the system, with a link to its architecture doc — and leave every section the repo already has
-untouched. Propose the text and where it goes before writing into a repo the method didn't create;
-a decline is a complete outcome, since the same information lives in the architecture doc — and in
-the `repos.yml` row where the project keeps an inventory, which a mono-repo project may not. The rule keys on whether a README already exists, not on how the repo got here:
-where a registered-in-place repo has **no** README there is nothing to preserve, so write it from
-the template — every section but Licensing, which describes a repo the method created and is left
-out here as it is when augmenting. That creates the one file, and nothing else about the repo is
-scaffolded, still proposed before it is written. **Every application-code repo the method *creates* also inherits
-the license posture established by `init.sh`:** read the authoritative selection from the docs
+its root for its internal design. **Every application-code repo the method *creates* also inherits
+the license posture and the CI gate.** Read the authoritative license selection from the docs
 hub's `.throughstone/project-license`. That file records the license for **Throughstone-authored
 and method-created material** — this docs hub, `prompts/`, and any repo the method creates — which
 in a project built from scratch is everything, and in a project that also references code it did
 not create is exactly that subset. It is not a claim about code the method didn't write. For an
-open-source selection, the docs hub must have
-a matching canonical `LICENSE`, which is copied unchanged to the new repo root. For
-`Proprietary`, the new repo gets no project `LICENSE`. **A repo registered in place gets neither
-that posture nor the CI gate** — its pipeline is its own, and `templates/ci/code-repo-ci.yml`
-fails until configured, so installing it would replace or break what already gates that repo's
-merges. Record what it runs instead. What such a repo *may* be owed is the notice: where the
-method leaves Throughstone-authored material behind — the `Role in <project>` section, or a README
-written from the template for a repo that had none — run
-`scripts/apply-project-license.sh --notice-only <repo>`, which places `LICENSE-THROUGHSTONE` and a
-`LICENSING.md` that names only what the notice covers and disclaims the rest of the repository. If
-the owners declined the addition, nothing Throughstone-authored is there and nothing is owed. Do
-not copy `LICENSE-THROUGHSTONE` into
-application-code repos that contain no Throughstone-authored material. Repos scaffolded through
-this method do contain the Throughstone-authored README and CI starter, so
-`scripts/apply-project-license.sh` copies `LICENSE-THROUGHSTONE` and writes a visible
-`LICENSING.md` that distinguishes retained scaffold material from project-authored code.
+open-source selection, the docs hub must have a matching canonical `LICENSE`, which is copied
+unchanged to the new repo root; for `Proprietary`, the new repo gets no project `LICENSE`.
+`scripts/apply-project-license.sh` does that, and also copies `LICENSE-THROUGHSTONE` and writes a
+visible `LICENSING.md` — a scaffolded repo *does* hold Throughstone-authored material, the README
+and CI starter, and its notice has to stay distinguishable from the project's own license grant.
 
-**The method records licensing; it never establishes licensing for code it did not create.** A
-repo **registered in place** (below) existed before the method reached it, so it already has an
-owner and a licensing status — a `LICENSE`, a `COPYING`, a `NOTICE`, vendored third-party terms,
-or a deliberate absence. Read what it uses and **record** it as found — in the repo inventory
-entry that describes it, and wherever the architecture docs cover it; never apply a posture to
-it. A divergence from the
-`init.sh` selection is not an error to fix: that selection governs the method's own artifacts and
-the repos it creates, and several in-place repos may legitimately carry several different
-licenses. Choosing or changing a license for an existing repo is its owner's act, taken
-deliberately by them — never a side effect of adding the method to it. So
-`scripts/apply-project-license.sh` is run **only on a repo the method creates**; it refuses a
-target that already states its own licensing.
+**A repo the method did *not* create keeps what it already has.** This is one rule, not four. Such
+a repo — **registered in place** (below) — existed before the method reached it, and its owners
+already decided how it is documented, gated, and licensed. Adding this method to a project is not
+an occasion to overturn any of those decisions; the job is to record them and supply only what the
+project is actually missing. Per artifact that means:
+
+- **README — augmented, never stamped over.** It already exists and is usually the repo's
+  most-read file, so the template is not copied onto it: add only the missing piece — a short
+  `Role in <project>` section naming what the repo is within the system, with a link to its
+  architecture doc — and leave every section the repo already has untouched. The rule keys on
+  whether a README is there, not on how the repo got here: where a registered-in-place repo has
+  **no** README there is nothing to preserve, so write it from the
+  template — every section but Licensing, which describes a repo the method created and is left
+  out here as it is when augmenting. That is the one file; nothing else about the repo is
+  scaffolded.
+- **CI — its own.** `templates/ci/code-repo-ci.yml` fails until configured, so installing it would
+  replace or break whatever already gates that repo's merges. Record what it runs instead.
+- **Licensing — recorded as found.** The repo already has a licensing status: a `LICENSE`, a
+  `COPYING`, a `NOTICE`, vendored third-party terms, or a deliberate absence. Read what it uses
+  and record it — in the repo inventory entry that describes it, and wherever the architecture
+  docs cover it. A divergence from the `init.sh` selection is not an error to fix: that selection
+  governs the method's own artifacts and the repos it creates, and several in-place repos may
+  legitimately carry several different licenses. It is worth telling the owners about once, where
+  they can act on it, and that is the whole of it. So `scripts/apply-project-license.sh` is run
+  **only on a repo the method creates**; it refuses a target that already states its own licensing.
+- **The Throughstone notice — only where something Throughstone-authored landed.** That is the one
+  thing such a repo may still be owed: where the method leaves its own material behind — the
+  `Role in <project>` section, or a README written from the template for a repo that had none —
+  run `scripts/apply-project-license.sh --notice-only <repo>`, which places `LICENSE-THROUGHSTONE`
+  and a `LICENSING.md` that names only what the notice covers and disclaims the rest of the
+  repository. Where the addition was declined, nothing Throughstone-authored is there and nothing
+  is owed; do not copy `LICENSE-THROUGHSTONE` into a repo that holds none of it.
+
+Every write above is **proposed before it happens** — show the exact text and where it goes, and
+wait for an answer. A decline is a complete outcome, not a gap: the same information lives in the
+architecture doc — and in the `repos.yml` row where the project keeps an inventory, which a
+mono-repo project may not. Choosing or changing what any of these say for an existing repo is its
+owners' act, taken deliberately by them, never a side effect of adding the method to it.
 
 **When the rules above don't settle it, ask.** They cover the cases the method has met: a repo it
 creates, and one registered in place that has a README, has none, or whose owners decline the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -279,6 +279,18 @@ affect work you do after pulling them.
   header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
+- **Licensing is no longer its own rule.** `METHOD.md` §7 had grown a separate doctrine paragraph
+  for licensing — "the method records licensing; it never establishes licensing for code it did not
+  create" — sitting alongside separate rules for the README, for CI, and for the Throughstone
+  notice. They were always the same rule applied to four artifacts: **a repo the method did not
+  create keeps what it already has.** §7 now states that once, with the four as consequences under
+  it and one gate covering all of them (propose the exact text, wait for an answer). **No behavior
+  changes** — every individual rule says what it said, and the helpers are untouched. What changes
+  is that the rationale lives in one place instead of being re-derived in each, and the files that
+  cite it — `AGENTS.md`, the planning session, and the repo README template — now quote the general
+  rule rather than a licensing-specific one. Pull those three with `METHOD.md`. **One thing to
+  check:** nothing; if you have local edits quoting the old licensing sentence, they are still
+  true, just narrower than the rule they came from.
 - **The project license is applied only to repos the method creates.** `METHOD.md` §7 already let a
   repo be **registered in place** — referenced where it sits, rather than created under `Code/` —
   but every instruction around `scripts/apply-project-license.sh` was written as though every repo

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -92,8 +92,8 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    and CI starter are retained Throughstone-authored scaffold material, and writes
    `LICENSING.md` to make clear that notice is not the application-code license. **Run it only on
    repos you create** — a repo **registered in place**, which existed before this project did,
-   keeps the licensing its owner set (`METHOD.md` §7: the method records licensing, it never
-   establishes licensing for code it did not create). Record what such a repo uses where its
+   keeps the licensing its owner set (`METHOD.md` §7: a repo the method did not create keeps what
+   it already has — README, CI, and licensing alike). Record what such a repo uses where its
    inventory entry describes it and move on; the helper refuses it. Repository
    visibility is separate: when adding a remote for each code repo, choose private or public
    deliberately rather than inferring it from the license. Publishing a proprietary repo makes

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -52,8 +52,8 @@
   between the two licenses explicit.
 
   For a repo REGISTERED IN PLACE — one that existed before this project did — do NOT run it.
-  That repo already has an owner and a licensing status; the method records licensing, it never
-  establishes licensing for code it did not create (`METHOD.md` §7). Read what the repo uses
+  That repo already has an owner and a licensing status; a repo the method did not create keeps
+  what it already has, licensing included (`METHOD.md` §7). Read what the repo uses
   (`LICENSE`, `COPYING`, `NOTICE`, package metadata, vendored third-party terms, or a deliberate
   absence), record that, and leave its licensing alone — including when it differs from the
   bootstrap selection, which governs only this method's own artifacts and the repos it creates.

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -96,6 +96,24 @@ run_case() {
   local repos="$docs/registries/repos.yml"
   local check_in="$docs/runbooks/check-in.md"
 
+  # --- One rule, not four. README, CI, licensing, and the notice are the same rule applied to four
+  # artifacts: a repo the method did not create keeps what it already has. Licensing had grown its
+  # own doctrine paragraph, which is how the same argument ended up restated in file after file and
+  # why the next artifact to hit this boundary would have needed one more. The heading is pinned
+  # because it is what the consumers cite; drop it and their pointers go stale silently.
+  assert_contains "$docs/METHOD.md" \
+    "**A repo the method did *not* create keeps what it already has.**" \
+    "METHOD.md §7 lost the single rule the per-artifact consequences hang off"
+  assert_contains "$docs/METHOD.md" "This is one rule, not four" \
+    "METHOD.md §7 no longer says the per-artifact rules are one rule"
+  # Licensing is one of those consequences now, not a separate doctrine with its own rationale.
+  assert_absent "$docs/METHOD.md" \
+    "**The method records licensing; it never establishes licensing for code it did not create.**" \
+    "METHOD.md §7 still gives licensing its own rule instead of one line under the general one"
+  # Every write into such a repo goes through one gate, stated once for all four artifacts.
+  assert_contains "$docs/METHOD.md" "proposed before it happens" \
+    "METHOD.md §7 no longer gates every write into an in-place repo on proposing it first"
+
   # --- The README. Stamp what the method creates; augment what it registers, keyed on whether the
   # file exists. The substituted section name doubles as the placeholder check.
   assert_contains "$readme_tpl" "STAMP this into a repo the method CREATES" \


### PR DESCRIPTION
§7 had four rules for a repo registered in place — augment its README rather than stamp over it, leave its CI alone, record its licensing rather than set it, place the Throughstone notice only where the method's own material landed. Each arrived separately as the artifact that needed it came up, and each brought its own paragraph of reasoning. Licensing had grown the largest: a doctrine sentence of its own, quoted back by `AGENTS.md`, the planning session, and the repo README template to explain themselves.

They were always one rule: **a repo the method did not create keeps what it already has.** §7 now says that once and hangs the four on it as consequences, with the gate that governs all of them — propose the exact text and where it goes, wait for an answer — stated once at the end rather than three times in the middle.

## What changes

- `METHOD.md` §7 — one rule, four bullets, one gate. Replaces the separate augment paragraph, the in-place halves of the posture/CI paragraph, and the standalone licensing doctrine paragraph.
- `AGENTS.md`, `templates/planning-session.md`, `templates/repo-readme-template.md` — the three files that cited the licensing-specific sentence now cite the general rule.
- `CHANGELOG.md`, `UPDATING-THROUGHSTONE.md` — the entry describing the helper's refusal names the rule it now enforces; a migration bullet says what moved.
- `tests/init-inplace-repo-rules.sh` — pins the heading the consumers cite, that it reads as one rule, that licensing no longer has its own, and that the propose-first gate is stated.

## What does not change

No behavior. Every individual rule says what it said, `apply-project-license.sh` and `init.sh` are untouched, and the "when the rules don't settle it, ask" fallback stays where it is. Greenfield-inert in the strong sense: this is prose an agent reads, and it reads the same for a project that never registers a repo in place.

Full suite green (13 files).

## Why this is the shape

Licensing being its own rule is what made the same argument get restated in file after file — the next artifact to meet this boundary would have needed a fifth paragraph. Under one rule it needs a line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
