### PR TITLE
Never make a repository public without being told to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,20 @@ any project built with it.
   written like every other header field, so the literal phrase never appears, and now that its value
   is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
   takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
+- **A repo's remote and visibility had no rule, and publishing was never stated as needing a
+  go-ahead.** §7 listed what the method does to a repo it did not create — README, CI, licensing,
+  the Throughstone notice — and covered remotes and visibility only by the general "a repo
+  registered in place is not scaffolded at all". A general statement followed by a list reads as
+  covering the list; that is the same gap that once let the license helper assume every repo was
+  one the method had scaffolded, and it left the one action here that cannot be reverted with
+  nothing pinning it. **Remote and visibility are now stated as the repo's owners':** no remote is
+  created for a repo that has one, no existing remote is repointed, no visibility is changed, and
+  the URL the repo already has is recorded in its `remote:` field instead. **And a separate,
+  broader rule now covers every repo, created ones included: nothing is made public without an
+  explicit go-ahead** — never inferred from an open-source license, a public sibling repo, or a
+  project describing itself as open source, and private wherever no answer was given. `init.sh`
+  already defaulted to private and still does; no tooling changed. The planning session and the
+  repo README template carry both rules to where the scaffolding actually happens.
 - **The same proposal was put to a repo's owners once per repo, after they had already declined.**
   Every write into a repo registered in place is proposed before it happens, and the text differs
   per repo, so the gate itself is right. But the question behind it — do you want this in your

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -523,6 +523,11 @@ project is actually missing. Per artifact that means:
   and a `LICENSING.md` that names only what the notice covers and disclaims the rest of the
   repository. Where the addition was declined, nothing Throughstone-authored is there and nothing
   is owed; do not copy `LICENSE-THROUGHSTONE` into a repo that holds none of it.
+- **Remote and visibility — its owners'.** A repo that predates the method already lives somewhere
+  and is already private or public, and both were somebody's decision. Do not create a remote for
+  one that has one, and do not repoint an existing remote. Record `remote:` in
+  `registries/repos.yml` as the cloneable URL the repo already has, so
+  `scripts/setup-workspace.sh` can find it, and change nothing about the repo itself.
 
 Every write above is **proposed before it happens** — show the exact text and where it goes, and
 wait for an answer. A decline is a complete outcome, not a gap: the same information lives in the
@@ -536,6 +541,22 @@ it runs: it is the answer that is being reused, never the permission, so a yes f
 nothing about the next, whose text is its own proposal. Choosing or changing what any of these say
 for an existing repo is its owners' act, taken deliberately by them, never a side effect of adding
 the method to it.
+
+**Nothing is made public without the user saying so, in words, for that thing.** This is not part
+of the list above — it governs every repo, the ones the method creates as much as the ones it
+finds. Making a repository public, publishing a package or a release, or putting anything else
+where strangers can read it happens **only** on an explicit go-ahead. Never infer it: not from an
+open-source license (a repo can be MIT and unpublished), not from a sibling repo being public, not
+from a remote being created, and not from a project describing itself as open source. Where no
+answer has been given, the answer is private — `init.sh` defaults that way for exactly this reason,
+and a public choice there is typed, never defaulted into.
+
+The rule is absolute because the mistake is the one that cannot be walked back. Every other error
+in this section writes a file, and a file can be reverted. Publishing hands a repository's whole
+history — every commit, every key ever committed and later removed, every customer name in a
+fixture — to forks, caches, and crawlers, and it does so in less time than it takes to notice.
+Setting the repo private again retrieves none of it. So when visibility is even adjacent to what
+you are doing, stop and ask; a question costs one message, and there is no undo on the other side.
 
 **When the rules above don't settle it, ask.** They cover the cases the method has met: a repo it
 creates, and one registered in place that has a README, has none, or whose owners decline the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -279,6 +279,22 @@ affect work you do after pulling them.
   header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
+- **Nothing is made public without you saying so, and an in-place repo's remote is left alone.**
+  §7 listed what happens to a repo the method did not create — its README, its CI, its licensing,
+  the Throughstone notice — and said nothing about its remote or its visibility. The general
+  "a repo registered in place is not scaffolded at all" was meant to cover them, but a general
+  statement followed by a list reads as covering the list, which is the same gap that once let the
+  license helper assume every repo was one the method had scaffolded. Two rules now say it
+  outright. **Remote and visibility are the repo's owners':** create no remote for a repo that has
+  one, repoint no existing one, change no visibility; record the URL it already has in its
+  `remote:` field and leave the repo alone. **And nothing is made public without an explicit
+  go-ahead** — for any repo, including ones the method creates. Public is never inferred from an
+  open-source license, a public sibling, or a project describing itself as open source; with no
+  answer given the answer is private. `init.sh` already defaulted that way, so no tooling changes;
+  what changes is that the rule is stated where an agent reads it. Pull `METHOD.md` §7 with
+  `templates/planning-session.md` and `templates/repo-readme-template.md`. **One thing to check:**
+  if a repo you registered in place had its visibility changed while adopting it, that is worth
+  looking at now — publishing cannot be undone, and a repo made public stays retrievable.
 - **A decline can be standing, so you are not asked once per repo.** Every write into a repo
   registered in place is proposed first, which is right — but the *question* behind each proposal
   is the same one every time, so a project with several such repos put it to the same owners repo

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -79,7 +79,7 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    STEP is almost always *"scaffold the repos and the skeleton"*: create each new code repo from
    `templates/repo-readme-template.md`, wire up the chosen stack, CI, and the environment/secrets
    baseline from the Environments architecture doc, plus any interface contract artifact placeholders or repo-local contract files
-   named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each repo as its
+   named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each new code repo as its
    `.env.example`, and adding a **stack-appropriate `.gitignore`** to each new code repo
    (language/build artifacts — `node_modules/`, `__pycache__/`, `target/`, `dist/`, … — plus
    the `.env` / `.secrets/` secret-file block so local secrets never get committed). Apply the
@@ -95,9 +95,12 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    keeps the licensing its owner set (`METHOD.md` §7: a repo the method did not create keeps what
    it already has — README, CI, and licensing alike). Record what such a repo uses where its
    inventory entry describes it and move on; the helper refuses it. Repository
-   visibility is separate: when adding a remote for each code repo, choose private or public
-   deliberately rather than inferring it from the license. Publishing a proprietary repo makes
-   its source visible without granting open-source reuse rights, so call that out explicitly.
+   visibility is separate: when adding a remote for a repo **you are creating**, choose private or
+   public deliberately rather than inferring it from the license — and **take public only from an
+   explicit go-ahead**, never from an open-source license, a public sibling repo, or the project
+   describing itself as open source. With no answer given, create it private: that is reversible
+   and publishing is not (`METHOD.md` §7). Publishing a proprietary repo also makes its source
+   visible without granting open-source reuse rights, so call that out explicitly.
    **Each
    repo's README isn't just stamped — its role one-liner and Overview get filled in** (what
    the repo is and the slice of the system it owns), and the repo gets a row in
@@ -111,7 +114,11 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    template over it. **If it has none:** write its README from the template. Either way it is the
    user's repo, so show them what you intend to add and where, and wait for a yes. **Its CI is
    its own** — never install `templates/ci/code-repo-ci.yml` into it; record what it runs in the
-   Test Strategy doc. If the README addition is accepted, run
+   Test Strategy doc. **Its remote and its visibility are its own too** — it already lives
+   somewhere and is already private or public, so create no remote for it, repoint no existing one,
+   and **never change its visibility**. Record the cloneable URL it already has in its `remote:`
+   field so `scripts/setup-workspace.sh` can find it, and change nothing about the repo. If the
+   README addition is accepted, run
    `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <repo-path>` to place the
    Throughstone notice for that retained material; if it was declined, nothing is owed.
    Confirm the repo list with the user — on a first run they're all new; note any

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -51,6 +51,14 @@
   would either replace what gates their merges or fail every build until removed. Record what the
   repo already runs and leave its pipeline alone.
 
+  NOTHING IS MADE PUBLIC WITHOUT THE USER SAYING SO. For a repo REGISTERED IN PLACE this is
+  absolute — it already lives somewhere and is already private or public, so create no remote for
+  it, repoint no existing one, and never change its visibility. For a repo this method CREATES,
+  public is a typed answer and never an inference: not from an open-source license, not from a
+  sibling repo being public, not from the project calling itself open source. With no answer given,
+  private. Publishing is the one mistake here that cannot be reverted — it hands the repo's whole
+  history to forks, caches, and crawlers before anyone notices (`METHOD.md` §7).
+
   For a repo this method CREATES, apply the project license established at bootstrap by running
   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <this-repo-path>`. It copies the
   docs hub's canonical `LICENSE` unchanged for open-source projects. Proprietary projects

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -95,6 +95,7 @@ run_case() {
   local ci_readme="$docs/templates/ci/README.md"
   local repos="$docs/registries/repos.yml"
   local check_in="$docs/runbooks/check-in.md"
+  local planning="$docs/templates/planning-session.md"
 
   # --- One rule, not four. README, CI, licensing, and the notice are the same rule applied to four
   # artifacts: a repo the method did not create keeps what it already has. Licensing had grown its
@@ -156,6 +157,32 @@ run_case() {
     "repo README template does not carry the standing-decline rule to the point of the write"
   assert_contains "$readme_tpl" "The permission is never what carries forward, only" \
     "repo README template's standing decline does not rule out carrying a yes forward"
+
+  # --- Remote and visibility. The fifth artifact, and the only one whose failure cannot be
+  # reverted: publishing hands a repo's whole history to forks, caches, and crawlers before anyone
+  # notices, and setting it private again retrieves none of it. Every other rule here writes a file
+  # that `git revert` undoes. It was also the one artifact §7 enumerated nothing for, which is the
+  # exact shape of the original defect — a general "not scaffolded at all" followed by a list, read
+  # as covering only what the list named.
+  assert_contains "$docs/METHOD.md" "**Remote and visibility — its owners'.**" \
+    "METHOD.md §7 has no rule for an in-place repo's remote and visibility"
+  assert_contains "$docs/METHOD.md" \
+    "**Nothing is made public without the user saying so, in words, for that thing.**" \
+    "METHOD.md §7 does not state the publishing rule for every repo, created ones included"
+  # Inference is the failure mode worth naming: a license, a sibling, or a self-description is not
+  # an answer about visibility, and treating one as an answer is how a private repo gets published.
+  assert_contains "$docs/METHOD.md" "Never infer it: not from an" \
+    "METHOD.md §7's publishing rule does not rule out inferring public from a license or sibling"
+  assert_contains "$readme_tpl" "NOTHING IS MADE PUBLIC WITHOUT THE USER SAYING SO." \
+    "repo README template does not carry the publishing rule to the point of scaffolding"
+  assert_contains "$planning" "take public only from an" \
+    "planning session lets a repo be created public without an explicit go-ahead"
+  assert_contains "$planning" "**Its remote and its visibility are its own too**" \
+    "planning session's in-place paragraph says nothing about remotes or visibility"
+  # The same paragraph scoped .gitignore to new repos and .env.example to "each repo" — the loose
+  # half would have an agent writing into a repo the method did not create.
+  assert_absent "$planning" "into each repo as its" \
+    "planning session still copies .env.example into every repo, not only the ones it creates"
 
   # --- CI. The gate fails until configured, so there is no safe way to land it in a running repo.
   # The rule belongs on the artifact being copied, not only in the files that point at it.


### PR DESCRIPTION
§7 listed four things the method does to a repo it did not create — README, CI, licensing, the Throughstone notice — and covered that repo's **remote and visibility** only by the general *"a repo registered in place is not scaffolded at all"*.

A general statement followed by a list reads as covering the list. That is the same shape as the defect this section was written to fix: §7 already allowed in-place repos, but every instruction around the license helper assumed a scaffolded one. Here it left unpinned the single action in the whole section that **cannot be reverted**.

## Two rules, because they are two different things

**Remote and visibility belong to the repo's owners.** It already lives somewhere and is already private or public, both somebody's decision — so create no remote for a repo that has one, repoint no existing one, change no visibility. Record the URL it already has in `remote:`, where `setup-workspace.sh` reads it, and change nothing about the repo.

**Nothing is made public without the user saying so, in words, for that thing.** This one is deliberately *not* on the in-place list — it governs every repo, the ones the method creates as much as the ones it finds. Public is never inferred: not from an open-source license (a repo can be MIT and unpublished), not from a sibling repo being public, not from a project calling itself open source. Where no answer was given, the answer is private.

## Why absolute

Every other error in §7 writes a file, and a file can be reverted. Publishing hands a repository's whole history — every commit, every key committed and later removed, every customer name in a fixture — to forks, caches, and crawlers in less time than it takes to notice. Making it private again retrieves none of it.

## No tooling change

`init.sh` already defaults `REMOTE_VISIBILITY=private` and requires an explicit `--visibility=public`; I verified that before writing the claim into §7. Nothing about the scripts changes — only where the rule is written down.

## Files

- `METHOD.md` §7 — the fifth consequence, and the publishing rule as its own statement above the ask-when-unclear fallback.
- `templates/planning-session.md` — both rules at the point of scaffolding; its in-place paragraph previously said nothing about remotes.
- `templates/repo-readme-template.md` — the publishing rule in the block an agent has open while scaffolding.
- `CHANGELOG.md`, `UPDATING-THROUGHSTONE.md` — entry and migration note, the latter flagging that a visibility change made during an adoption is worth looking at now.
- `tests/init-inplace-repo-rules.sh` — both rules, the never-infer clause, and the `.env.example` scoping below.

## Drive-by in the same sentence

The planning session had `.gitignore` scoped to *new* repos and `.env.example` scoped to *"each repo"* in one line. The loose half is now scoped like the other, and pinned by an `assert_absent`.

Full suite green (13 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
