### PR TITLE
Stop re-asking a repo's owners after they have already declined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,16 @@ any project built with it.
   written like every other header field, so the literal phrase never appears, and now that its value
   is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
   takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
+- **The same proposal was put to a repo's owners once per repo, after they had already declined.**
+  Every write into a repo registered in place is proposed before it happens, and the text differs
+  per repo, so the gate itself is right. But the question behind it — do you want this in your
+  repos at all? — is the same one every time, and nothing said whether a "no" covered that repo or
+  the practice. A project with several in-place repos therefore re-asked someone who had answered.
+  A decline now establishes which it is, and a standing one stops the proposals and records that
+  those repos document themselves. It carries one way only: a yes is never reused, since the next
+  repo's text is its own proposal and nobody has seen it yet. `METHOD.md` §7 and
+  `templates/repo-readme-template.md` both say so, the latter being the file open at the moment of
+  the write.
 - **The project license could be applied to a repo the method didn't create.** `METHOD.md` §7 lets a
   repo be **registered in place** — referenced where it already sits instead of created under
   `Code/` — but every instruction around `scripts/apply-project-license.sh` was written for a repo

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -527,8 +527,15 @@ project is actually missing. Per artifact that means:
 Every write above is **proposed before it happens** — show the exact text and where it goes, and
 wait for an answer. A decline is a complete outcome, not a gap: the same information lives in the
 architecture doc — and in the `repos.yml` row where the project keeps an inventory, which a
-mono-repo project may not. Choosing or changing what any of these say for an existing repo is its
-owners' act, taken deliberately by them, never a side effect of adding the method to it.
+mono-repo project may not. **A decline may be standing.** Where several repos are registered in
+place, the same proposal is put to the same owners repeatedly, and someone who has said no once is
+not asking to be asked again for every remaining repo — so when a proposal is declined, establish
+whether that answer covers this repo or the rest of them, and where it is standing, stop proposing
+and record that those repos document themselves. Ask that once, not per repo — and note which way
+it runs: it is the answer that is being reused, never the permission, so a yes for one repo says
+nothing about the next, whose text is its own proposal. Choosing or changing what any of these say
+for an existing repo is its owners' act, taken deliberately by them, never a side effect of adding
+the method to it.
 
 **When the rules above don't settle it, ask.** They cover the cases the method has met: a repo it
 creates, and one registered in place that has a README, has none, or whose owners decline the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -279,6 +279,16 @@ affect work you do after pulling them.
   header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
+- **A decline can be standing, so you are not asked once per repo.** Every write into a repo
+  registered in place is proposed first, which is right — but the *question* behind each proposal
+  is the same one every time, so a project with several such repos put it to the same owners repo
+  after repo, and someone who had already said no got asked again for each remaining one. Nothing
+  about the gate changes: the text is still shown and still waits for an answer, because the text
+  differs per repo. What is added is that a decline now establishes whether it covers this repo or
+  the rest, and a standing one stops the proposals and records that those repos document
+  themselves. It runs one way only — a yes is never carried forward, since the next repo's text is
+  its own proposal. Pull `METHOD.md` §7 with `templates/repo-readme-template.md`. **One thing to
+  check:** nothing; this only removes repeat asking.
 - **Licensing is no longer its own rule.** `METHOD.md` §7 had grown a separate doctrine paragraph
   for licensing — "the method records licensing; it never establishes licensing for code it did not
   create" — sitting alongside separate rules for the README, for CI, and for the Throughstone

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -37,6 +37,13 @@
   in the repo's architecture doc, and in its `registries/repos.yml` row where the project keeps
   an inventory.
 
+  A DECLINE MAY BE STANDING. With several repos registered in place this same proposal goes to
+  the same people repo after repo, and someone who has already said no is not asking to be asked
+  again for each remaining one. So on a decline, establish whether it covers this repo or the
+  rest — and where it is standing, stop proposing and record that those repos document
+  themselves. Ask that once, not per repo. The permission is never what carries forward, only
+  the refusal: a yes for one repo says nothing about the next, whose text is its own proposal.
+
   For a repo this method CREATES, stamp the CI gate named by the Test Strategy architecture doc
   too: drop `templates/ci/code-repo-ci.yml` into this repo's `.github/workflows/ci.yml` and fill
   in its stack's test command (see `templates/ci/README.md`). For a repo REGISTERED IN PLACE,

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -141,6 +141,21 @@ run_case() {
     "check-in README sweep does not check that written README the way a created repo's is checked"
   assert_absent "$check_in" "A repo **registered in place** owns its own README" \
     "check-in README sweep still says every in-place repo owns its own README"
+  # A decline carries forward; a yes does not. The gate is per repo because the text is per repo,
+  # but the QUESTION behind it is the same one every time — so a project with several in-place
+  # repos put the same proposal to the same owners repo after repo, and someone who had already
+  # said no got asked again for each remaining one. Both directions are pinned: that a decline can
+  # be standing, and that permission is never what carries (a yes for one repo says nothing about
+  # the next, whose text nobody has seen).
+  assert_contains "$docs/METHOD.md" "**A decline may be standing.**" \
+    "METHOD.md §7 re-asks every in-place repo's owners after they have already declined"
+  assert_contains "$docs/METHOD.md" \
+    "it is the answer that is being reused, never the permission" \
+    "METHOD.md §7's standing decline does not rule out carrying a yes forward"
+  assert_contains "$readme_tpl" "A DECLINE MAY BE STANDING." \
+    "repo README template does not carry the standing-decline rule to the point of the write"
+  assert_contains "$readme_tpl" "The permission is never what carries forward, only" \
+    "repo README template's standing decline does not rule out carrying a yes forward"
 
   # --- CI. The gate fails until configured, so there is no safe way to land it in a running repo.
   # The rule belongs on the artifact being copied, not only in the files that point at it.


### PR DESCRIPTION
Every write into a repo registered in place is proposed before it happens, and that gate is right — the text differs per repo, so it needs its own look. But the *question* behind each proposal is the same one every time (do you want this in your repos at all?), and §7 never said whether a "no" covered that repo or the practice. A project with several in-place repos therefore put the same proposal to the same owners repo after repo, including to someone who had already answered it.

A decline now establishes which it is, and a standing one stops the proposals and records that those repos document themselves. Asked once, not per repo.

## It runs one way only

Worth stating outright, and pinned by a test in both directions: **the answer carries forward, never the permission.** A no can stand for the rest because refusing is a decision about the practice. A yes cannot, because it was given for one repo's text and nobody has seen the next one's yet.

## What does not change

The gate itself. The text is still shown, still waits for an answer, and a decline is still a complete outcome rather than a gap — the framing lives in the architecture doc and the inventory row either way. The check-in sweep already treats a declined addition as "not a gap to close here", so a standing decline needs nothing there.

## Files

- `METHOD.md` §7 — the rule, under the existing propose-first gate.
- `templates/repo-readme-template.md` — the same rule at the point of the write, which is the file an agent actually has open then.
- `CHANGELOG.md`, `UPDATING-THROUGHSTONE.md` — entry and migration note.
- `tests/init-inplace-repo-rules.sh` — pins both files, and both directions of the carry.

Full suite green (13 files).

## Scope note

Greenfield-inert in the usual sense — it only fires for a repo registered in place. This is the base half of a pair; the adoption half adds a `Docs (as found)` column to the recon map and says once what it shows, so the per-repo proposals arrive with the shape already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
