### PR TITLE
Never publish or repoint an adopted repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,16 @@ error/corruption and re-run paths, not normal operation.
     observation, not a gate: nothing asks for a blanket yes before any text exists, because the
     text is what you are agreeing to. And a decline can stand for the rest, so you say no once
     rather than once per repo.
+  - **Your repos are never published, and their remotes are never touched.** Adoption said nothing
+    about either — every repo it registers already lives somewhere and is already private or
+    public, both decisions made before the project existed. It now says so outright: no remote is
+    created for a repo that has one, no existing remote is repointed, and **no repository's
+    visibility is changed, in either direction, for any reason.** The URL a repo already has is
+    recorded in its inventory row so `scripts/setup-workspace.sh` can find it, and nothing about
+    the repo itself is touched. If you ask for a repo to be published, that is a go-ahead for that
+    repo and nothing else — never standing, never extended to a sibling. Adoption is where this
+    matters most: many repos in flight across a codebase the method didn't write, and publishing
+    is the one action here with no undo.
   - **Your CI is left alone, and the Throughstone notice follows what was actually added.**
     Adoption never installs Throughstone's CI workflow into a repo you already have — that gate
     fails until configured, so in a running system it would either replace the workflow gating your

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -358,6 +358,19 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   deletes it. These repos already have CI; the recon map's **Tests & CI** section recorded what
   each one runs, and session `1.12` writes that up. Bringing a repo onto the standard gate is a
   change its owners decide on later, not a side effect of adoption.
+  **Never touch an adopted repo's remote, and never change its visibility.** Every repo here
+  already lives somewhere and is already private or public — both somebody's decision, made before
+  this project existed. So create no remote for it, repoint no existing one, and
+  **change no repository's visibility, in either direction, for any reason.** Adoption has no
+  business doing it: nothing here needs a remote created, and a repo's audience is not something a
+  scan can infer.
+  Put the URL it already has in its `remote:` field so `scripts/setup-workspace.sh` can find it,
+  and leave the repo alone (`METHOD.md` §7). **If the user asks for a repo to be published, that is
+  an explicit go-ahead for that repo and nothing else** — never a standing one, never extended to a
+  sibling, and worth confirming once more before it happens, because publishing a repository hands
+  its entire history to forks, caches, and crawlers and making it private again retrieves none of
+  it. Adoption is the exact circumstance where this matters most: you are working across a stranger's
+  private codebase, at speed, with more repos in flight than anyone is tracking closely.
   **Place the Throughstone notice only if something Throughstone-authored landed.** If the README
   addition was accepted, that section is BSD-3-Clause scaffold material, so run
   `scripts/apply-project-license.sh --notice-only <repo-path>` — it writes `LICENSE-THROUGHSTONE`

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -382,6 +382,17 @@ All but the last are documentation only; nothing you already produced is rewritt
   `registries/repos.yml` — now quote the general rule rather than a licensing-specific one. Pull
   those five with `METHOD.md`. **One thing to check:** nothing; if you have local edits quoting the
   old licensing sentence, they are still true, just narrower than the rule they came from.
+- **Adoption never touches a repo's remote or its visibility.** `RETCON-PROMPT.md` had no rule for
+  either — it did not mention remotes at all — while adoption is the circumstance where the mistake
+  is easiest and least recoverable: many repos in flight across a codebase the method did not
+  write. It now says it outright, beside the never-install-CI rule it sits next to: create no remote
+  for a repo that has one, repoint no existing one, and change no repository's visibility in either
+  direction for any reason; record the URL the repo already has in its `remote:` field and leave
+  the repo alone. A request to publish a specific repo is a go-ahead for **that repo only** — never
+  standing, never extended to a sibling. Pull `RETCON-PROMPT.md` with `METHOD.md` §7, which carries
+  the general form of both rules. **One thing to check:** if a repo's visibility was changed during
+  an adoption, look at it now — a repo that was made public stays retrievable regardless of what it
+  is set to today.
 - **The recon map records whether each repo explains itself, and a decline can be standing.**
   Adoption's one offer to a repo it did not create is the framing its README probably lacks, and
   which repos need it was rediscovered one at a time at the moment of writing into each. The map's

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -167,6 +167,16 @@ run_existing_case() {
   # A decline carries to the remaining repos; a yes never does.
   assert_file_contains "$docs/RETCON-PROMPT.md" "**And a no can stand for the rest.**"
   assert_file_contains "$docs/RETCON-PROMPT.md" "a yes is never carried"
+  # Remotes and visibility. The file said nothing at all about either — it had zero occurrences of
+  # "remote" — while adoption is the exact circumstance where the mistake is easiest and worst: a
+  # stranger's private codebase, many repos in flight, and no undo once one is published. Both the
+  # never-touch rule and the scope of a go-ahead are pinned; a go-ahead that silently covered
+  # siblings would be the whole failure, dressed as permission.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "**Never touch an adopted repo's remote, and never change its visibility.**"
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "change no repository's visibility, in either direction, for any reason"
+  assert_file_contains "$docs/RETCON-PROMPT.md" "never a standing one, never extended to a"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing is recorded as found, never set here"
   # A user who has just chosen the project's license should hear where their own repos don't match


### PR DESCRIPTION
The adoption half of #151. `RETCON-PROMPT.md` had **no rule for either** — the file did not contain the word "remote" anywhere, and said nothing about visibility.

That is the worst place for the gap to be. Adoption is the exact circumstance where the mistake is easiest to make and worst to make: a codebase the method did not write, many repos in flight at once, and no undo on the far side of one of them being published.

## The rule

Sits beside the never-install-CI rule it belongs with. Every repo here already lives somewhere and is already private or public, both decided before this project existed — so create no remote for one, repoint no existing one, and **change no repository's visibility, in either direction, for any reason.** Record the URL the repo already has in its `remote:` field, where `setup-workspace.sh` reads it, and leave the repo alone.

## The scope of a go-ahead

Stated explicitly, because that is where a rule like this actually fails in practice. A request to publish a repository is permission for **that repository and nothing else** — never standing, never extended to a sibling, and worth confirming once more before it happens. A go-ahead that silently covered siblings would be the whole failure mode, dressed up as permission. Pinned by a test.

## Files

- `RETCON-PROMPT.md` — the rule in the per-repo substep, next to CI.
- `CHANGELOG.md`, `UPDATING-THROUGHSTONE.md` — entry and migration note; the latter flags that a visibility change made during an adoption is worth looking at now, since a repo that was made public stays retrievable regardless of its current setting.
- `tests/init-retcon-mode.sh` — the never-touch rule, the in-either-direction clause, and the scope of a go-ahead.

Full suite green (15 files). Prose only; no script or behavior changes.

## Ordering

#151 should land first — this is the adoption half of the general rules it puts in `METHOD.md` §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
