### PR TITLE
Leave an accepted README addition as a commit on a branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,17 @@ error/corruption and re-run paths, not normal operation.
     observation, not a gate: nothing asks for a blanket yes before any text exists, because the
     text is what you are agreeing to. And a decline can stand for the rest, so you say no once
     rather than once per repo.
+  - **An accepted README addition is committed on a branch and left for you.** Adoption told the
+    agent to show you the text and wait for a yes, then said nothing about what happens to the
+    file — so the obvious next move was a commit on whatever branch was checked out, which on a
+    repo you already run is usually `main`, and a push to your remote. Your yes was about the
+    text, not about how a change reaches your trunk; that is your review process, not the
+    method's. It now makes a branch, commits **only the file it proposed** (never `git add -A`,
+    which would sweep up work in progress), tells you the branch and commit, and stops — no push,
+    no pull request, no merge. If that file already has uncommitted changes, it says so and leaves
+    it alone. The same goes for a README written from the template where a repo had none: one
+    file, on a branch — and never an `ARCHITECTURE.md` at your repo's root, which is where the
+    template's Overview comment would otherwise point. That write-up goes in the docs hub.
   - **Your repos are never published, and their remotes are never touched.** Adoption said nothing
     about either — every repo it registers already lives somewhere and is already private or
     public, both decisions made before the project existed. It now says so outright: no remote is

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -344,6 +344,17 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   writing into a repo they own. **A no is a complete answer, not a gap:** the same information is
   already in the recon map, the repo's `architecture/` doc, and its `repos.yml` row, so record
   that the repo documents itself and move on.
+  **On a yes, commit it on a branch and stop.** The yes was about the text, not about how that
+  change should reach their trunk — this is a running system with a review process you did not
+  design. So make a branch in that repo, commit **only the file you proposed** (name it; never
+  `git add -A`, which would sweep up whatever they had in progress), tell them the branch and the
+  commit, and stop there. **Never push, open a pull request, or merge**, and never commit onto
+  whatever branch happens to be checked out — on an adopted repo that is usually `main`. If the
+  working tree already has uncommitted changes to that file, say so and leave it rather than
+  committing around them (`METHOD.md` §7). Writing a repo's README from the template where it had
+  none is the same: that one file, on a branch, committed and left — and **not** the
+  `ARCHITECTURE.md` the template's Overview comment suggests for a complex repo, which every
+  adopted repo is. Its internal design goes in the docs hub's `architecture/`, not at its root.
   **And a no can stand for the rest.** This same proposal reaches the same people once per repo,
   which in a fourteen-repo system is fourteen times — so on a decline, ask whether it covers this
   repo or all of them, and where it is standing, stop proposing and record the remaining repos as

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -353,10 +353,12 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   working tree already has uncommitted changes to that file, say so and leave it rather than
   committing around them (`METHOD.md` §7). Writing a repo's README from the template where it had
   none is the same: that one file, on a branch, committed and left — and **not** an
-  `ARCHITECTURE.md` alongside it. The template calls for one in a repo *this method created* with
-  real internal complexity; every adopted repo is that kind of repo and none of them is that kind
-  of repo's owner, so its internal design goes in the docs hub's `architecture/`, not at its root.
-  A repo that already has an `ARCHITECTURE.md` of its own keeps it — read it, link it, leave it.
+  `ARCHITECTURE.md` alongside it. The template calls for one in a repo with real internal
+  complexity **that this method created**, and adoption creates none: these repos have the
+  complexity and other people own them. So an adopted repo's internal design is written up in the
+  docs hub's `architecture/`, never as a second new file at its root. Where a repo already has an
+  `ARCHITECTURE.md` of its own, that is theirs — read it, link it from the `Role` section if it
+  helps, and leave it alone.
   **And a no can stand for the rest.** This same proposal reaches the same people once per repo,
   which in a fourteen-repo system is fourteen times — so on a decline, ask whether it covers this
   repo or all of them, and where it is standing, stop proposing and record the remaining repos as

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -352,9 +352,11 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   whatever branch happens to be checked out — on an adopted repo that is usually `main`. If the
   working tree already has uncommitted changes to that file, say so and leave it rather than
   committing around them (`METHOD.md` §7). Writing a repo's README from the template where it had
-  none is the same: that one file, on a branch, committed and left — and **not** the
-  `ARCHITECTURE.md` the template's Overview comment suggests for a complex repo, which every
-  adopted repo is. Its internal design goes in the docs hub's `architecture/`, not at its root.
+  none is the same: that one file, on a branch, committed and left — and **not** an
+  `ARCHITECTURE.md` alongside it. The template calls for one in a repo *this method created* with
+  real internal complexity; every adopted repo is that kind of repo and none of them is that kind
+  of repo's owner, so its internal design goes in the docs hub's `architecture/`, not at its root.
+  A repo that already has an `ARCHITECTURE.md` of its own keeps it — read it, link it, leave it.
   **And a no can stand for the rest.** This same proposal reaches the same people once per repo,
   which in a fourteen-repo system is fourteen times — so on a decline, ask whether it covers this
   repo or all of them, and where it is standing, stop proposing and record the remaining repos as

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -382,6 +382,17 @@ All but the last are documentation only; nothing you already produced is rewritt
   `registries/repos.yml` — now quote the general rule rather than a licensing-specific one. Pull
   those five with `METHOD.md`. **One thing to check:** nothing; if you have local edits quoting the
   old licensing sentence, they are still true, just narrower than the rule they came from.
+- **An accepted README addition is committed on a branch and left there.** `RETCON-PROMPT.md` told
+  the agent to show you the text and wait for a yes, then said nothing about the file afterwards —
+  no branch, no commit, no push. On an adopted repo the obvious continuation is a commit on
+  whichever branch is checked out, usually `main`, followed by a push. It now makes a branch,
+  commits only the file it proposed, reports the branch and commit, and stops; never pushes, opens
+  a PR, or merges; and leaves the file alone if it already has uncommitted changes. A README
+  written from the template for a repo that had none follows the same path, and never brings an
+  `ARCHITECTURE.md` with it — an adopted repo's internal design is written up in the docs hub's
+  `architecture/`. Pull `RETCON-PROMPT.md` with `METHOD.md` §7. **One thing to check:** if an
+  earlier adoption committed such a change onto a shared branch or pushed it, that commit is still
+  there and is worth reviewing like any other.
 - **Adoption never touches a repo's remote or its visibility.** `RETCON-PROMPT.md` had no rule for
   either — it did not mention remotes at all — while adoption is the circumstance where the mistake
   is easiest and least recoverable: many repos in flight across a codebase the method did not

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -190,9 +190,10 @@ run_existing_case() {
   # An ARCHITECTURE.md at an adopted repo's root is a file appearing in somebody else's repository,
   # and the template comment suggesting one is inside the Overview section a README-less repo gets
   # written from. Adopted repos are exactly the ones with real internal complexity.
-  assert_file_contains "$docs/RETCON-PROMPT.md" "and **not** an"
   assert_file_contains "$docs/RETCON-PROMPT.md" \
-    "A repo that already has an \`ARCHITECTURE.md\` of its own keeps it"
+    "complexity **that this method created**, and adoption creates none: these repos have the"
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "docs hub's \`architecture/\`, never as a second new file at its root. Where a repo already has an"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing is recorded as found, never set here"
   # A user who has just chosen the project's license should hear where their own repos don't match

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -190,8 +190,9 @@ run_existing_case() {
   # An ARCHITECTURE.md at an adopted repo's root is a file appearing in somebody else's repository,
   # and the template comment suggesting one is inside the Overview section a README-less repo gets
   # written from. Adopted repos are exactly the ones with real internal complexity.
+  assert_file_contains "$docs/RETCON-PROMPT.md" "and **not** an"
   assert_file_contains "$docs/RETCON-PROMPT.md" \
-    "\`ARCHITECTURE.md\` the template's Overview comment suggests for a complex repo"
+    "A repo that already has an \`ARCHITECTURE.md\` of its own keeps it"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing is recorded as found, never set here"
   # A user who has just chosen the project's license should hear where their own repos don't match

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -177,6 +177,21 @@ run_existing_case() {
   assert_file_contains "$docs/RETCON-PROMPT.md" \
     "change no repository's visibility, in either direction, for any reason"
   assert_file_contains "$docs/RETCON-PROMPT.md" "never a standing one, never extended to a"
+  # What happens after the yes. The prompt told an agent to write into a running system's repo and
+  # said nothing about branch, commit, or push — so the obvious continuation was a commit on
+  # whatever branch was out (main, on an adopted repo) and a push to their remote. The method now
+  # stops at a local commit on a branch they can inspect, amend, or delete.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "**On a yes, commit it on a branch and stop.**"
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "**Never push, open a pull request, or merge**"
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "which would sweep up whatever they had in progress"
+  # An ARCHITECTURE.md at an adopted repo's root is a file appearing in somebody else's repository,
+  # and the template comment suggesting one is inside the Overview section a README-less repo gets
+  # written from. Adopted repos are exactly the ones with real internal complexity.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "\`ARCHITECTURE.md\` the template's Overview comment suggests for a complex repo"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing is recorded as found, never set here"
   # A user who has just chosen the project's license should hear where their own repos don't match


### PR DESCRIPTION
The adoption half of #153.

The per-repo substep told an agent to show the exact text, wait for a yes, and write it into a repo the user owns — **and then stopped talking.** Nothing said what happens to the file afterwards: no branch, no commit, no push. On an adopted repo the obvious continuation is a commit on whichever branch is checked out — usually `main`, on a system currently serving traffic — followed by a push to a remote nobody authorized touching.

## What it does now

The yes was about the *text*. It said nothing about how that change should reach their trunk, which is a review process this method did not design and does not know.

- make a **branch** in that repo
- commit **only the file proposed** — named, never `git add -A`, which would sweep up work in progress
- report the branch and commit, then **stop**
- never push, open a PR, or merge
- if the working tree already has uncommitted changes to that file, say so and leave it

## And nothing rides along

A README written from the template for a repo that had none follows the same path and brings nothing with it — in particular not the `ARCHITECTURE.md` that template's Overview comment suggests for a repo with real internal complexity. Every adopted repo is that kind of repo, and it would put a new file at the root of somebody else's repository. That write-up belongs in the docs hub's `architecture/`.

## Files

- `RETCON-PROMPT.md` — the landing rule in the per-repo substep, next to the propose-and-wait gate it completes.
- `CHANGELOG.md`, `UPDATING-THROUGHSTONE.md` — entry and migration note; the latter flags that a commit pushed by an earlier run is still there and worth reviewing.
- `tests/init-retcon-mode.sh` — the branch-and-stop rule, the never-push clause, the `git add -A` scoping, and the ARCHITECTURE.md exclusion.

Full suite green (15 files). Prose only.

## Ordering

#153 first — this is the adoption half of the general rules it puts in `METHOD.md` §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
