### PR TITLE
Record whether each adopted repo explains itself, and say the total once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,14 @@ error/corruption and re-run paths, not normal operation.
     repo's architecture doc, and its inventory row — and nothing else in the README is touched.
     What decides this is whether a README is already there, not that the repo was adopted: where a
     repo has none, adoption offers to write one from the template — that one file, since adopting
-    a repo scaffolds nothing else in it.
+    a repo scaffolds nothing else in it. **You are told the shape of this before it starts, and
+    asked once if you don't want it.** The recon map's new **Docs (as found)** column records, per
+    repo, whether it explains its place in the system, so confirming the map also tells you what
+    is coming — *"11 of your 14 repos have a README that doesn't say what it is within the system;
+    3 have none"* — instead of proposals arriving one at a time from nowhere. That line is an
+    observation, not a gate: nothing asks for a blanket yes before any text exists, because the
+    text is what you are agreeing to. And a decline can stand for the rest, so you say no once
+    rather than once per repo.
   - **Your CI is left alone, and the Throughstone notice follows what was actually added.**
     Adoption never installs Throughstone's CI workflow into a repo you already have — that gate
     fails until configured, so in a running system it would either replace the workflow gating your

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -144,7 +144,8 @@ is complete.
 ### `inv-3` — Draft the recon map
 Copy `templates/reports/recon-map-report-template.md` to `reports/YYYY-MM-DD-step-0001-recon-map.md`
 and fill every section from the scan: inventory, stack per repo (including each repo's licensing
-**as found** — recorded, never set), entry points/services, data stores,
+**as found** — recorded, never set — and whether its README says what the repo is *within the
+system*), entry points/services, data stores,
 integrations, existing-docs classification + trust, tests/CI, and the confidence/unknowns. Propose a
 **Scope** for each Inventory row (`adopt` unless the code says otherwise) — the user settles it at
 `inv-4`; a draft proposal is not the decision. Stamp the
@@ -201,6 +202,16 @@ Nothing is reconciled and nothing is written into those repos: the choice just m
 method's material, not theirs. What comes of it is the user's call on their own code. Say it here
 so the per-repo substeps don't have to raise it eight more times; if every repo already matches,
 say nothing at all rather than reporting a clean comparison nobody asked for.
+
+**Say what the docs column adds up to, too.** The **Docs (as found)** column has just recorded, per
+repo, whether it explains its place in the system — so give the user the shape of it in one line
+before Stage 2 starts working through them: *"11 of your 14 repos have a README that doesn't say
+what it is within the system; 3 have none at all."* That is the whole of it here. **Do not turn it
+into a gate** — do not ask now whether they want READMEs touched, and do not collect a blanket yes.
+Each repo's addition is proposed with its own text when its substep comes up, because the text is
+what they are agreeing to and none of it is written yet. This line exists so that when those
+proposals start arriving they are expected and their number is known, rather than appearing one at
+a time from nowhere. If they decline early on, `METHOD.md` §7 lets that decline stand for the rest.
 
 Once the map is confirmed and frozen, mark `inv-4` **Done**.
 
@@ -333,6 +344,14 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   writing into a repo they own. **A no is a complete answer, not a gap:** the same information is
   already in the recon map, the repo's `architecture/` doc, and its `repos.yml` row, so record
   that the repo documents itself and move on.
+  **And a no can stand for the rest.** This same proposal reaches the same people once per repo,
+  which in a fourteen-repo system is fourteen times — so on a decline, ask whether it covers this
+  repo or all of them, and where it is standing, stop proposing and record the remaining repos as
+  documenting themselves (`METHOD.md` §7). Ask that once. It runs one way: a yes is never carried
+  forward, because the next repo's text is its own proposal and they haven't seen it.
+  Which repos need what is already known — the map's **Docs (as found)** column recorded it at
+  `inv-3` and `inv-4` said the shape out loud — so this arrives expected rather than as a surprise
+  fourteen times over.
   **Never install CI into an adopted repo.** `templates/ci/code-repo-ci.yml` is the gate for a repo
   the method creates, and it is failing-until-configured by design — so dropping it into a running
   system either replaces the workflow that gates their merges or fails every build until someone

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -382,6 +382,18 @@ All but the last are documentation only; nothing you already produced is rewritt
   `registries/repos.yml` — now quote the general rule rather than a licensing-specific one. Pull
   those five with `METHOD.md`. **One thing to check:** nothing; if you have local edits quoting the
   old licensing sentence, they are still true, just narrower than the rule they came from.
+- **The recon map records whether each repo explains itself, and a decline can be standing.**
+  Adoption's one offer to a repo it did not create is the framing its README probably lacks, and
+  which repos need it was rediscovered one at a time at the moment of writing into each. The map's
+  **Stack Per Repo** table gains a **Docs (as found)** column — `role stated` / `README, no role` /
+  `none` — recorded during the scan like the licensing column beside it, and the recon-map
+  checkpoint says the total out loud so the per-repo proposals arrive expected. That line is
+  deliberately **not** a gate: no blanket yes is collected before any text exists, and each repo's
+  addition is still proposed with its own text and still waits. What changes for someone who does
+  not want it is that a decline can now stand for the remaining repos (`METHOD.md` §7) instead of
+  being re-asked per repo. Pull `templates/reports/recon-map-report-template.md` with
+  `RETCON-PROMPT.md`. **One thing to check:** a recon map already written has no such column —
+  leave it alone, since a confirmed map is frozen; the per-repo work reads the repo itself anyway.
 - **Adoption chooses its license after reading the codebase, not at install time.**
   `init.sh --mode=existing` used to ask the license question up front, alongside the greenfield
   flow. At that moment nobody has read the repos yet, so the question arrives with nothing to

--- a/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
@@ -64,9 +64,18 @@ instead of picking a winner. This column is what the project's own license quest
 from at `inv-4` — read it, name where the repos differ from the answer once, and reconcile
 nothing: the project's license covers the method's material, and each repo here keeps its own.
 
-| Repo | Languages | Frameworks / runtimes | Build / package manager | Licensing (as found) | Notes |
-|------|-----------|-----------------------|-------------------------|----------------------|-------|
-| {{repo}} | {{langs}} | {{frameworks, runtime versions}} | {{tool}} | {{identifier (file it came from) / none stated; + vendored terms}} | {{monorepo? generated code? notable pins}} |
+**Whether each repo explains itself is recorded the same way.** Adoption's one offer to a repo it
+did not create is the framing its README probably lacks — a `Role in <project>` section where a
+README exists, the file itself where none does (`METHOD.md` §7). Which of those a repo needs is a
+fact about the repo, so read it here rather than rediscovering it one repo at a time later: does a
+`README` exist at all, and if it does, does it say what this repo is *within the system* — not
+just what it does on its own. Record one of `role stated`, `README, no role`, or `none`. Like the
+licensing column this is a record, not a verdict: a repo whose README explains it perfectly needs
+nothing, and `none` on a small internal library is a fact, not a failing.
+
+| Repo | Languages | Frameworks / runtimes | Build / package manager | Licensing (as found) | Docs (as found) | Notes |
+|------|-----------|-----------------------|-------------------------|----------------------|-----------------|-------|
+| {{repo}} | {{langs}} | {{frameworks, runtime versions}} | {{tool}} | {{identifier (file it came from) / none stated; + vendored terms}} | {{role stated / README, no role / none}} | {{monorepo? generated code? notable pins}} |
 
 ## Entry Points & Services
 

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -151,6 +151,22 @@ run_existing_case() {
     "\`scripts/apply-project-license.sh\` against any of these repos"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing (as found)"
+  # Whether a repo explains its place in the system is a fact about the repo, recorded once during
+  # the scan like its licensing — not rediscovered per repo at the moment of writing into it. The
+  # column is what lets inv-4 say the shape out loud and the substeps arrive expected.
+  assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
+    "Docs (as found)"
+  assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
+    "role stated / README, no role / none"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "Say what the docs column adds up to"
+  # The line is an observation, never a gate. A blanket yes collected before any text exists would
+  # be consent to writes nobody has seen — the opposite of what the per-repo proposal is for — so
+  # both halves are pinned: say the shape, and do not turn it into an approval.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "**Do not turn it"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "do not collect a blanket yes"
+  # A decline carries to the remaining repos; a yes never does.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "**And a no can stand for the rest.**"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "a yes is never carried"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing is recorded as found, never set here"
   # A user who has just chosen the project's license should hear where their own repos don't match


### PR DESCRIPTION
The adoption half of #149. Adoption's one offer to a repo it did not create is the framing its README probably lacks — a `Role in <project>` section where a README exists, the file itself where none does. Which of those a repo needs was being rediscovered one repo at a time, at the moment of writing into each, so the user met the proposals one at a time too with no idea how many were coming.

## Record it during the scan

**Stack Per Repo** gains a **Docs (as found)** column — `role stated` / `README, no role` / `none` — read alongside the licensing column beside it, which is the same shape of fact about the repo. `inv-3` fills it; `inv-4` says the total out loud:

> 11 of your 14 repos have a README that doesn't say what it is within the system; 3 have none at all.

The per-repo proposals now arrive expected, and their number is known before the first one lands.

## Deliberately not a gate

This is the part I'd most want a second look at. The line **asks for nothing and collects no blanket yes** — a yes given before any text exists is consent to writes nobody has seen, which is exactly what the per-repo proposal exists to prevent. Each repo's addition is still shown as text, in its own substep, and still waits. Both halves are pinned by tests: say the shape, and do not turn it into an approval.

Nothing about what gets written changes. README missing → written from the template. README present → a Role section added, nothing else touched. Either way the exact text is shown first.

## The retcon half of the standing decline

A no can cover the remaining repos instead of being re-asked once per repo. One way only, same as the base rule: a yes is never carried forward, because the next repo's text is its own proposal.

## Files

- `templates/reports/recon-map-report-template.md` — the column, and how to read it (a record, not a verdict: `none` on a small internal library is a fact, not a failing).
- `RETCON-PROMPT.md` — `inv-3` fills it, `inv-4` says the total, the per-repo substep carries the standing decline.
- `CHANGELOG.md`, `UPDATING-THROUGHSTONE.md` — entry and migration note.
- `tests/init-retcon-mode.sh` — column present and its values, the say-once line, that it is not a gate, and both directions of the carry.

Full suite green (15 files).

## Ordering

#149 should land first — this references `METHOD.md` §7 for the standing decline. Both are additive to prose only; no script or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
