### PR TITLE
Close the gaps a full review of the in-place repo rules found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,20 @@ any project built with it.
   written like every other header field, so the literal phrase never appears, and now that its value
   is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
   takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
+- **Nothing said what happened after an accepted change was written into a repo you already had.**
+  Four files told an agent to propose the `Role in <project>` section and wait for a yes, and none
+  said what to do once the file changed on disk — no branch, no commit, no push. The obvious
+  continuation was to commit onto whatever branch was checked out (usually `main` on a running
+  system) and push it. A yes settles what the text should say, not how it reaches a trunk; that is
+  the team's own process. The method now creates a branch, commits **only the file(s) proposed** —
+  never `git add -A`, which would sweep up work in progress — reports the branch and commit, and
+  stops. No push, no pull request, no merge, and no committing around uncommitted changes to the
+  same file.
+- **`ARCHITECTURE.md` could be added to a repo the method didn't create.** §7 stated it unscoped in
+  its general repo paragraph, and the comment suggesting one sits in the repo README template's
+  Overview section — which is what an in-place repo with no README gets written from, and adopted
+  repos are exactly the ones with real internal complexity. Now scoped to repos the method creates;
+  an in-place repo's internal design goes in the docs hub's `architecture/` instead.
 - **A repo's remote and visibility had no rule, and publishing was never stated as needing a
   go-ahead.** §7 listed what the method does to a repo it did not create — README, CI, licensing,
   the Throughstone notice — and covered remotes and visibility only by the general "a repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,19 @@ any project built with it.
   written like every other header field, so the literal phrase never appears, and now that its value
   is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
   takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
+- **A remote is created only when you ask for one.** §7 said "do not create a remote for a repo
+  that has one", which by implication permitted creating one for a repo that has none — pushing
+  code to a host its owners never picked. The rule now covers every repo the same way, and it is
+  what the method already did where it creates repos: `init.sh` sets up no remotes unless asked,
+  and asks before it does. A repo registered without a remote is not missing one.
+- **The gate said "every write above is proposed" over five bullets, only two of which are
+  writes.** The README addition and the Throughstone notice that follows it put a file in the
+  repo; CI, licensing, and remote/visibility are things the method *doesn't* do, so there is
+  nothing to propose or decline for them. §7 now names the two, which is also what makes the
+  decline rules below it parse.
+- **The ask-when-unclear fallback listed only README and licensing cases.** It read as an
+  exhaustive list and had fallen behind two artifacts; it is now explicitly illustrative, with a
+  visibility and a remote example among them, so it stops needing an edit per rule added.
 - **Nothing said what happened after an accepted change was written into a repo you already had.**
   Four files told an agent to propose the `Role in <project>` section and wait for a yes, and none
   said what to do once the file changed on disk — no branch, no commit, no push. The obvious

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,16 +147,20 @@ any project built with it.
   written like every other header field, so the literal phrase never appears, and now that its value
   is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
   takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
-- **A remote is created only when you ask for one.** §7 said "do not create a remote for a repo
-  that has one", which by implication permitted creating one for a repo that has none — pushing
-  code to a host its owners never picked. The rule now covers every repo the same way, and it is
-  what the method already did where it creates repos: `init.sh` sets up no remotes unless asked,
-  and asks before it does. A repo registered without a remote is not missing one.
+- **A repo's remote changes only when you ask.** §7 said "do not create a remote for a repo that
+  has one", which by implication permitted creating one for a repo that has none — pushing code to
+  a host its owners never picked — and said nothing about removing one. The rule now names all
+  three verbs (never created, repointed, or removed as a side effect) and covers every repo the
+  same way, which is what the method already did where it creates them: `init.sh` sets up no
+  remotes unless asked, and asks before it does. A repo registered without a remote is not missing
+  one; it is recorded as local.
 - **The gate said "every write above is proposed" over five bullets, only two of which are
   writes.** The README addition and the Throughstone notice that follows it put a file in the
   repo; CI, licensing, and remote/visibility are things the method *doesn't* do, so there is
-  nothing to propose or decline for them. §7 now names the two, which is also what makes the
-  decline rules below it parse.
+  nothing to propose or decline for them. §7 now names the two — and says that only the README
+  addition is actually put to the repo's owners, since the notice follows automatically from an
+  addition they have already accepted rather than being a second question. That is also what makes
+  the decline rules below the gate parse.
 - **The ask-when-unclear fallback listed only README and licensing cases.** It read as an
   exhaustive list and had fallen behind two artifacts; it is now explicitly illustrative, with a
   visibility and a remote example among them, so it stops needing an edit per rule added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,10 +170,13 @@ any project built with it.
   stops. No push, no pull request, no merge, and no committing around uncommitted changes to the
   same file.
 - **`ARCHITECTURE.md` could be added to a repo the method didn't create.** §7 stated it unscoped in
-  its general repo paragraph, and the comment suggesting one sits in the repo README template's
+  its general repo paragraph, and the comment calling for one sits in the repo README template's
   Overview section — which is what an in-place repo with no README gets written from, and adopted
-  repos are exactly the ones with real internal complexity. Now scoped to repos the method creates;
-  an in-place repo's internal design goes in the docs hub's `architecture/` instead.
+  repos are exactly the ones with real internal complexity. **Both** now scope it to repos the
+  method creates: scoping §7 alone would have left the contradiction in the file an agent actually
+  has open while writing into somebody else's repository. An in-place repo's internal design goes
+  in the docs hub's `architecture/` instead, and where such a repo already has an `ARCHITECTURE.md`
+  of its own it is read and linked, never rewritten.
 - **A repo's remote and visibility had no rule, and publishing was never stated as needing a
   go-ahead.** §7 listed what the method does to a repo it did not create — README, CI, licensing,
   the Throughstone notice — and covered remotes and visibility only by the general "a repo

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -550,7 +550,9 @@ out — that branch is often `main` on a running system, and often has someone e
 the working tree already has uncommitted changes to a file being touched, stop and say so rather
 than committing around them. This is the last unguarded step in the list above: everything before
 it decides *what* goes into somebody else's repository, and this decides how far the method carries
-it, which is exactly as far as a local commit they can inspect, amend, or delete. **A decline may be standing.** Where several repos are registered in
+it, which is exactly as far as a local commit they can inspect, amend, or delete.
+
+**A decline may be standing.** Where several repos are registered in
 place, the same proposal is put to the same owners repeatedly, and someone who has said no once is
 not asking to be asked again for every remaining repo — so when a proposal is declined, establish
 whether that answer covers this repo or the rest of them, and where it is standing, stop proposing

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -529,12 +529,22 @@ project is actually missing. Per artifact that means:
   repository. Where the addition was declined, nothing Throughstone-authored is there and nothing
   is owed; do not copy `LICENSE-THROUGHSTONE` into a repo that holds none of it.
 - **Remote and visibility — its owners'.** A repo that predates the method already lives somewhere
-  and is already private or public, and both were somebody's decision. Do not create a remote for
-  one that has one, and do not repoint an existing remote. Record `remote:` in
-  `registries/repos.yml` as the cloneable URL the repo already has, so
-  `scripts/setup-workspace.sh` can find it, and change nothing about the repo itself.
+  and is already private or public, and both were somebody's decision. Do not repoint an existing
+  remote. Record `remote:` in `registries/repos.yml` as the cloneable URL the repo already has, so
+  `scripts/setup-workspace.sh` can find it, and change nothing about the repo itself. **A remote is
+  created only when the user asks for one** — for any repo, this one or a new one. That is already
+  how the method works where it creates repos: `init.sh` sets up no remotes unless asked, and asks
+  before it does. So a repo with **no** remote is not missing one; it is a repo whose owners have
+  not put it on a server, and creating one would push their code somewhere they did not choose.
+  Record it as local and move on.
 
-Every write above is **proposed before it happens** — show the exact text and where it goes, and
+**Exactly two of those five put a file in the repo: the README addition, and the Throughstone
+notice that follows it when the addition is accepted.** The other three are things the method
+*doesn't* do — it does not install CI, does not set licensing, does not touch a remote or a
+visibility setting — so there is nothing to propose for them and nothing to decline. Everything
+below is about those two.
+
+Each is **proposed before it happens** — show the exact text and where it goes, and
 wait for an answer. A decline is a complete outcome, not a gap: the same information lives in the
 architecture doc — and in the `repos.yml` row where the project keeps an inventory, which a
 mono-repo project may not.
@@ -580,10 +590,13 @@ you are doing, stop and ask; a question costs one message, and there is no undo 
 
 **When the rules above don't settle it, ask.** They cover the cases the method has met: a repo it
 creates, and one registered in place that has a README, has none, or whose owners decline the
-addition. A real project produces ones they don't obviously reach — a repo the method created that
-another team has since taken over, a README that is half boilerplate, a repo whose own files
-disagree about its license, a notice `scripts/apply-project-license.sh --notice-only` refuses to
-place after the README text has already landed. Where it is genuinely unclear which side of the
+addition. A real project produces ones they don't obviously reach. **These are examples, not a
+list to complete** — the point is the habit, and any rule above can produce a case it doesn't
+reach: a repo the method created that another team has since taken over, a README that is half
+boilerplate, a repo whose own files disagree about its license, a notice
+`scripts/apply-project-license.sh --notice-only` refuses to place after the README text has
+already landed, a repo that is already public and whose owners hadn't realized it, a remote
+pointing at a host the team abandoned two migrations ago. Where it is genuinely unclear which side of the
 created / registered-in-place line a repo sits on, or what a rule above means for it, **stop and
 ask, and write nothing into that repo until you have an answer**. Not writing is recoverable;
 writing into a repo the method did not create is the failure this section exists to prevent, and

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -481,8 +481,9 @@ filled in when the repo is scaffolded (with a matching one-line `description` in
 `registries/repos.yml`); a repo **the method creates** with real internal complexity adds an
 `ARCHITECTURE.md` at its root for its internal design. Not every repo gets one — it is a judgment
 call about complexity, not part of the scaffold — and a repo the method did not create never gets
-one, since that is a file appearing at the root of somebody else's repository (below). **Every application-code repo the method *creates* also inherits
-the license posture and the CI gate.** Read the authoritative license selection from the docs
+one, since that is a file appearing at the root of somebody else's repository (below).
+**Every application-code repo the method *creates* also inherits the license posture and the CI
+gate.** Read the authoritative license selection from the docs
 hub's `.throughstone/project-license`. That file records the license for **Throughstone-authored
 and method-created material** — this docs hub, `prompts/`, and any repo the method creates — which
 in a project built from scratch is everything, and in a project that also references code it did
@@ -531,23 +532,27 @@ project is actually missing. Per artifact that means:
   repository. Where the addition was declined, nothing Throughstone-authored is there and nothing
   is owed; do not copy `LICENSE-THROUGHSTONE` into a repo that holds none of it.
 - **Remote and visibility — its owners'.** A repo that predates the method already lives somewhere
-  and is already private or public, and both were somebody's decision. Do not repoint an existing
-  remote. Record `remote:` in `registries/repos.yml` as the cloneable URL the repo already has, so
-  `scripts/setup-workspace.sh` can find it, and change nothing about the repo itself. **A remote is
-  created only when the user asks for one** — for any repo, this one or a new one. That is already
-  how the method works where it creates repos: `init.sh` sets up no remotes unless asked, and asks
-  before it does. So a repo with **no** remote is not missing one; it is a repo whose owners have
-  not put it on a server, and creating one would push their code somewhere they did not choose.
-  Record it as local and move on.
+  and is already private or public, and both were somebody's decision. Visibility is governed by
+  the publishing rule below, which covers every repo; this bullet is about the remote.
+  **A repo's remote changes only when the user asks: never created, repointed, or removed as a
+  side effect of anything here.** That is already how the method works where it creates repos —
+  `init.sh` sets up no remotes unless asked, and asks before it does — so it is one answer for
+  every repo rather than a special case for this one. A repo with **no** remote is therefore not
+  missing one; it is a repo whose owners have not put it on a server, and creating one would push
+  their code somewhere they did not choose. Record `remote:` in `registries/repos.yml` as the
+  cloneable URL the repo already has, so `scripts/setup-workspace.sh` can find it, or record it as
+  local where there is none — and change nothing about the repo itself.
 
 **Exactly two of those five put a file in the repo: the README addition, and the Throughstone
-notice that follows it when the addition is accepted.** The other three are things the method
-*doesn't* do — it does not install CI, does not set licensing, does not touch a remote or a
-visibility setting — so there is nothing to propose for them and nothing to decline. Everything
-below is about those two.
+notice that follows it.** The other three are things the method *doesn't* do — it does not install
+CI, does not set licensing, does not touch a remote or a visibility setting — so there is nothing
+to propose for them and nothing to decline. Of the two, only the **README addition** is put to the
+owners. The notice follows from it automatically and is not asked about separately: it exists to
+mark material they have just agreed to take, so a second question about it would be asking
+permission to label what they already said yes to.
 
-Each is **proposed before it happens** — show the exact text and where it goes, and
-wait for an answer. A decline is a complete outcome, not a gap: the same information lives in the
+**That addition is proposed before it happens** — show the exact text and where it goes, and wait
+for an answer. A decline is a complete outcome, not a gap: the same information lives in the
 architecture doc — and in the `repos.yml` row where the project keeps an inventory, which a
 mono-repo project may not.
 
@@ -560,12 +565,12 @@ them the branch and the commit, and let them take it through their own process. 
 open a pull request, do not merge, and do not commit onto whatever branch happened to be checked
 out — that branch is often `main` on a running system, and often has someone else's work on it. If
 the working tree already has uncommitted changes to a file being touched, stop and say so rather
-than committing around them. This is the last unguarded step in the list above: everything before
-it decides *what* goes into somebody else's repository, and this decides how far the method carries
-it, which is exactly as far as a local commit they can inspect, amend, or delete.
+than committing around them. The rules above decide *what* goes into somebody else's repository;
+this one decides how far the method carries it, which is exactly as far as a local commit they can
+inspect, amend, or delete.
 
-**A decline may be standing.** Where several repos are registered in
-place, the same proposal is put to the same owners repeatedly, and someone who has said no once is
+**A decline may be standing.** Where several repos are registered in place, the same proposal is
+put to the same owners repeatedly, and someone who has said no once is
 not asking to be asked again for every remaining repo — so when a proposal is declined, establish
 whether that answer covers this repo or the rest of them, and where it is standing, stop proposing
 and record that those repos document themselves. Ask that once, not per repo — and note which way
@@ -598,8 +603,9 @@ reach: a repo the method created that another team has since taken over, a READM
 boilerplate, a repo whose own files disagree about its license, a notice
 `scripts/apply-project-license.sh --notice-only` refuses to place after the README text has
 already landed, a repo that is already public and whose owners hadn't realized it, a remote
-pointing at a host the team abandoned two migrations ago. Where it is genuinely unclear which side of the
-created / registered-in-place line a repo sits on, or what a rule above means for it, **stop and
+pointing at a host the team abandoned two migrations ago.
+Where it is genuinely unclear which side of the created / registered-in-place line a repo sits on,
+or what a rule above means for it, **stop and
 ask, and write nothing into that repo until you have an answer**. Not writing is recoverable;
 writing into a repo the method did not create is the failure this section exists to prevent, and
 the question costs one message. This is a fallback for a case the rules don't reach — not an

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -478,8 +478,10 @@ decision/section, ADR, issue/follow-up STEP, incident report under `reports/inci
 check-in report under `reports/` — then add the register row. **Every repo carries a README explaining
 what it is** — its role and the slice of the system it owns — stamped from that template and
 filled in when the repo is scaffolded (with a matching one-line `description` in
-`registries/repos.yml`); a repo with real internal complexity adds an `ARCHITECTURE.md` at
-its root for its internal design. **Every application-code repo the method *creates* also inherits
+`registries/repos.yml`); a repo **the method creates** with real internal complexity adds an
+`ARCHITECTURE.md` at its root for its internal design. Not every repo gets one — it is a judgment
+call about complexity, not part of the scaffold — and a repo the method did not create never gets
+one, since that is a file appearing at the root of somebody else's repository (below). **Every application-code repo the method *creates* also inherits
 the license posture and the CI gate.** Read the authoritative license selection from the docs
 hub's `.throughstone/project-license`. That file records the license for **Throughstone-authored
 and method-created material** — this docs hub, `prompts/`, and any repo the method creates — which
@@ -491,7 +493,7 @@ unchanged to the new repo root; for `Proprietary`, the new repo gets no project 
 visible `LICENSING.md` — a scaffolded repo *does* hold Throughstone-authored material, the README
 and CI starter, and its notice has to stay distinguishable from the project's own license grant.
 
-**A repo the method did *not* create keeps what it already has.** This is one rule, not four. Such
+**A repo the method did *not* create keeps what it already has.** This is one rule, not five. Such
 a repo — **registered in place** (below) — existed before the method reached it, and its owners
 already decided how it is documented, gated, and licensed. Adding this method to a project is not
 an occasion to overturn any of those decisions; the job is to record them and supply only what the
@@ -505,7 +507,10 @@ project is actually missing. Per artifact that means:
   **no** README there is nothing to preserve, so write it from the
   template — every section but Licensing, which describes a repo the method created and is left
   out here as it is when augmenting. That is the one file; nothing else about the repo is
-  scaffolded.
+  scaffolded — including the `ARCHITECTURE.md` the template's Overview comment suggests for a
+  complex repo, which is exactly the kind of repo being adopted. An in-place repo's internal design
+  is written up in the docs hub's `architecture/`, where the project's own docs live, not as a new
+  file at the root of a repository the method does not own.
 - **CI — its own.** `templates/ci/code-repo-ci.yml` fails until configured, so installing it would
   replace or break whatever already gates that repo's merges. Record what it runs instead.
 - **Licensing — recorded as found.** The repo already has a licensing status: a `LICENSE`, a
@@ -532,7 +537,20 @@ project is actually missing. Per artifact that means:
 Every write above is **proposed before it happens** — show the exact text and where it goes, and
 wait for an answer. A decline is a complete outcome, not a gap: the same information lives in the
 architecture doc — and in the `repos.yml` row where the project keeps an inventory, which a
-mono-repo project may not. **A decline may be standing.** Where several repos are registered in
+mono-repo project may not.
+
+**An accepted write is committed and left there. It is never pushed.** A yes settles what the text
+should say; it does not say anything about how that change should reach the repo's trunk, and every
+team has its own answer — a PR, a review, a signed commit, a CI gate, a release train. So make the
+edit on a **branch** created for it, commit **only the file(s) proposed** (name them explicitly;
+never `git add -A`, which would sweep up whatever the owners had in progress), and stop. Then tell
+them the branch and the commit, and let them take it through their own process. Do not push, do not
+open a pull request, do not merge, and do not commit onto whatever branch happened to be checked
+out — that branch is often `main` on a running system, and often has someone else's work on it. If
+the working tree already has uncommitted changes to a file being touched, stop and say so rather
+than committing around them. This is the last unguarded step in the list above: everything before
+it decides *what* goes into somebody else's repository, and this decides how far the method carries
+it, which is exactly as far as a local commit they can inspect, amend, or delete. **A decline may be standing.** Where several repos are registered in
 place, the same proposal is put to the same owners repeatedly, and someone who has said no once is
 not asking to be asked again for every remaining repo — so when a proposal is declined, establish
 whether that answer covers this repo or the rest of them, and where it is standing, stop proposing

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -507,10 +507,12 @@ project is actually missing. Per artifact that means:
   **no** README there is nothing to preserve, so write it from the
   template — every section but Licensing, which describes a repo the method created and is left
   out here as it is when augmenting. That is the one file; nothing else about the repo is
-  scaffolded — including the `ARCHITECTURE.md` the template's Overview comment suggests for a
-  complex repo, which is exactly the kind of repo being adopted. An in-place repo's internal design
-  is written up in the docs hub's `architecture/`, where the project's own docs live, not as a new
-  file at the root of a repository the method does not own.
+  scaffolded — in particular no `ARCHITECTURE.md`, which the template calls for in a *created*
+  repo with real internal complexity and which adopted repos, being exactly that kind of repo,
+  would otherwise attract. An in-place repo's internal design is written up in the docs hub's
+  `architecture/`, where the project's own docs live, not as a second new file at the root of a
+  repository the method does not own. Where such a repo already has an `ARCHITECTURE.md`, it is
+  its owners': read it, link it, leave it.
 - **CI — its own.** `templates/ci/code-repo-ci.yml` fails until configured, so installing it would
   replace or break whatever already gates that repo's merges. Record what it runs instead.
 - **Licensing — recorded as found.** The repo already has a licensing status: a `LICENSE`, a

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -279,6 +279,25 @@ affect work you do after pulling them.
   header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
+- **An accepted change to a repo you already had is committed on a branch and left there.** §7 said
+  to propose the `Role in <project>` section and wait for a yes, and then said nothing about what
+  happens after the file changes on disk — no branch, no commit, no push. The obvious continuation
+  was to commit onto whatever branch was checked out, which on a running system is usually `main`,
+  and push it to their remote. A yes settles what the text should say; it says nothing about how
+  that change should reach a trunk, and every team has its own answer. So the method now makes a
+  branch, commits **only the file(s) proposed** (never `git add -A`, which would sweep up work in
+  progress), tells you the branch and commit, and stops — no push, no pull request, no merge. If
+  the working tree already has uncommitted changes to that file, it stops and says so instead.
+  Pull `METHOD.md` §7 with `templates/planning-session.md` and `templates/repo-readme-template.md`.
+  **One thing to check:** if an earlier run committed such a change onto a shared branch or pushed
+  it, that commit is still there and is worth reviewing like any other.
+- **An `ARCHITECTURE.md` is never added to a repo you already had.** §7 said "a repo with real
+  internal complexity adds an `ARCHITECTURE.md` at its root" in its general repo paragraph, without
+  scoping it — and the comment suggesting one lives in the repo README template's Overview section,
+  which is exactly what gets written for an in-place repo that has no README. Adopted repos are
+  also exactly the ones with real internal complexity. It is now scoped to repos the method
+  creates; an in-place repo's internal design is written up in the docs hub's `architecture/`
+  instead. **One thing to check:** nothing, unless a run added such a file to a repo of yours.
 - **Nothing is made public without you saying so, and an in-place repo's remote is left alone.**
   §7 listed what happens to a repo the method did not create — its README, its CI, its licensing,
   the Throughstone notice — and said nothing about its remote or its visibility. The general
@@ -309,8 +328,8 @@ affect work you do after pulling them.
   for licensing — "the method records licensing; it never establishes licensing for code it did not
   create" — sitting alongside separate rules for the README, for CI, and for the Throughstone
   notice. They were always the same rule applied to four artifacts: **a repo the method did not
-  create keeps what it already has.** §7 now states that once, with the four as consequences under
-  it and one gate covering all of them (propose the exact text, wait for an answer). **No behavior
+  create keeps what it already has.** §7 now states that once, with each of them as a consequence
+  under it and one gate covering all of them (propose the exact text, wait for an answer). **No behavior
   changes** — every individual rule says what it said, and the helpers are untouched. What changes
   is that the rationale lives in one place instead of being re-derived in each, and the files that
   cite it — `AGENTS.md`, the planning session, and the repo README template — now quote the general

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -279,6 +279,16 @@ affect work you do after pulling them.
   header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
+- **A remote is created only when you ask for one, and the in-place rules read straight.** Three
+  wording fixes in §7, no behavior change. *Remotes:* the rule said "do not create a remote for a
+  repo that has one", implying you could create one for a repo that has none — it now covers every
+  repo the same way, matching what `init.sh` already does (no remotes unless asked). *The gate:*
+  "every write above is proposed" sat over five bullets of which only two are writes, so it now
+  names them — the README addition and the Throughstone notice that follows it — and says the other
+  three are things the method doesn't do. *The fallback:* its case list was README- and
+  licensing-only and read as exhaustive; it is now explicitly illustrative and includes a
+  visibility and a remote example. Pull `METHOD.md` §7 with `templates/planning-session.md` and
+  `templates/repo-readme-template.md`. **One thing to check:** nothing.
 - **An accepted change to a repo you already had is committed on a branch and left there.** §7 said
   to propose the `Role in <project>` section and wait for a yes, and then said nothing about what
   happens after the file changes on disk — no branch, no commit, no push. The obvious continuation

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -279,15 +279,18 @@ affect work you do after pulling them.
   header field. It now takes any `Coverage:` field whose value isn't `full`. Pull
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
-- **A remote is created only when you ask for one, and the in-place rules read straight.** Three
+- **A repo's remote changes only when you ask, and the in-place rules read straight.** Three
   wording fixes in §7, no behavior change. *Remotes:* the rule said "do not create a remote for a
-  repo that has one", implying you could create one for a repo that has none — it now covers every
-  repo the same way, matching what `init.sh` already does (no remotes unless asked). *The gate:*
-  "every write above is proposed" sat over five bullets of which only two are writes, so it now
-  names them — the README addition and the Throughstone notice that follows it — and says the other
-  three are things the method doesn't do. *The fallback:* its case list was README- and
-  licensing-only and read as exhaustive; it is now explicitly illustrative and includes a
-  visibility and a remote example. Pull `METHOD.md` §7 with `templates/planning-session.md` and
+  repo that has one", implying you could create one for a repo that has none, and said nothing
+  about removing one — it now names all three verbs (never created, repointed, or removed as a
+  side effect) and covers every repo the same way, matching what `init.sh` already does (no
+  remotes unless asked). *The gate:* "every write above is proposed" sat over five bullets of
+  which only two are writes, so it now names them — the README addition and the Throughstone
+  notice that follows it — says the other three are things the method doesn't do, and says that
+  only the README addition is put to the repo's owners, the notice following automatically from an
+  addition they already accepted. *The fallback:* its case list was README- and licensing-only and
+  read as exhaustive; it is now explicitly illustrative and includes a visibility and a remote
+  example. Pull `METHOD.md` §7 with `templates/planning-session.md` and
   `templates/repo-readme-template.md`. **One thing to check:** nothing.
 - **An accepted change to a repo you already had is committed on a branch and left there.** §7 said
   to propose the `Role in <project>` section and wait for a yes, and then said nothing about what

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -95,10 +95,11 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    keeps the licensing its owner set (`METHOD.md` §7: a repo the method did not create keeps what
    it already has — README, CI, and licensing alike). Record what such a repo uses where its
    inventory entry describes it and move on; the helper refuses it. Repository
-   visibility is separate — and comes up only if remotes are being added at all. **A remote is
-   created only when the user asks for one**, for any repo: `init.sh` sets none up unless asked, and
-   a repo already registered without one is not missing a remote, it is a repo its owners have not
-   put on a server (`METHOD.md` §7). When adding a remote for a repo **you are creating**, choose private or
+   visibility is separate, and comes up only if remotes are being added at all.
+   **A remote is created only when the user asks for one**, for any repo: `init.sh` sets none up
+   unless asked, and a repo already registered without one is not missing a remote — it is a repo
+   its owners have not put on a server (`METHOD.md` §7).
+   When adding a remote for a repo **you are creating**, choose private or
    public deliberately rather than inferring it from the license — and **take public only from an
    explicit go-ahead**, never from an open-source license, a public sibling repo, or the project
    describing itself as open source. With no answer given, create it private: that is reversible

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -111,8 +111,14 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    it (above). The one thing it may still be owed is the role-and-place framing its README
    probably lacks, and what to do keys on whether a README is there. **If it has one:** add a
    short `Role in {{PROJECT}}` section and leave every existing section alone — never stamp the
-   template over it. **If it has none:** write its README from the template. Either way it is the
-   user's repo, so show them what you intend to add and where, and wait for a yes. **Its CI is
+   template over it. **If it has none:** write its README from the template — that one file, and
+   not the `ARCHITECTURE.md` its Overview comment suggests for a complex repo; an in-place repo's
+   internal design is written up in the docs hub's `architecture/`, not as a new file at its root.
+   Either way it is the user's repo, so show them what you intend to add and where, and wait for a
+   yes. **On a yes, commit it on a branch and stop** — commit only the file you proposed, never
+   `git add -A`, and **never push, open a PR, or merge**. Tell them the branch and commit and let
+   them take it through their own process; how a change reaches their trunk is theirs to decide
+   (`METHOD.md` §7). **Its CI is
    its own** — never install `templates/ci/code-repo-ci.yml` into it; record what it runs in the
    Test Strategy doc. **Its remote and its visibility are its own too** — it already lives
    somewhere and is already private or public, so create no remote for it, repoint no existing one,

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -95,7 +95,10 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    keeps the licensing its owner set (`METHOD.md` §7: a repo the method did not create keeps what
    it already has — README, CI, and licensing alike). Record what such a repo uses where its
    inventory entry describes it and move on; the helper refuses it. Repository
-   visibility is separate: when adding a remote for a repo **you are creating**, choose private or
+   visibility is separate — and comes up only if remotes are being added at all. **A remote is
+   created only when the user asks for one**, for any repo: `init.sh` sets none up unless asked, and
+   a repo already registered without one is not missing a remote, it is a repo its owners have not
+   put on a server (`METHOD.md` §7). When adding a remote for a repo **you are creating**, choose private or
    public deliberately rather than inferring it from the license — and **take public only from an
    explicit go-ahead**, never from an open-source license, a public sibling repo, or the project
    describing itself as open source. With no answer given, create it private: that is reversible

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -106,13 +106,17 @@
      (link that for the full picture). This section is required — a repo without it doesn't
      explain itself.
 
-     For a repo THIS METHOD CREATED with real internal complexity, a README paragraph isn't
-     enough: add an `ARCHITECTURE.md` at the repo root for its internal design — the main
-     modules, key flows, and *why* it's built this way (the codebase-level counterpart to the
-     hub's system-wide `architecture/` docs) — and link it from here. Skip it for a simple repo.
+     An `ARCHITECTURE.md` at the repo root splits the same way everything above does — on
+     whether this method created the repo. Check that before reading either branch:
 
-     NOT for a repo REGISTERED IN PLACE, including one whose README you are writing from this
-     template because it had none. That would be a second new file at the root of somebody
+     A REPO THIS METHOD CREATED, with real internal complexity, gets one: a README paragraph
+     isn't enough, so add an `ARCHITECTURE.md` at the root for its internal design — the main
+     modules, key flows, and *why* it's built this way (the codebase-level counterpart to the
+     hub's system-wide `architecture/` docs) — and link it from here. Skip it for a simple repo;
+     it is a judgment call about complexity, not something every repo gets.
+
+     A REPO REGISTERED IN PLACE NEVER GETS ONE — not even when you are writing its README from
+     this template because it had none. That would be a second new file at the root of somebody
      else's repository, and adopted repos are exactly the ones with real internal complexity, so
      this is the paragraph most likely to be read the wrong way. Their internal design is written
      up in the docs hub's `architecture/` instead (`METHOD.md` §7). If such a repo already has an

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -106,10 +106,18 @@
      (link that for the full picture). This section is required — a repo without it doesn't
      explain itself.
 
-     For a repo with real internal complexity, a README paragraph isn't enough: add an
-     `ARCHITECTURE.md` at the repo root for its internal design — the main modules, key
-     flows, and *why* it's built this way (the codebase-level counterpart to the hub's
-     system-wide `architecture/` docs) — and link it from here. Skip it for a simple repo. -->
+     For a repo THIS METHOD CREATED with real internal complexity, a README paragraph isn't
+     enough: add an `ARCHITECTURE.md` at the repo root for its internal design — the main
+     modules, key flows, and *why* it's built this way (the codebase-level counterpart to the
+     hub's system-wide `architecture/` docs) — and link it from here. Skip it for a simple repo.
+
+     NOT for a repo REGISTERED IN PLACE, including one whose README you are writing from this
+     template because it had none. That would be a second new file at the root of somebody
+     else's repository, and adopted repos are exactly the ones with real internal complexity, so
+     this is the paragraph most likely to be read the wrong way. Their internal design is written
+     up in the docs hub's `architecture/` instead (`METHOD.md` §7). If such a repo already has an
+     `ARCHITECTURE.md` of its own, it is theirs: read it, link it from the `Role in {{PROJECT}}`
+     section if useful, and leave it alone. -->
 
 ## Licensing
 

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -37,6 +37,14 @@
   in the repo's architecture doc, and in its `registries/repos.yml` row where the project keeps
   an inventory.
 
+  ON A YES, COMMIT IT ON A BRANCH AND STOP. A yes settles what the text says, not how it should
+  reach their trunk — every team has its own answer to that. So make a branch, commit only the
+  file(s) you proposed (name them; never `git add -A`, which sweeps up whatever they had in
+  progress), and tell them the branch and commit. NEVER push, open a pull request, merge, or
+  commit onto whatever branch is checked out — that is usually `main` on a running system. If the
+  working tree already has uncommitted changes to that file, stop and say so instead of committing
+  around them.
+
   A DECLINE MAY BE STANDING. With several repos registered in place this same proposal goes to
   the same people repo after repo, and someone who has already said no is not asking to be asked
   again for each remaining one. So on a decline, establish whether it covers this repo or the

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -93,7 +93,7 @@
 
   EVERYTHING ABOVE SPLITS ON ONE QUESTION: did this method create this repo, or did the repo get
   here first? Where that is genuinely unclear, or where the answer doesn't settle what to do with
-  this repo's README, CI, license, or notice, ASK THE USER AND WRITE NOTHING UNTIL THEY ANSWER
+  this repo's README, CI, license, notice, remote, or visibility, ASK THE USER AND WRITE NOTHING UNTIL THEY ANSWER
   (`METHOD.md` §7). The question costs one message; the wrong write lands in a repo this method
   does not own. That is a fallback for a case these rules don't reach, not a substitute for
   following them where they do.

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -185,9 +185,13 @@ run_case() {
   # none, and its Overview comment called for an ARCHITECTURE.md unconditionally — so §7 said one
   # thing and the file in front of the agent said another. Scoping §7 alone would leave the
   # contradiction exactly where it does the damage.
-  assert_contains "$readme_tpl" "For a repo THIS METHOD CREATED with real internal complexity" \
-    "repo README template still calls for an ARCHITECTURE.md in any complex repo"
-  assert_contains "$readme_tpl" "NOT for a repo REGISTERED IN PLACE, including one whose README" \
+  # Both branches lead with their scope, in the same caps-led shape as STAMP/AUGMENT above. The
+  # affirmative used to open the paragraph with its qualifier fifteen words ahead of the verb, so
+  # a reader hit "add an ARCHITECTURE.md at the repo root" while still holding the scope — which
+  # is how this reads as a contradiction with the prohibition below it.
+  assert_contains "$readme_tpl" "A REPO THIS METHOD CREATED, with real internal complexity, gets one" \
+    "repo README template still calls for an ARCHITECTURE.md before naming which repos it means"
+  assert_contains "$readme_tpl" "A REPO REGISTERED IN PLACE NEVER GETS ONE" \
     "repo README template does not rule out an ARCHITECTURE.md for an in-place repo"
   # A repo that brought its own ARCHITECTURE.md keeps it — read and link, never rewrite.
   assert_contains "$readme_tpl" "it is theirs: read it, link it from the" \

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -130,6 +130,27 @@ run_case() {
   # Every write into such a repo goes through one gate, stated once for all the artifacts.
   assert_contains "$docs/METHOD.md" "proposed before it happens" \
     "METHOD.md §7 no longer gates every write into an in-place repo on proposing it first"
+  # Only two of the five put a file in the repo. The gate read as though all five were proposals,
+  # which made the decline rules below it parse oddly — declining CI or licensing is not a thing,
+  # because the method never offered to do them. Naming the two keeps the gate about what it gates.
+  assert_contains "$docs/METHOD.md" \
+    "**Exactly two of those five put a file in the repo: the README addition, and the Throughstone" \
+    "METHOD.md §7 does not say which of the five artifacts actually put a file in the repo"
+  # A remote is created only on request — the same answer for a created repo and an in-place one.
+  # Stated only as "do not create a remote for one that has one", it implied you may create one for
+  # a repo that has none, which is pushing somebody's code to a host they never picked.
+  assert_contains "$docs/METHOD.md" "**A remote is" \
+    "METHOD.md §7 does not require a request before a remote is created"
+  assert_contains "$docs/METHOD.md" "is not missing one; it is a repo whose owners have" \
+    "METHOD.md §7 still reads a repo with no remote as missing one"
+  assert_contains "$planning" "**A remote is" \
+    "planning session does not require a request before a remote is created"
+  # The fallback's case list is illustrative. It enumerated only README and licensing cases and
+  # would need an edit per artifact added, which is how it fell behind two of them.
+  assert_contains "$docs/METHOD.md" "**These are examples, not a" \
+    "METHOD.md §7's fallback still reads as an exhaustive list of cases"
+  assert_contains "$readme_tpl" "license, notice, remote, or visibility" \
+    "repo README template's fallback does not cover remote or visibility"
   # And a yes settles the TEXT, not how it reaches their trunk. Four files told an agent to write
   # the Role section and none said what happens next, so the obvious continuation was to commit on
   # whatever branch was out — usually main on a running system — and push. Both halves are pinned:

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -169,8 +169,19 @@ run_case() {
   # section — which an in-place repo with no README gets written from.
   assert_contains "$docs/METHOD.md" "a repo **the method creates** with real internal complexity" \
     "METHOD.md §7 still tells any repo with internal complexity to add an ARCHITECTURE.md"
-  assert_contains "$docs/METHOD.md" "not as a new" \
+  assert_contains "$docs/METHOD.md" "not as a second new" \
     "METHOD.md §7 does not send an in-place repo's internal design to the docs hub instead"
+  # The template is the file an agent has open while writing a README for an in-place repo that had
+  # none, and its Overview comment called for an ARCHITECTURE.md unconditionally — so §7 said one
+  # thing and the file in front of the agent said another. Scoping §7 alone would leave the
+  # contradiction exactly where it does the damage.
+  assert_contains "$readme_tpl" "For a repo THIS METHOD CREATED with real internal complexity" \
+    "repo README template still calls for an ARCHITECTURE.md in any complex repo"
+  assert_contains "$readme_tpl" "NOT for a repo REGISTERED IN PLACE, including one whose README" \
+    "repo README template does not rule out an ARCHITECTURE.md for an in-place repo"
+  # A repo that brought its own ARCHITECTURE.md keeps it — read and link, never rewrite.
+  assert_contains "$readme_tpl" "it is theirs: read it, link it from the" \
+    "repo README template does not say an in-place repo's own ARCHITECTURE.md is left alone"
 
   # --- The README. Stamp what the method creates; augment what it registers, keyed on whether the
   # file exists. The substituted section name doubles as the placeholder check.

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -136,19 +136,28 @@ run_case() {
   assert_contains "$docs/METHOD.md" \
     "**Exactly two of those five put a file in the repo: the README addition, and the Throughstone" \
     "METHOD.md §7 does not say which of the five artifacts actually put a file in the repo"
-  # A remote is created only on request — the same answer for a created repo and an in-place one.
+  # Of those two, only the README addition is asked about. The notice follows automatically — it
+  # marks material the owners just agreed to take, so asking again would be asking permission to
+  # label what they already said yes to. Pinned because "two writes" reads as "two questions".
+  assert_contains "$docs/METHOD.md" "owners. The notice follows from it automatically and is not" \
+    "METHOD.md §7 turns the Throughstone notice into a second question of its own"
+  # A remote changes only on request — the same answer for a created repo and an in-place one.
   # Stated only as "do not create a remote for one that has one", it implied you may create one for
-  # a repo that has none, which is pushing somebody's code to a host they never picked.
-  assert_contains "$docs/METHOD.md" "**A remote is" \
-    "METHOD.md §7 does not require a request before a remote is created"
-  assert_contains "$docs/METHOD.md" "is not missing one; it is a repo whose owners have" \
+  # a repo that has none, which is pushing somebody's code to a host they never picked. All three
+  # verbs are named because forbidding only one of them is what produced that reading.
+  assert_contains "$docs/METHOD.md" \
+    "**A repo's remote changes only when the user asks: never created, repointed, or removed as a" \
+    "METHOD.md §7 does not require a request before a repo's remote changes"
+  assert_contains "$docs/METHOD.md" "missing one; it is a repo whose owners have not put it on a" \
     "METHOD.md §7 still reads a repo with no remote as missing one"
-  assert_contains "$planning" "**A remote is" \
+  assert_contains "$planning" "**A remote is created only when the user asks for one**" \
     "planning session does not require a request before a remote is created"
   # The fallback's case list is illustrative. It enumerated only README and licensing cases and
   # would need an edit per artifact added, which is how it fell behind two of them.
   assert_contains "$docs/METHOD.md" "**These are examples, not a" \
     "METHOD.md §7's fallback still reads as an exhaustive list of cases"
+  assert_contains "$docs/METHOD.md" "a repo that is already public and whose owners hadn't" \
+    "METHOD.md §7's fallback carries no case from the visibility rule"
   assert_contains "$readme_tpl" "license, notice, remote, or visibility" \
     "repo README template's fallback does not cover remote or visibility"
   # And a yes settles the TEXT, not how it reaches their trunk. Four files told an agent to write
@@ -169,7 +178,8 @@ run_case() {
   # section — which an in-place repo with no README gets written from.
   assert_contains "$docs/METHOD.md" "a repo **the method creates** with real internal complexity" \
     "METHOD.md §7 still tells any repo with internal complexity to add an ARCHITECTURE.md"
-  assert_contains "$docs/METHOD.md" "not as a second new" \
+  assert_contains "$docs/METHOD.md" \
+    "\`architecture/\`, where the project's own docs live, not as a second new file at the root of a" \
     "METHOD.md §7 does not send an in-place repo's internal design to the docs hub instead"
   # The template is the file an agent has open while writing a README for an in-place repo that had
   # none, and its Overview comment called for an ARCHITECTURE.md unconditionally — so §7 said one

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -97,23 +97,59 @@ run_case() {
   local check_in="$docs/runbooks/check-in.md"
   local planning="$docs/templates/planning-session.md"
 
-  # --- One rule, not four. README, CI, licensing, and the notice are the same rule applied to four
-  # artifacts: a repo the method did not create keeps what it already has. Licensing had grown its
-  # own doctrine paragraph, which is how the same argument ended up restated in file after file and
-  # why the next artifact to hit this boundary would have needed one more. The heading is pinned
-  # because it is what the consumers cite; drop it and their pointers go stale silently.
+  # --- One rule, not five. README, CI, licensing, the notice, and remote/visibility are the same
+  # rule applied to five artifacts: a repo the method did not create keeps what it already has.
+  # Licensing had grown its own doctrine paragraph, which is how the same argument ended up
+  # restated in file after file. The heading is pinned because it is what the consumers cite; drop
+  # it and their pointers go stale silently.
+  #
+  # The COUNT is checked against the bullets rather than asserted as a literal. A literal is how
+  # this went wrong once already: remote/visibility was added as a fifth bullet while the sentence
+  # still said "not four", and the assertion pinned the stale number, so the test agreed with the
+  # error instead of catching it. Counting the list means the next bullet either updates the
+  # sentence or fails here.
   assert_contains "$docs/METHOD.md" \
     "**A repo the method did *not* create keeps what it already has.**" \
     "METHOD.md §7 lost the single rule the per-artifact consequences hang off"
-  assert_contains "$docs/METHOD.md" "This is one rule, not four" \
-    "METHOD.md §7 no longer says the per-artifact rules are one rule"
+  local claimed bullets
+  claimed="$(sed -n 's/.*This is one rule, not \([a-z]*\)\..*/\1/p' "$docs/METHOD.md")"
+  bullets="$(sed -n '/A repo the method did \*not\* create keeps/,/^Every write above/p' \
+    "$docs/METHOD.md" | grep -c '^- \*\*')"
+  case "$bullets" in
+    3) expected=three ;; 4) expected=four ;; 5) expected=five ;;
+    6) expected=six ;;  7) expected=seven ;; *) expected="(unhandled: $bullets)" ;;
+  esac
+  [ "$claimed" = "$expected" ] || {
+    echo "FAIL: METHOD.md §7 says \"not $claimed\" but lists $bullets per-artifact bullets" >&2
+    return 1
+  }
   # Licensing is one of those consequences now, not a separate doctrine with its own rationale.
   assert_absent "$docs/METHOD.md" \
     "**The method records licensing; it never establishes licensing for code it did not create.**" \
     "METHOD.md §7 still gives licensing its own rule instead of one line under the general one"
-  # Every write into such a repo goes through one gate, stated once for all four artifacts.
+  # Every write into such a repo goes through one gate, stated once for all the artifacts.
   assert_contains "$docs/METHOD.md" "proposed before it happens" \
     "METHOD.md §7 no longer gates every write into an in-place repo on proposing it first"
+  # And a yes settles the TEXT, not how it reaches their trunk. Four files told an agent to write
+  # the Role section and none said what happens next, so the obvious continuation was to commit on
+  # whatever branch was out — usually main on a running system — and push. Both halves are pinned:
+  # the commit is made and left, and nothing leaves the machine.
+  assert_contains "$docs/METHOD.md" \
+    "**An accepted write is committed and left there. It is never pushed.**" \
+    "METHOD.md §7 does not say how an accepted write into an in-place repo lands"
+  assert_contains "$docs/METHOD.md" "never \`git add -A\`, which would sweep up whatever the" \
+    "METHOD.md §7 does not scope the commit to the files that were proposed"
+  assert_contains "$readme_tpl" "ON A YES, COMMIT IT ON A BRANCH AND STOP." \
+    "repo README template does not carry the landing rule to the point of the write"
+  assert_contains "$planning" "**On a yes, commit it on a branch and stop**" \
+    "planning session does not say how an accepted write into an in-place repo lands"
+  # ARCHITECTURE.md is a write at the root of somebody else's repository. It was stated unscoped in
+  # §7's general repo paragraph, and the template comment suggesting it is inside the Overview
+  # section — which an in-place repo with no README gets written from.
+  assert_contains "$docs/METHOD.md" "a repo **the method creates** with real internal complexity" \
+    "METHOD.md §7 still tells any repo with internal complexity to add an ARCHITECTURE.md"
+  assert_contains "$docs/METHOD.md" "not as a new" \
+    "METHOD.md §7 does not send an in-place repo's internal design to the docs hub instead"
 
   # --- The README. Stamp what the method creates; augment what it registers, keyed on whether the
   # file exists. The substituted section name doubles as the placeholder check.


### PR DESCRIPTION
A review of §7 from the top, read against the files that carry it — then a second read-through of the result, which turned up as much again in my own new text. Seven commits, grouped below.

## The original findings

**1. What happens after the yes.** Four files told an agent to propose the `Role in <project>` section and wait for agreement. **None said what to do once the file changed on disk** — no branch, no commit, no push. The obvious continuation is a commit onto whatever branch is checked out (usually `main` on a running system) and a push to their remote. The method now makes a branch, commits **only the file(s) proposed** (never `git add -A`), reports the branch and commit, and stops. If the working tree already has uncommitted changes to that file, it stops and says so.

**2. `ARCHITECTURE.md` at somebody else's root.** §7 stated it unscoped, and the comment calling for one lives in the README template's **Overview** section — which is what an in-place repo with no README gets written from. Adopted repos are exactly the complex ones. **Both files** now scope it; scoping §7 alone would have left the contradiction in the file an agent actually has open. Their own `ARCHITECTURE.md`, if they have one, is read and linked, never rewritten.

**3. A count the test agreed with.** The rule said *"not four"* while the list had grown to **five**, and the assertion pinned the stale literal — so the test confirmed the error. The assertion now counts the bullets. Bite-checked:
```
FAIL: METHOD.md §7 says "not four" but lists 5 per-artifact bullets
```

**4. A repo's remote changes only when asked.** *"Do not create a remote for a repo that has one"* implied you could create one for a repo that has **none** — pushing code to a host its owners never picked — and said nothing about removal. All three verbs now sit under one condition. This is what the method already does where it creates repos: `init.sh` sets up no remotes unless asked.

**5. Two of the five are writes.** The gate said *"every write above is proposed"* over five bullets. Only the README addition and the notice put a file in the repo; CI, licensing and remote/visibility are things the method *doesn't* do.

**6. The fallback's cases are examples**, not a list to complete — it had already fallen behind two artifacts. Now explicitly illustrative, with a visibility and a remote case.

## What the second read-through caught in the above

- **The gate implied the notice is proposed too.** Naming two writes read as two questions. Only the README addition is put to the owners; the notice follows automatically from an addition they already accepted. (Matches the decision to leave the notice automatic.)
- **"Everything below is about those two" was false** — the publishing rule and the fallback both sit below and are about neither. Scoped to the three paragraphs it introduces.
- **The remote rule forbade repointing outright while allowing creation on request** — an inconsistency on its face. One condition now covers create/repoint/remove.
- **"The last unguarded step"** stopped being true once the rest of the list was guarded.
- **A paragraph-break regression** (the landing rule swallowed the standing-decline opening), and **two lines past the section's wrap** — one at 151 chars where an edit joined two sentences, one at 144 where a rewrap dropped a break.
- **Test needles truncated at wrap points** — several would have passed on partial text. All full single-line phrases now.

## Verification

Full suite green (13 files). Prose and tests only; no script or behavior changes. `init.sh`'s remote and visibility defaults were checked against the source before being asserted in §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
