### PR TITLE
Ask an adopted codebase for its license after reading it, not before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,12 +131,22 @@ error/corruption and re-run paths, not normal operation.
     sits, so each one's licensing stays its owner's: the recon map records what each repo actually
     says — the identifier and the file it came from, `none stated` where nothing does, plus vendored
     third-party terms — and nothing writes a `LICENSE` into a repo you already had. The license you
-    pick at install time covers this method's own artifacts and anything it creates for you, so a
-    repo whose license differs from it is not a problem to fix, and adopted repos carrying several
-    different licenses is a normal result rather than an inconsistency. `init.sh` now says that at
-    the point it asks: when you're adopting, the license and copyright-holder questions state up
-    front that they cover the documentation hub being created and anything created later, not the
-    code you're bringing — so you aren't answering about repos that already have their own answer.
+    pick covers this method's own artifacts and anything it creates for you, so adopted repos
+    carrying several different licenses is a normal result rather than an inconsistency to
+    reconcile.
+  - **The license question is asked after your codebase has been read, not before.** In adoption,
+    `init.sh` no longer asks it at install time — at that point nobody has read your repos, so the
+    question arrives with nothing to answer it from, and phrased as "open source or private?" it
+    reads as being about the code you're bringing rather than about the docs hub being created.
+    Adoption now leaves the choice open and asks once at the recon-map checkpoint, where each repo's
+    licensing has just been recorded and is in front of you, offering what your repos say as the
+    default. A new `scripts/set-project-license.sh` answers it in one command — the posture, the
+    canonical `LICENSE`, and the files init left saying the license had not been chosen — and
+    answers it once, refusing to change an answer already given. Until then no `LICENSE` is written
+    and nothing is claimed. Where your repos differ from what you chose, you're told once, at that
+    checkpoint, and nothing is reconciled or written into them. **Greenfield is unchanged** — it
+    creates everything it licenses and has nothing to read first, so it still asks at setup, and
+    `--license=NAME` still decides at install time in either mode.
 
 ### Changed
 - **`status.sh` no longer guesses when the kickoff marker is missing.** If `overview.md` exists but
@@ -312,10 +322,10 @@ error/corruption and re-run paths, not normal operation.
   the project's `LICENSE` and a `LICENSING.md` asserting that license over the entire repository,
   written from an answer given at install time about code the method never authored. The helper now
   refuses such a target before writing anything, and `METHOD.md` §7 states the rule the refusal
-  enforces — **the method records licensing; it never establishes licensing for code it did not
-  create** — with `AGENTS.md`, the planning session, and the repo README template all pointing at
-  it. A repo the method creates carries none of those files, so nothing about scaffolding a new
-  repo changes.
+  enforces — **a repo the method did not create keeps what it already has**, licensing along with
+  its README and its CI — with `AGENTS.md`, the planning session, and the repo README template all
+  pointing at it. A repo the method creates carries none of those files, so nothing about
+  scaffolding a new repo changes.
 - **`.throughstone/project-license` was described more broadly than it acts.** It was called "the
   project-license posture" and "the authoritative selection" everywhere, but it only ever governs
   **Throughstone-authored and method-created material** — the docs hub, `prompts/`, and any repo

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -175,10 +175,11 @@ copies `LICENSE-THROUGHSTONE` because the standard generated repo retains Throug
 README and CI scaffolding, and writes `LICENSING.md` to make those scopes explicit.
 **Run it only on a repo you create.** A repo **registered in place** — one that existed before
 this project did — keeps whatever licensing its owner set: read it, record it as found in that
-repo's `registries/repos.yml` `license:` field, and leave it alone. The method records licensing; it never
-establishes licensing for code it did not create (`METHOD.md` §7), so do not apply the posture
-to such a repo, and do not treat a difference between it and the bootstrap selection as
-something to reconcile. The helper refuses a target that already states its own licensing.
+repo's `registries/repos.yml` `license:` field, and leave it alone. A repo the method did not
+create keeps what it already has — its README, its CI, and its licensing alike (`METHOD.md` §7) —
+so do not apply the posture to such a repo, and do not treat a difference between it and the
+project's own selection as something to reconcile. The helper refuses a target that already states
+its own licensing.
 `scripts/setup-workspace.sh` sets up a new developer's machine (clones the siblings, writes
 the root pointers). From the workspace root, `./doctor.sh status`, `./doctor.sh check`, and
 `./doctor.sh links` are thin shortcuts to the docs hub's `scripts/status.sh`,

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -490,52 +490,57 @@ check-in report under `reports/` — then add the register row. **Every repo car
 what it is** — its role and the slice of the system it owns — stamped from that template and
 filled in when the repo is scaffolded (with a matching one-line `description` in
 `registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
-its root for its internal design. **A repo registered in place is *augmented*, not stamped.** Its
-README already exists and is usually its most-read file, so the template is not copied over it:
-add only the missing piece — a short `Role in <project>` section naming what the repo is within
-the system, with a link to its architecture doc — and leave every section the repo already has
-untouched. Propose the text and where it goes before writing into a repo the method didn't create;
-a decline is a complete outcome, since the same information lives in the architecture doc — and in
-the `repos.yml` row where the project keeps an inventory, which a mono-repo project may not. The rule keys on whether a README already exists, not on how the repo got here:
-where a registered-in-place repo has **no** README there is nothing to preserve, so write it from
-the template — every section but Licensing, which describes a repo the method created and is left
-out here as it is when augmenting. That creates the one file, and nothing else about the repo is
-scaffolded, still proposed before it is written. **Every application-code repo the method *creates* also inherits
-the license posture established by `init.sh`:** read the authoritative selection from the docs
+its root for its internal design. **Every application-code repo the method *creates* also inherits
+the license posture and the CI gate.** Read the authoritative license selection from the docs
 hub's `.throughstone/project-license`. That file records the license for **Throughstone-authored
 and method-created material** — this docs hub, `prompts/`, and any repo the method creates — which
 in a project built from scratch is everything, and in a project that also references code it did
 not create is exactly that subset. It is not a claim about code the method didn't write. For an
-open-source selection, the docs hub must have
-a matching canonical `LICENSE`, which is copied unchanged to the new repo root. For
-`Proprietary`, the new repo gets no project `LICENSE`. **A repo registered in place gets neither
-that posture nor the CI gate** — its pipeline is its own, and `templates/ci/code-repo-ci.yml`
-fails until configured, so installing it would replace or break what already gates that repo's
-merges. Record what it runs instead. What such a repo *may* be owed is the notice: where the
-method leaves Throughstone-authored material behind — the `Role in <project>` section, or a README
-written from the template for a repo that had none — run
-`scripts/apply-project-license.sh --notice-only <repo>`, which places `LICENSE-THROUGHSTONE` and a
-`LICENSING.md` that names only what the notice covers and disclaims the rest of the repository. If
-the owners declined the addition, nothing Throughstone-authored is there and nothing is owed. Do
-not copy `LICENSE-THROUGHSTONE` into
-application-code repos that contain no Throughstone-authored material. Repos scaffolded through
-this method do contain the Throughstone-authored README and CI starter, so
-`scripts/apply-project-license.sh` copies `LICENSE-THROUGHSTONE` and writes a visible
-`LICENSING.md` that distinguishes retained scaffold material from project-authored code.
+open-source selection, the docs hub must have a matching canonical `LICENSE`, which is copied
+unchanged to the new repo root; for `Proprietary`, the new repo gets no project `LICENSE`.
+`scripts/apply-project-license.sh` does that, and also copies `LICENSE-THROUGHSTONE` and writes a
+visible `LICENSING.md` — a scaffolded repo *does* hold Throughstone-authored material, the README
+and CI starter, and its notice has to stay distinguishable from the project's own license grant.
 
-**The method records licensing; it never establishes licensing for code it did not create.** A
-repo **registered in place** (below) existed before the method reached it, so it already has an
-owner and a licensing status — a `LICENSE`, a `COPYING`, a `NOTICE`, vendored third-party terms,
-or a deliberate absence. Read what it uses and **record** it as found — in its
-`registries/repos.yml` `license:` field (an identifier and the file it came from, or `none
-stated`), and wherever the architecture docs cover it; never apply a posture to it. A divergence
-from the
-`init.sh` selection is not an error to fix: that selection governs the method's own artifacts and
-the repos it creates, and several in-place repos may legitimately carry several different
-licenses. Choosing or changing a license for an existing repo is its owner's act, taken
-deliberately by them — never a side effect of adding the method to it. So
-`scripts/apply-project-license.sh` is run **only on a repo the method creates**; it refuses a
-target that already states its own licensing.
+**A repo the method did *not* create keeps what it already has.** This is one rule, not four. Such
+a repo — **registered in place** (below) — existed before the method reached it, and its owners
+already decided how it is documented, gated, and licensed. Adding this method to a project is not
+an occasion to overturn any of those decisions; the job is to record them and supply only what the
+project is actually missing. Per artifact that means:
+
+- **README — augmented, never stamped over.** It already exists and is usually the repo's
+  most-read file, so the template is not copied onto it: add only the missing piece — a short
+  `Role in <project>` section naming what the repo is within the system, with a link to its
+  architecture doc — and leave every section the repo already has untouched. The rule keys on
+  whether a README is there, not on how the repo got here: where a registered-in-place repo has
+  **no** README there is nothing to preserve, so write it from the
+  template — every section but Licensing, which describes a repo the method created and is left
+  out here as it is when augmenting. That is the one file; nothing else about the repo is
+  scaffolded.
+- **CI — its own.** `templates/ci/code-repo-ci.yml` fails until configured, so installing it would
+  replace or break whatever already gates that repo's merges. Record what it runs instead.
+- **Licensing — recorded as found.** The repo already has a licensing status: a `LICENSE`, a
+  `COPYING`, a `NOTICE`, vendored third-party terms, or a deliberate absence. Read what it uses
+  and record it — in its `registries/repos.yml` `license:` field (an identifier and the file it
+  came from, or `none stated`), and wherever the architecture docs cover it. A divergence from the
+  project's own selection is not an error to fix: that selection governs the method's artifacts and
+  the repos it creates, and several in-place repos may legitimately carry several different
+  licenses. It is worth telling the owners about once, where they can act on it, and that is the
+  whole of it. So `scripts/apply-project-license.sh` is run **only on a repo the method creates**;
+  it refuses a target that already states its own licensing.
+- **The Throughstone notice — only where something Throughstone-authored landed.** That is the one
+  thing such a repo may still be owed: where the method leaves its own material behind — the
+  `Role in <project>` section, or a README written from the template for a repo that had none —
+  run `scripts/apply-project-license.sh --notice-only <repo>`, which places `LICENSE-THROUGHSTONE`
+  and a `LICENSING.md` that names only what the notice covers and disclaims the rest of the
+  repository. Where the addition was declined, nothing Throughstone-authored is there and nothing
+  is owed; do not copy `LICENSE-THROUGHSTONE` into a repo that holds none of it.
+
+Every write above is **proposed before it happens** — show the exact text and where it goes, and
+wait for an answer. A decline is a complete outcome, not a gap: the same information lives in the
+architecture doc — and in the `repos.yml` row where the project keeps an inventory, which a
+mono-repo project may not. Choosing or changing what any of these say for an existing repo is its
+owners' act, taken deliberately by them, never a side effect of adding the method to it.
 
 **When the rules above don't settle it, ask.** They cover the cases the method has met: a repo it
 creates, and one registered in place that has a README, has none, or whose owners decline the

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -5,8 +5,10 @@
 > Built with **Throughstone** — this file and the other scaffold files (`templates/`,
 > `runbooks/`, `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause; the full text is
 > retained as `LICENSE-THROUGHSTONE` in this docs hub. Application code this project creates is
-> under the open-source license you chose at setup or remains private/proprietary; a repo that
-> existed before this project keeps the licensing its owner set (§7). For open-source
+> under the open-source license you chose or remains private/proprietary; a project that adopted
+> an existing codebase chooses at the recon-map checkpoint rather than at setup, once its repos
+> have been read. A repo that existed before this project keeps the licensing its owner set (§7).
+> For open-source
 > projects, the docs hub's `LICENSE` is the canonical project-license file copied into each
 > application-code repo when that repo is created. The durable selection is recorded separately
 > in `.throughstone/project-license`, so a missing license file cannot silently change it.

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -32,13 +32,14 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 | [`registries/`](registries/README.md) | Machine-readable inventories — repo map (`repos.yml`) and accepted risk / tech-debt index (`risks.yml`) (indexed). |
 | [`reports/`](reports/README.md) | Durable review and operational reports, including check-in, incident, security review, and test-result reports. |
 | [`templates/`](templates/) | The session, STEP, and doc templates the method runs from. |
-| [`scripts/`](scripts/) | Setup and doctor helpers — status, structural checks, stale-link checks, workspace setup, and project-license propagation. |
+| [`scripts/`](scripts/) | Setup and doctor helpers — status, structural checks, stale-link checks, workspace setup, and choosing and propagating the project license. |
 
 > Built with **Throughstone**. The scaffold files (`METHOD.md`, `templates/`, `runbooks/`,
 > `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause — full text in
 > `LICENSE-THROUGHSTONE`. Your application code and project docs are yours. What this project
-> creates is under the open-source license you chose at setup or kept private/proprietary; a repo
-> that existed beforehand keeps the licensing its owner set. For open-source projects,
+> creates is under the open-source license you chose or kept private/proprietary — chosen at setup,
+> or at the recon-map checkpoint for a project that adopted an existing codebase and read its repos
+> first. A repo that existed beforehand keeps the licensing its owner set. For open-source projects,
 > this repo's `LICENSE` is the canonical project-license file copied unchanged into each
 > application-code repo when it is created. `.throughstone/project-license` records the durable
 > selection independently, and the repo-scaffolding helper validates the two before copying.

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -170,8 +170,31 @@ Inventory is frozen — never rewritten** (an asset discovered later is a record
 edit). The per-asset **detail is not frozen** — it deepens later in the living docs (repo READMEs,
 `architecture/`), and some exploration is deliberately deferred for weeks or months via the depth dial
 (`Coverage: deferred` → `risks.yml` → the check-in backfill). If the user can't yet confirm an area,
-mark it bounded/deferred in Coverage & Confidence rather than guessing it into fact. Once the map is
-confirmed and frozen, mark `inv-4` **Done**.
+mark it bounded/deferred in Coverage & Confidence rather than guessing it into fact.
+
+**Answer the project-license question here.** `init.sh --mode=existing` left it open on purpose:
+at install time nobody had read the codebase, so the question had nothing to answer it from, and
+`.throughstone/project-license` holds `Unset`. Now it does — **Stack Per Repo** has each adopted
+repo's licensing as found, and the user is already reading the map. So ask once, with that in
+front of them: *what licenses this documentation hub and anything the method creates later?*
+Offer what the repos say as the default — if they agree on one license, propose it; if they carry
+several, or none states anything, say so and ask. Be explicit that the answer covers **this
+method's own material and nothing else**: it is not applied to the adopted repos, which keep the
+licensing their owners set. Then run it in once:
+
+```
+Code/{{PROJECT}}-docs/scripts/set-project-license.sh <mit|bsd-3|apache-2.0|private> [--holder "<name>"]
+```
+
+That writes the posture, the docs hub's canonical `LICENSE` for an open-source answer, and the
+`LICENSING.md` and inventory rows for the repos `init.sh` created — the files it left saying the
+license had not been chosen yet. Commit the result in each repo it touched. It answers the
+question once and refuses to change an answer already given; if the user supplied `--license` at
+install time there is nothing open, and the helper will say so. If the user would rather decide
+later, that is a fine answer too — the posture stays `Unset`, and nothing needs it until the
+project creates its first repo, which is where `apply-project-license.sh` will ask for it.
+
+Once the map is confirmed and frozen, mark `inv-4` **Done**.
 
 ### `inv-5` — Upgrade this PLAN by addition
 The confirmed map now fixes both the asset list and which sessions apply. Edit

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -194,6 +194,14 @@ install time there is nothing open, and the helper will say so. If the user woul
 later, that is a fine answer too — the posture stays `Unset`, and nothing needs it until the
 project creates its first repo, which is where `apply-project-license.sh` will ask for it.
 
+**Then say once where their own repos don't match, and stop.** This is the moment for it: the
+answer is fresh and the licensing column is on screen. Name them plainly — *"you chose MIT;
+`billing-api` is Apache-2.0 (LICENSE) and `legacy-etl` states nothing"* — and leave it there.
+Nothing is reconciled and nothing is written into those repos: the choice just made covers this
+method's material, not theirs. What comes of it is the user's call on their own code. Say it here
+so the per-repo substeps don't have to raise it eight more times; if every repo already matches,
+say nothing at all rather than reporting a clean comparison nobody asked for.
+
 Once the map is confirmed and frozen, mark `inv-4` **Done**.
 
 ### `inv-5` — Upgrade this PLAN by addition
@@ -348,12 +356,17 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   it at `inv-3` as part of the frozen point-in-time snapshot, and this row's `license:` field is
   the **living** copy that stays current as the repo changes. Copy it across as found — same
   identifier, same source file, `none stated` where the repo says nothing — rather than
-  re-deriving it, so the two records can't disagree from the day they are written. The license
-  chosen at install time governs this method's own artifacts — the docs hub
-  and anything it later creates — not the code being adopted, so a repo whose license differs from
-  it is **not a finding**, several adopted repos may carry several different licenses, and none of
-  that is reconciled. If the user raises relicensing, it is their act on their repo: say what you
-  observed and stop there.
+  re-deriving it, so the two records can't disagree from the day they are written.
+  **A repo whose licensing differs from the project's is recorded, not reconciled.** The project's
+  license — chosen at `inv-4` — governs this method's own artifacts, the docs hub and anything it
+  later creates. The adopted repos are not measured against it and never take it. Any divergence
+  was already named once at `inv-4`, when the user chose with the map's licensing column in front
+  of them; do not re-raise it here, repo by repo, and do not open a finding or a risk row for it.
+  Several adopted repos legitimately carrying several different licenses is a normal inventory,
+  and a repo with no `LICENSE` at all is the ordinary state of private code, not a gap. Write the
+  row and move on. If the user asks for a repo's licensing to be changed, that is their act on
+  their repo: propose the exact file and wait for a yes, the same as any other write into a repo
+  this method did not create.
 - **Per doc-set** — copy the found source docs into `inputs/` and add each one's
   `inputs/inputs-index.md` row(s) (`Live`), per the base inputs lifecycle (point-in-time; the code
   wins on conflict). Their

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -347,8 +347,9 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   If the user declined the README addition, nothing Throughstone-authored is in the repo and
   nothing is owed — placing a notice for absent material would only confuse a later reader.
   **Never license an adopted repo.** Every repo here is registered in place, so its licensing is
-  its owner's and the method only records it (`METHOD.md` §7: the method records licensing; it
-  never establishes licensing for code it did not create). Concretely: do **not** run
+  its owner's and the method only records it — the same rule that leaves its README augmented and
+  its CI alone (`METHOD.md` §7: a repo the method did not create keeps what it already has).
+  Concretely: do **not** run
   `scripts/apply-project-license.sh` against any of these repos — it will refuse one that states
   its own terms, and the ones it would not refuse are exactly the repos that would silently gain a
   `LICENSE` and a `LICENSING.md` claiming it over code you did not write. Recording it **is** the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -370,6 +370,18 @@ All but the last are documentation only; nothing you already produced is rewritt
   thing to check:** if you have registered an existing repo in place and ran the helper on it, look
   at that repo's `LICENSE` / `LICENSING.md` and decide, as its owner, whether they say what you
   intend.
+- **Licensing is no longer its own rule.** `METHOD.md` §7 had grown a separate doctrine paragraph
+  for licensing — "the method records licensing; it never establishes licensing for code it did not
+  create" — sitting alongside separate rules for the README, for CI, and for the Throughstone
+  notice. They were always the same rule applied to four artifacts: **a repo the method did not
+  create keeps what it already has.** §7 now states that once, with the four as consequences under
+  it and one gate covering all of them (propose the exact text, wait for an answer). **No behavior
+  changes** — every individual rule says what it said, and the helpers are untouched. What changes
+  is that the rationale lives in one place instead of being re-derived in each, and the files that
+  cite it — `AGENTS.md`, `RETCON-PROMPT.md`, the planning session, the repo README template, and
+  `registries/repos.yml` — now quote the general rule rather than a licensing-specific one. Pull
+  those five with `METHOD.md`. **One thing to check:** nothing; if you have local edits quoting the
+  old licensing sentence, they are still true, just narrower than the rule they came from.
 - **Adoption chooses its license after reading the codebase, not at install time.**
   `init.sh --mode=existing` used to ask the license question up front, alongside the greenfield
   flow. At that moment nobody has read the repos yet, so the question arrives with nothing to

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -370,6 +370,23 @@ All but the last are documentation only; nothing you already produced is rewritt
   thing to check:** if you have registered an existing repo in place and ran the helper on it, look
   at that repo's `LICENSE` / `LICENSING.md` and decide, as its owner, whether they say what you
   intend.
+- **Adoption chooses its license after reading the codebase, not at install time.**
+  `init.sh --mode=existing` used to ask the license question up front, alongside the greenfield
+  flow. At that moment nobody has read the repos yet, so the question arrives with nothing to
+  answer it from — and phrased as "is this project open source or private?" it reads as a question
+  about the code being adopted, which is not what it sets. It is now **deferred**: adoption leaves
+  `.throughstone/project-license` holding `Unset` and asks once at the recon-map checkpoint
+  (`inv-4`), where each repo's licensing has just been recorded and is in front of you. A new
+  helper answers it — `scripts/set-project-license.sh <license> [--holder NAME]` — writing the
+  posture, the canonical `LICENSE`, and the `LICENSING.md` and inventory rows that init left
+  saying the license had not been chosen. It answers once and refuses to change an answer already
+  given. `scripts/apply-project-license.sh` refuses an `Unset` posture and names the checkpoint
+  that settles it. **Greenfield is unchanged** — it creates everything it licenses and has nothing
+  to read first, so it still asks at setup. `--license=NAME` still decides at install time in
+  either mode and defers nothing; in adoption it is now optional rather than required under
+  `--non-interactive`. Pull `init.sh`, both `scripts/*-project-license.sh`, `RETCON-PROMPT.md`,
+  and `registries/repos.yml`. **One thing to check:** nothing to do for an existing project — your
+  posture is already chosen, and the helper will tell you so if you run it.
 - **`.throughstone/project-license` is described more narrowly.** The posture file was called "the
   project license" everywhere, but it only ever governed **Throughstone-authored and method-created
   material** — your docs hub, `prompts/`, and any repo the method creates. Nothing about the file

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -43,8 +43,8 @@
 # REGISTERED IN PLACE — one that existed before this project did — it is whatever that repo already
 # says, written down as found: an identifier and the file it came from (`GPL-2.0 (COPYING)`), or
 # `none stated` when the repo says nothing, which is a fact worth recording rather than a gap to
-# fill. Never set a license for such a repo; see METHOD.md §7 — the method records licensing, it
-# never establishes licensing for code it did not create. A missing value means "not recorded", not
+# fill. Never set a license for such a repo; see METHOD.md §7 — a repo the method did not create
+# keeps what it already has, licensing included. A missing value means "not recorded", not
 # "same as everything else", and repos legitimately carrying different licenses is a normal
 # inventory rather than an inconsistency to reconcile.
 #

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -47,6 +47,12 @@
 # never establishes licensing for code it did not create. A missing value means "not recorded", not
 # "same as everything else", and repos legitimately carrying different licenses is a normal
 # inventory rather than an inconsistency to reconcile.
+#
+# `Unset` on a created repo's row is its own answer: a project that adopted an existing codebase
+# defers the license question until the codebase has been read, so these rows say so until the
+# recon-map checkpoint answers it and `scripts/set-project-license.sh` rewrites them. It never
+# appears on a registered-in-place row — that row records what the repo itself says, which is
+# `none stated` when the answer is nothing.
 
 repos:
   - name: "{{PROJECT}}-docs"

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -233,6 +233,17 @@ case "$PROJECT_LICENSE_ID" in
   Proprietary)
     PROJECT_IS_OPEN_SOURCE=0
     ;;
+  Unset)
+    # A project that adopted an existing codebase defers the license question to the recon-map
+    # checkpoint, where the repos' own licensing is on the table to answer it from. Reaching here
+    # means a repo is being scaffolded before that happened — so say which question is unanswered
+    # and where it gets answered, rather than failing as though the file were corrupt.
+    echo "apply-project-license.sh: this project has not chosen its license yet." >&2
+    echo "        Adoption defers the question to the recon-map checkpoint, which answers it with" >&2
+    echo "        scripts/set-project-license.sh. Run that first; this helper stamps the answer." >&2
+    echo "        Nothing was written." >&2
+    exit 1
+    ;;
   *)
     echo "apply-project-license.sh: invalid project-license posture in $POLICY_FILE: $PROJECT_LICENSE_ID" >&2
     exit 1

--- a/Code/{{PROJECT}}-docs/scripts/set-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/set-project-license.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# set-project-license.sh LICENSE [--holder NAME] — answer the project-license question once,
+# after the codebase has been read.
+#
+# A project that adopts an existing codebase does not choose its license at install time. Nobody
+# has read the repos yet at that point, and the repos themselves already carry the answer, so
+# `init.sh --mode=existing` leaves `.throughstone/project-license` holding `Unset` and the
+# adoption flow puts the question at the recon-map checkpoint instead — with each repo's licensing
+# recorded in front of the user and what was found as the default. This helper is what that
+# checkpoint runs. It exists so answering the question is one command rather than five
+# hand-edits that can each be half-done.
+#
+# What it covers is what the posture has always covered: THROUGHSTONE-AUTHORED AND METHOD-CREATED
+# material — this docs hub, prompts/, and any repo the method creates later. It is not a statement
+# about the adopted code, and it writes nothing into an adopted repo. Those repos keep the
+# licensing their owners set; the recon map and the repo inventory record it.
+#
+# It is deliberately one-way. Answering a question nobody has answered yet is bookkeeping;
+# CHANGING a license already in force is not — repos are stamped from it, LICENSING.md files
+# assert it, and copies may already be published. So a posture that is anything other than `Unset`
+# is left alone: re-running with the same answer is a no-op, and a different answer is refused
+# with what to do instead.
+
+set -euo pipefail
+
+# This script lives in Code/{{PROJECT}}-docs/scripts/ in the scaffold and in
+# Code/<project>-docs/scripts/ after initialization; derive the docs hub without resolving
+# the placeholder in this template checkout.
+DOCS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY_FILE="$DOCS_ROOT/.throughstone/project-license"
+REGISTRY="$DOCS_ROOT/registries/repos.yml"
+
+# The first line of the LICENSING.md that init.sh writes for a deferred posture. Finding it is how
+# this script locates the generated repos without needing to know the project's layout: exactly
+# the directories that got the placeholder summary are the ones owed the settled one.
+DEFERRED_MARKER="This project has not chosen its license yet."
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: set-project-license.sh LICENSE [--holder NAME]
+
+  LICENSE   mit | bsd-3 | apache-2.0 | private
+  --holder  Copyright holder (name or org) — required for an open-source license
+
+Answers the deferred project-license question for a project that adopted an existing codebase.
+Covers this docs hub and anything the method creates later, never the adopted code.
+USAGE
+}
+
+LICENSE_IN=""
+HOLDER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --holder) HOLDER="${2:-}"; shift ;;
+    --holder=*) HOLDER="${1#*=}" ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "set-project-license.sh: unknown option: $1" >&2; usage; exit 2 ;;
+    *)
+      if [ -n "$LICENSE_IN" ]; then
+        echo "set-project-license.sh: unexpected extra argument: $1" >&2
+        exit 2
+      fi
+      LICENSE_IN="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$LICENSE_IN" ]; then
+  usage
+  exit 2
+fi
+
+# Same friendly tokens init.sh accepts for --license, so the two questions take the same answers.
+LICENSE_TEMPLATE_NAME=""
+case "$(printf '%s' "$LICENSE_IN" | tr '[:upper:]' '[:lower:]')" in
+  mit)
+    PROJECT_LICENSE_ID="MIT"; LICENSE_TEMPLATE_NAME="MIT.txt" ;;
+  bsd-3|bsd-3-clause|bsd)
+    PROJECT_LICENSE_ID="BSD-3-Clause"; LICENSE_TEMPLATE_NAME="BSD-3-Clause.txt" ;;
+  apache-2.0|apache-2|apache)
+    PROJECT_LICENSE_ID="Apache-2.0"; LICENSE_TEMPLATE_NAME="Apache-2.0.txt" ;;
+  private|proprietary)
+    PROJECT_LICENSE_ID="Proprietary" ;;
+  *)
+    echo "set-project-license.sh: invalid license '$LICENSE_IN' (mit | bsd-3 | apache-2.0 | private)." >&2
+    exit 2 ;;
+esac
+PROJECT_IS_OPEN_SOURCE=0
+[ -n "$LICENSE_TEMPLATE_NAME" ] && PROJECT_IS_OPEN_SOURCE=1
+
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "set-project-license.sh: missing project-license posture: $POLICY_FILE" >&2
+  echo "        This runs inside an initialized project; the posture file is written by init.sh." >&2
+  exit 1
+fi
+CURRENT="$(cat "$POLICY_FILE")"
+
+# Already answered. Same answer is a re-run and does nothing; a different one is a relicensing,
+# which is the project owner's deliberate act across every repo already stamped — not a flag flip.
+if [ "$CURRENT" != "Unset" ]; then
+  if [ "$CURRENT" = "$PROJECT_LICENSE_ID" ]; then
+    echo "project license: already $PROJECT_LICENSE_ID (nothing to do)"
+    exit 0
+  fi
+  echo "set-project-license.sh: this project's license is already $CURRENT." >&2
+  echo "        This helper answers the question once, for a project that deferred it; it does" >&2
+  echo "        not relicense one. Changing $CURRENT to $PROJECT_LICENSE_ID means rewriting every" >&2
+  echo "        repo stamped from it and every LICENSING.md asserting it, and any copy already" >&2
+  echo "        published stays under $CURRENT. Do it deliberately, not through this script." >&2
+  echo "        Nothing was written." >&2
+  exit 1
+fi
+
+if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ]; then
+  if [ -z "$HOLDER" ]; then
+    echo "set-project-license.sh: --holder is required for $PROJECT_LICENSE_ID (it goes in the copyright line)." >&2
+    exit 2
+  fi
+  TEMPLATE="$DOCS_ROOT/templates/licenses/$LICENSE_TEMPLATE_NAME"
+  if [ ! -f "$TEMPLATE" ]; then
+    echo "set-project-license.sh: project license template is missing: $TEMPLATE" >&2
+    exit 1
+  fi
+fi
+
+# generated_repos — print each directory holding a LICENSING.md this project has not settled yet.
+# Reads: the docs hub, its sibling prompts/, and the workspace root.
+# Writes: nothing (prints one path per line).
+# Returns: 0 always.
+#
+# Those three are every directory init.sh can turn into a generated repo: multi-repo makes the docs
+# hub and prompts/ repos, mono-repo makes the workspace root one. Selecting by the marker rather
+# than by layout means this stays correct whichever one the project used, and skips a directory
+# that is not a generated repo — the marker is only ever written by init.sh's deferred path.
+generated_repos() {
+  local dir
+  for dir in "$DOCS_ROOT" "$DOCS_ROOT/../../prompts" "$DOCS_ROOT/../.."; do
+    [ -f "$dir/LICENSING.md" ] || continue
+    grep -Fq "$DEFERRED_MARKER" "$dir/LICENSING.md" || continue
+    ( cd "$dir" && pwd )
+  done
+}
+
+# write_licensing_summary DIR — replace the deferred summary with the settled one.
+# Reads: PROJECT_LICENSE_ID.
+# Writes: DIR/LICENSING.md.
+# Returns: 0.
+#
+# Identical wording to init.sh's, so a project that deferred the question ends up with the same
+# file a project that answered it at install time would have.
+write_licensing_summary() {
+  if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ]; then
+    cat > "$1/LICENSING.md" <<EOF
+# Licensing
+
+Project-authored content in this repository is licensed under $PROJECT_LICENSE_ID. See
+\`LICENSE\` for the full project license.
+
+\`LICENSE-THROUGHSTONE\` applies only to retained Throughstone-authored scaffold material;
+it does not replace or alter the project license.
+EOF
+  else
+    cat > "$1/LICENSING.md" <<'EOF'
+# Licensing
+
+Project-authored content in this repository is proprietary. No project `LICENSE` is
+provided, and the presence of `LICENSE-THROUGHSTONE` does not grant permission to copy,
+modify, or distribute the project's application code.
+
+`LICENSE-THROUGHSTONE` applies only to retained Throughstone-authored scaffold material.
+EOF
+  fi
+}
+
+REPOS="$(generated_repos)"
+
+# Render the license text once, then copy it, so every repo carries byte-identical terms and the
+# docs hub's canonical copy is the same file apply-project-license.sh will hand to future repos.
+if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ]; then
+  RENDERED="$(mktemp "${TMPDIR:-/tmp}/throughstone-license.XXXXXX")"
+  trap 'rm -f "$RENDERED"' EXIT
+  YEAR="$(date +%Y)" HOLDER="$HOLDER" perl -pe \
+    's/\Q{{YEAR}}\E/$ENV{YEAR}/g; s/\Q{{HOLDER}}\E/$ENV{HOLDER}/g' \
+    "$TEMPLATE" > "$RENDERED"
+  # The docs hub always keeps the canonical copy, whether or not it is itself a generated repo:
+  # apply-project-license.sh reads it from there for every repo the method creates later.
+  cp "$RENDERED" "$DOCS_ROOT/LICENSE"
+  echo "  canonical project license: $DOCS_ROOT/LICENSE"
+  while IFS= read -r repo; do
+    [ -n "$repo" ] || continue
+    [ "$repo" = "$DOCS_ROOT" ] && continue
+    cp "$RENDERED" "$repo/LICENSE"
+    echo "  license: $repo/LICENSE"
+  done <<EOF
+$REPOS
+EOF
+fi
+
+printf '%s\n' "$PROJECT_LICENSE_ID" > "$POLICY_FILE"
+echo "  posture: $POLICY_FILE ($PROJECT_LICENSE_ID)"
+
+# The inventory rows for the repos init.sh created carry the same `Unset` until now. Only that
+# literal is replaced: a row recording an adopted repo's own licensing holds what that repo says,
+# and must not be touched by an answer about this method's material.
+if [ -f "$REGISTRY" ] && grep -Fq 'license: "Unset"' "$REGISTRY"; then
+  PROJECT_LICENSE_ID="$PROJECT_LICENSE_ID" perl -pi -e \
+    's/\Qlicense: "Unset"\E/license: "$ENV{PROJECT_LICENSE_ID}"/g' "$REGISTRY"
+  echo "  repo inventory: $REGISTRY"
+fi
+
+while IFS= read -r repo; do
+  [ -n "$repo" ] || continue
+  write_licensing_summary "$repo"
+  echo "  licensing summary: $repo/LICENSING.md"
+done <<EOF
+$REPOS
+EOF
+
+if [ "$PROJECT_IS_OPEN_SOURCE" = "0" ]; then
+  echo "project license: Proprietary (no LICENSE created)"
+fi
+echo "Commit these changes in each repo they touched."

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -92,8 +92,8 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    and CI starter are retained Throughstone-authored scaffold material, and writes
    `LICENSING.md` to make clear that notice is not the application-code license. **Run it only on
    repos you create** — a repo **registered in place**, which existed before this project did,
-   keeps the licensing its owner set (`METHOD.md` §7: the method records licensing, it never
-   establishes licensing for code it did not create). Record what such a repo uses in its
+   keeps the licensing its owner set (`METHOD.md` §7: a repo the method did not create keeps what
+   it already has — README, CI, and licensing alike). Record what such a repo uses in its
    `registries/repos.yml` `license:` field and move on; the helper refuses it. Repository
    visibility is separate: when adding a remote for each code repo, choose private or public
    deliberately rather than inferring it from the license. Publishing a proprietary repo makes

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -52,8 +52,8 @@
   between the two licenses explicit.
 
   For a repo REGISTERED IN PLACE — one that existed before this project did — do NOT run it.
-  That repo already has an owner and a licensing status; the method records licensing, it never
-  establishes licensing for code it did not create (`METHOD.md` §7). Read what the repo uses
+  That repo already has an owner and a licensing status; a repo the method did not create keeps
+  what it already has, licensing included (`METHOD.md` §7). Read what the repo uses
   (`LICENSE`, `COPYING`, `NOTICE`, package metadata, vendored third-party terms, or a deliberate
   absence), record that, and leave its licensing alone — including when it differs from the
   bootstrap selection, which governs only this method's own artifacts and the repos it creates.

--- a/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
@@ -60,8 +60,9 @@ already true (`METHOD.md` §7). Read the repo root — `LICENSE`, `COPYING`, `NO
 their own terms. Record what you find: an identifier and the file it came from
 (`GPL-2.0 (COPYING)`), or `none stated` when the repo says nothing, which is itself a fact worth
 recording rather than a gap to fill. Where the repo's own files disagree with each other, say so
-instead of picking a winner. Nothing here is compared against, or reconciled with, the license
-chosen at install time.
+instead of picking a winner. This column is what the project's own license question is answered
+from at `inv-4` — read it, name where the repos differ from the answer once, and reconcile
+nothing: the project's license covers the method's material, and each repo here keeps its own.
 
 | Repo | Languages | Frameworks / runtimes | Build / package manager | Licensing (as found) | Notes |
 |------|-----------|-----------------------|-------------------------|----------------------|-------|

--- a/init.sh
+++ b/init.sh
@@ -167,6 +167,9 @@ Options:
   --slug=SLUG            Project slug (lowercase kebab-case, e.g. acme-scheduler)
   --desc=TEXT           One-line description
   --license=NAME        mit | bsd-3 | apache-2.0 | private
+                         With --mode=existing this is optional: left off, the question is
+                         asked at the recon-map checkpoint, once each repo's licensing
+                         has been read. Supplied, it decides now and nothing is deferred.
   --holder=NAME         Copyright holder (required for open-source licenses)
   --layout=LAYOUT       multi | mono                    (default: multi)
   --registries=yes|no   Keep registries/ (mono-repo only; default: yes; always kept
@@ -410,31 +413,34 @@ DESC="$(want "$DESC_IN" 'One-line description')"
 # result is PROJECT_LICENSE_ID, written later to .throughstone/project-license so generated
 # helpers can distinguish proprietary projects from missing LICENSE files.
 #
-# When adopting an existing codebase the question needs its scope said out loud. The repos being
-# adopted already answer "open source or proprietary?" — possibly differently from each other —
-# and a user reading the bare question reasonably thinks they are recording that fact about their
-# code. They are not: this selection covers the documentation hub being created here and anything
-# the method creates later, and their existing repos keep the licensing their owners set (the
-# method records licensing, it never establishes it for code it did not create). The same scope
-# governs the copyright-holder answer below, which is why the note precedes both.
+# Adoption defers the question rather than asking it here. At this moment nobody has read the
+# codebase yet, so the question arrives with nothing to answer it from — while the repos being
+# adopted already carry the answer in their own files. Asked here it also reads as "what is your
+# code licensed under?", which is not what it sets. So --mode=existing leaves the posture Unset
+# and the adoption flow asks once at the recon-map checkpoint, with each repo's licensing in front
+# of the user and what was found as the default. An explicit --license still wins: a caller who
+# has already decided is not made to wait for a scan to confirm it.
 LICENSE_CHOICE=""
-if [ "$MODE" = "existing" ] && [ -z "$LICENSE_IN" ] && [ "$NONINTERACTIVE" != "1" ]; then
-  echo
-  echo "  The next two answers cover the documentation hub Throughstone is creating for you,"
-  echo "  and any repo it creates later — NOT the code you're adopting. Your existing repos keep"
-  echo "  whatever licensing they already have; the agent records what it finds, never changes it."
-fi
 if [ -n "$LICENSE_IN" ]; then
   normalize_license_choice "$LICENSE_IN" \
     || { echo "init.sh: invalid --license '$LICENSE_IN' (mit | bsd-3 | apache-2.0 | private)." >&2; exit 2; }
   LICENSE_CHOICE="$NORMALIZED_LICENSE_CHOICE"
+elif [ "$MODE" = "existing" ]; then
+  LICENSE_CHOICE="deferred"
+  echo
+  echo "  Project license: asked later, once the agent has read your repos. The recon map records"
+  echo "  what each one is licensed under, and the question is put to you there with that in hand."
+  echo "  It covers this documentation hub and anything the method creates later; your existing"
+  echo "  repos keep whatever licensing they already have."
 elif [ "$NONINTERACTIVE" = "1" ]; then
   echo "init.sh: --license is required in --non-interactive mode (mit | bsd-3 | apache-2.0 | private)." >&2; exit 2
 else
   choose_license_interactively
 fi
+# The holder only exists to render a license template. A deferred posture renders none yet, so the
+# question travels with the license question to the recon-map checkpoint.
 HOLDER=""
-if [ "$LICENSE_CHOICE" != "private" ]; then
+if [ "$LICENSE_CHOICE" != "private" ] && [ "$LICENSE_CHOICE" != "deferred" ]; then
   HOLDER="$(want "$HOLDER_IN" 'Copyright holder (name or org)')"
 fi
 LICENSE_TEMPLATE_NAME=""
@@ -454,6 +460,11 @@ case "$LICENSE_CHOICE" in
     ;;
   private)
     PROJECT_LICENSE_ID="Proprietary"
+    ;;
+  deferred)
+    # Adoption only. A real value, not an empty file: helpers must be able to tell "not chosen
+    # yet" from a truncated or missing posture, and say which one they are looking at.
+    PROJECT_LICENSE_ID="Unset"
     ;;
   *)
     echo "init.sh: internal error: unsupported license choice '$LICENSE_CHOICE'." >&2
@@ -790,6 +801,24 @@ WARNING
     exit 2
   fi
 fi
+# The same hazard as the warning above, reached from the other direction: publishing before the
+# license question has been answered puts the content in public with no grant attached. Unlike
+# proprietary, this one is temporary — answering the question at the recon-map checkpoint settles
+# it — so the remedy offered is to publish then, not to choose now with nothing read yet.
+if [ "$MK_REMOTES" = "1" ] \
+  && [ "$REMOTE_VISIBILITY" = "public" ] \
+  && [ "$LICENSE_CHOICE" = "deferred" ]; then
+  cat >&2 <<'WARNING'
+WARNING: public visibility before the project license is chosen publishes this content with no
+license granting anyone the right to use it. The question is answered at the recon-map
+checkpoint; --license=NAME decides it now instead, or keep these repos private until then.
+WARNING
+  if [ "$NONINTERACTIVE" != "1" ] \
+    && ! yesno "Continue with public repositories before the license is chosen?"; then
+    echo "init.sh: public repository creation cancelled." >&2
+    exit 2
+  fi
+fi
 
 # --- 2. Untether from the template origin -----------------------------------
 # Destructive bootstrap boundary. Everything above this line is validation and choice
@@ -856,8 +885,10 @@ mkdir -p "$ROOT/.throughstone"
 printf '%s\n' "$PROJECT_LICENSE_ID" > "$DOCS/.throughstone/project-license"
 
 # The repo inventory records what each repo is licensed under, so fill the seed rows with the same
-# posture. These two repos are ones init.sh creates, so the posture IS their license. A repo
-# registered in place later records what that repo already says instead (registries/repos.yml).
+# posture. These two repos are ones init.sh creates, so the posture IS their license — including
+# when it is still `Unset`, which is the honest value until the question is answered and
+# scripts/set-project-license.sh rewrites both. A repo registered in place later records what that
+# repo already says instead (registries/repos.yml).
 grep -rlF '{{PROJECT_LICENSE}}' . --exclude-dir=.git 2>/dev/null | while read -r f; do
   PROJECT_LICENSE_ID="$PROJECT_LICENSE_ID" perl -pi -e \
     's/\Q{{PROJECT_LICENSE}}\E/$ENV{PROJECT_LICENSE_ID}/g' "$f"
@@ -1035,9 +1066,13 @@ GI
 # Proprietary projects skip LICENSE creation; LICENSE-THROUGHSTONE remains separate and covers
 # only retained scaffold material. In mono-repo mode the docs hub also keeps the canonical copy
 # so apply-project-license.sh has the same source of truth as multi-repo projects.
+#
+# A deferred posture writes nothing for the same reason a proprietary one doesn't: there is no
+# license to render. scripts/set-project-license.sh writes it when the question is answered.
 stamp_license() {
   local src
   [ "$LICENSE_CHOICE" = "private" ] && return 0
+  [ "$LICENSE_CHOICE" = "deferred" ] && return 0
   src="$DOCS/templates/licenses/$LICENSE_TEMPLATE_NAME"
   [ -f "$src" ] || {
     echo "init.sh: project license template disappeared during setup: $src" >&2
@@ -1056,7 +1091,20 @@ stamp_license() {
 # Every generated repo gets LICENSING.md so readers do not mistake LICENSE-THROUGHSTONE for the
 # project's license grant.
 write_licensing_summary() {
-  if [ "$LICENSE_CHOICE" = "private" ]; then
+  if [ "$LICENSE_CHOICE" = "deferred" ]; then
+    # Says the true thing for the window it covers. Silence would read as "proprietary", which
+    # nobody has chosen yet; the default-closed wording keeps that window safe either way.
+    cat > "$1/LICENSING.md" <<'EOF'
+# Licensing
+
+This project has not chosen its license yet. It is chosen once the codebase has been read —
+the recon map records what each adopted repo is licensed under, and the question is put to the
+project's owner there. Until then no project `LICENSE` is provided and no permission to copy,
+modify, or distribute this content is granted.
+
+`LICENSE-THROUGHSTONE` applies only to retained Throughstone-authored scaffold material.
+EOF
+  elif [ "$LICENSE_CHOICE" = "private" ]; then
     cat > "$1/LICENSING.md" <<'EOF'
 # Licensing
 

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -96,6 +96,24 @@ run_case() {
   local repos="$docs/registries/repos.yml"
   local check_in="$docs/runbooks/check-in.md"
 
+  # --- One rule, not four. README, CI, licensing, and the notice are the same rule applied to four
+  # artifacts: a repo the method did not create keeps what it already has. Licensing had grown its
+  # own doctrine paragraph, which is how the method ended up restating the same argument in eight
+  # files and why the next artifact to hit this boundary would have needed a ninth. The heading is
+  # pinned because it is what the consumers cite; drop it and their pointers go stale silently.
+  assert_contains "$docs/METHOD.md" \
+    "**A repo the method did *not* create keeps what it already has.**" \
+    "METHOD.md §7 lost the single rule the per-artifact consequences hang off"
+  assert_contains "$docs/METHOD.md" "This is one rule, not four" \
+    "METHOD.md §7 no longer says the per-artifact rules are one rule"
+  # Licensing is one of those consequences now, not a separate doctrine with its own rationale.
+  assert_absent "$docs/METHOD.md" \
+    "**The method records licensing; it never establishes licensing for code it did not create.**" \
+    "METHOD.md §7 still gives licensing its own rule instead of one line under the general one"
+  # Every write into such a repo goes through one gate, stated once for all four artifacts.
+  assert_contains "$docs/METHOD.md" "proposed before it happens" \
+    "METHOD.md §7 no longer gates every write into an in-place repo on proposing it first"
+
   # --- The README. Stamp what the method creates; augment what it registers, keyed on whether the
   # file exists. The substituted section name doubles as the placeholder check.
   assert_contains "$readme_tpl" "STAMP this into a repo the method CREATES" \

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -289,37 +289,57 @@ run_existing_env_case() {
     || { echo "FAIL: $name (env) did not seed the stub PLAN" >&2; return 1; }
 }
 
-# run_license_scope_note_case — the interactive license/holder questions say what they cover when
-# adopting an existing codebase, and say nothing extra when starting from scratch. Without the
-# note the questions read as "what is your code licensed under?", which is not what they set:
-# a user answering about their existing repos would be choosing the docs hub's license instead.
-run_license_scope_note_case() {
-  local name="retcon-license-note" green="green-license-note"
+# run_deferred_license_case — adoption does not ask the license question at install time, and
+# greenfield still does. Asked here it would arrive before anybody has read the codebase, with
+# nothing to answer it from, and it reads as "what is your code licensed under?" — which is not
+# what it sets. Adoption leaves the posture Unset and the recon-map checkpoint asks it instead.
+run_deferred_license_case() {
+  local name="retcon-license-deferred" green="green-license-question"
   local work="$TMP_ROOT/$name" green_work="$TMP_ROOT/$green"
-  local note="NOT the code you're adopting"
+  local question="Is this project open source"
 
-  # Answers, in order: mode=existing, open source, MIT, copyright holder.
+  # The only answer offered is the mode. Reaching the end without a license prompt is the point:
+  # a stray prompt would consume no input and the run would fail or hang instead of completing.
   copy_template "$work"
   (
     cd "$work"
-    printf '2\n1\n1\nThroughstone Test\n' | ./init.sh \
+    printf '2\n' | ./init.sh \
       --slug="$name" \
-      --desc="Adoption license scope note" \
+      --desc="Adoption defers the license question" \
       --layout=multi \
       --collab=solo \
       --remotes=no
   ) >"$TMP_ROOT/$name.out" 2>&1
 
-  assert_file_contains "$TMP_ROOT/$name.out" "$note"
-  # The note must precede the questions it scopes — after the fact it explains nothing.
-  [ "$(grep -n "$note" "$TMP_ROOT/$name.out" | head -1 | cut -d: -f1)" \
-    -lt "$(grep -n "Is this project open source" "$TMP_ROOT/$name.out" | head -1 | cut -d: -f1)" ] || {
-    echo "FAIL: $name printed the scope note after the license question" >&2
+  if grep -Fq "$question" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name asked the license question before reading the codebase" >&2
+    return 1
+  fi
+  assert_file_contains "$TMP_ROOT/$name.out" "asked later, once the agent has read your repos"
+
+  # Unset is a real value, not an empty file: helpers must tell "not chosen yet" from truncated.
+  local posture="$work/Code/$name-docs/.throughstone/project-license"
+  grep -Fxq "Unset" "$posture" || {
+    echo "FAIL: $name did not leave the posture Unset: $(cat "$posture" 2>&1)" >&2
     return 1
   }
+  # No license is chosen, so none is rendered — and the placeholder summary says so rather than
+  # leaving a reader to infer a posture nobody selected.
+  if [ -e "$work/Code/$name-docs/LICENSE" ]; then
+    echo "FAIL: $name wrote a project LICENSE with no license chosen" >&2
+    return 1
+  fi
+  assert_file_contains "$work/Code/$name-docs/LICENSING.md" "has not chosen its license yet"
+  assert_file_contains "$work/Code/$name-docs/registries/repos.yml" 'license: "Unset"'
   assert_file_contains "$work/Code/$name-docs/overview.md" "PROJECT-STATUS: retcon"
 
-  # Greenfield creates every repo it licenses, so there is nothing to scope and no note.
+  # The checkpoint that asks the question must name the helper that answers it.
+  assert_file_contains "$work/Code/$name-docs/RETCON-PROMPT.md" \
+    "Answer the project-license question here"
+  assert_file_contains "$work/Code/$name-docs/RETCON-PROMPT.md" \
+    "scripts/set-project-license.sh"
+
+  # Greenfield creates every repo it licenses and has nothing to read first, so it still asks.
   copy_template "$green_work"
   (
     cd "$green_work"
@@ -331,11 +351,109 @@ run_license_scope_note_case() {
       --remotes=no
   ) >"$TMP_ROOT/$green.out" 2>&1
 
-  if grep -Fq "$note" "$TMP_ROOT/$green.out"; then
-    echo "FAIL: $green printed the adoption license-scope note" >&2
+  assert_file_contains "$TMP_ROOT/$green.out" "$question"
+  grep -Fxq "MIT" "$green_work/Code/$green-docs/.throughstone/project-license" || {
+    echo "FAIL: $green did not record the license chosen at install time" >&2
+    return 1
+  }
+  assert_file_contains "$green_work/Code/$green-docs/overview.md" "PROJECT-STATUS: not-started"
+}
+
+# run_set_project_license_case — the helper the checkpoint runs. It answers the question once:
+# it renders the license, settles every file init.sh left deferred, and refuses to change an
+# answer already given (relicensing is a deliberate act across repos already stamped, not a
+# flag flip). apply-project-license.sh must also refuse to stamp a repo before the answer exists.
+run_set_project_license_case() {
+  local name="retcon-license-set"
+  local work="$TMP_ROOT/$name" docs
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --mode=existing \
+      --slug="$name" \
+      --desc="Answering the deferred license question" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+  docs="$work/Code/$name-docs"
+
+  # A repo created before the question is answered has no posture to inherit. The refusal must
+  # name the unanswered question, not read as a corrupt file.
+  mkdir -p "$work/early-repo"
+  if "$docs/scripts/apply-project-license.sh" "$work/early-repo" >"$TMP_ROOT/$name.early" 2>&1; then
+    echo "FAIL: $name stamped a repo before the project chose a license" >&2
     return 1
   fi
-  assert_file_contains "$green_work/Code/$green-docs/overview.md" "PROJECT-STATUS: not-started"
+  assert_file_contains "$TMP_ROOT/$name.early" "has not chosen its license yet"
+  if [ -e "$work/early-repo/LICENSE" ] || [ -e "$work/early-repo/LICENSING.md" ]; then
+    echo "FAIL: $name wrote into the target it refused" >&2
+    return 1
+  fi
+
+  # An open-source answer needs a holder for the copyright line; without one nothing is written.
+  if "$docs/scripts/set-project-license.sh" mit >"$TMP_ROOT/$name.noholder" 2>&1; then
+    echo "FAIL: $name rendered an open-source license with no copyright holder" >&2
+    return 1
+  fi
+  grep -Fxq "Unset" "$docs/.throughstone/project-license" || {
+    echo "FAIL: $name changed the posture on a rejected answer" >&2
+    return 1
+  }
+
+  "$docs/scripts/set-project-license.sh" mit --holder "Acme Corp" >"$TMP_ROOT/$name.set" 2>&1 || {
+    echo "FAIL: $name could not answer the deferred license question" >&2
+    return 1
+  }
+  grep -Fxq "MIT" "$docs/.throughstone/project-license" || {
+    echo "FAIL: $name did not record the answer" >&2
+    return 1
+  }
+  assert_file_contains "$docs/LICENSE" "Copyright (c)"
+  assert_file_contains "$docs/LICENSE" "Acme Corp"
+  assert_file_contains "$docs/LICENSING.md" "licensed under MIT"
+  assert_file_contains "$docs/registries/repos.yml" 'license: "MIT"'
+  # Every repo init.sh created carries the same terms, byte for byte.
+  cmp -s "$docs/LICENSE" "$work/prompts/LICENSE" || {
+    echo "FAIL: $name left the generated repos under different license text" >&2
+    return 1
+  }
+  if grep -rlF 'license: "Unset"' "$docs/registries" >/dev/null 2>&1; then
+    echo "FAIL: $name left an unanswered row in the repo inventory" >&2
+    return 1
+  fi
+  if grep -Fq "has not chosen its license yet" "$docs/LICENSING.md"; then
+    echo "FAIL: $name left the deferred licensing summary in place" >&2
+    return 1
+  fi
+
+  # Re-running with the same answer is a no-op; a different one is a relicensing and is refused.
+  "$docs/scripts/set-project-license.sh" mit --holder "Acme Corp" >"$TMP_ROOT/$name.again" 2>&1 || {
+    echo "FAIL: $name failed on an idempotent re-run" >&2
+    return 1
+  }
+  if "$docs/scripts/set-project-license.sh" private >"$TMP_ROOT/$name.change" 2>&1; then
+    echo "FAIL: $name relicensed a project through the answer-once helper" >&2
+    return 1
+  fi
+  assert_file_contains "$TMP_ROOT/$name.change" "already MIT"
+  grep -Fxq "MIT" "$docs/.throughstone/project-license" || {
+    echo "FAIL: $name changed the posture on a refused relicensing" >&2
+    return 1
+  }
+
+  # With the question answered, the repo that was refused earlier stamps normally.
+  "$docs/scripts/apply-project-license.sh" "$work/early-repo" >"$TMP_ROOT/$name.late" 2>&1 || {
+    echo "FAIL: $name could not stamp a repo after the license was chosen" >&2
+    return 1
+  }
+  cmp -s "$docs/LICENSE" "$work/early-repo/LICENSE" || {
+    echo "FAIL: $name stamped different license text than the canonical copy" >&2
+    return 1
+  }
 }
 
 # run_new_case NAME EXTRA_ARGS... — greenfield must be untouched (marker, no PLAN, message).
@@ -514,7 +632,8 @@ run_missing_stub_case() {
 run_existing_case "retcon-multi" multi
 run_existing_case "retcon-mono"  mono
 run_existing_env_case
-run_license_scope_note_case
+run_deferred_license_case
+run_set_project_license_case
 run_new_case "green-explicit" --mode=new
 run_new_case "green-default"
 run_invalid_mode_case

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -153,6 +153,16 @@ run_existing_case() {
     "Licensing (as found)"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing is recorded as found, never set here"
+  # A user who has just chosen the project's license should hear where their own repos don't match
+  # it — once, at the checkpoint where they chose and the licensing column is in front of them.
+  # Both halves are pinned because either one alone is a failure mode: without the telling, the
+  # method silently knows something the user would want; without the bound, an agent re-raises it
+  # at every repo and turns a one-line observation into pressure to relicense.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "say once where their own repos don't match"
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "recorded, not reconciled"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "do not re-raise it here"
   # The frozen map is the snapshot; the inventory row is the living copy. Both must be asked for,
   # and asked for as a copy — deriving the row separately is how two records start disagreeing.
   assert_file_contains "$docs/RETCON-PROMPT.md" "this row's \`license:\` field is"


### PR DESCRIPTION
Adoption asked the license question at install time, alongside the greenfield flow. For greenfield that is right — the project creates everything it licenses, and there is nothing to consult. For adoption it is the one question asked at the worst possible moment: nobody has read the codebase, so the answer comes from memory, while the repos being adopted already state the answer in their own files. Phrased as *"is this project open source or private/proprietary?"* it also reads as a question about the code being brought in, which is not what it sets.

Three changes, one per commit.

## 1. Ask after the scan, not before

`--mode=existing` leaves `.throughstone/project-license` holding `Unset` and the recon-map checkpoint (`inv-4`) asks instead — where **Stack Per Repo** has just recorded each repo's licensing and the user is already reading it, so the question arrives with its own answer beside it and a default to offer.

New `scripts/set-project-license.sh <license> [--holder NAME]` is what the checkpoint runs, so answering is one command rather than five hand-edits that can each be half-done: posture, canonical `LICENSE`, and the `LICENSING.md` and inventory rows init left saying the license had not been chosen. It answers **once** — same answer is a no-op, a different one is refused, because changing a license already in force means rewriting every repo stamped from it and cannot be undone for copies already published.

The window before the answer is default-closed: no `LICENSE`, a `LICENSING.md` that says plainly nothing is granted, a warning on public visibility, and `apply-project-license.sh` refusing an `Unset` posture by naming the unanswered question rather than failing as though the file were corrupt.

**Greenfield is untouched.** `--license=NAME` still decides at install time in either mode, making the deferral opt-out rather than mandatory; it is no longer required under `--non-interactive` when there is a checkpoint to ask at.

## 2. Say where the repos differ — once

The rule said a repo whose license differs is *"not a finding"* and nothing is reconciled. Right about the writing, wrong about the telling: the user answers "MIT" and never hears that two of their own repos say otherwise.

`inv-4` now names them once, right after the answer, and stops. Nothing reconciled, nothing written, no finding or risk row — and where every repo already matches, nothing is said at all. The per-repo substep keeps the prohibition and is told **not** to re-raise it, because an observation worth one line at the checkpoint becomes pressure to relicense when it arrives eight times.

## 3. Licensing is not its own rule

The retcon half of #147. §7's four separate rules for an in-place repo — README, CI, licensing, notice — become one: **a repo the method did not create keeps what it already has**, with the four as consequences and one propose-first gate covering all of them. No behavior change; the files that cited the licensing-specific sentence now cite the general rule.

## Verification

Full suite green (15 files). New coverage in `tests/init-retcon-mode.sh`: that adoption does not prompt and leaves `Unset`; that no `LICENSE` is written meanwhile; that `apply-project-license.sh` refuses and writes nothing; that `set-project-license.sh` requires a holder, settles every deferred file byte-identically across repos, is idempotent, refuses a relicensing, and that the earlier-refused repo then stamps normally. Greenfield still asks and still records its answer.

Also verified by hand end-to-end on multi and mono layouts, open-source and private answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
