### PR TITLE
State the principle behind adoption's intake rules, and where it stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ error/corruption and re-run paths, not normal operation.
   greenfield one, from which the ordinary forward flow continues) arrive in the remaining 2.0
   increments. **Default mode is `new`**; a project stood up from scratch never enters this path and is
   unchanged.
+- **Adoption states the principle its intake rules come from** (`RETCON-PROMPT.md`) — the individual
+  rules were all in place (your README is added to, your CI is left alone, your licensing is
+  recorded, your remotes and visibility are untouched), but nothing said what they had in common, so
+  a case none of them named had no answer. Adoption now opens by saying it: it is **additive** —
+  nearly everything it produces is new and lands where nothing was, so that the method can be used
+  from here forward — and the intake is not a pass over your prior work. Your code is read, never
+  rewritten. Where it would touch something you already own, it asks and waits for a yes, for that
+  file, in that repo, with the exact text in front of you; and where it meets something it did not
+  create that no rule covers, it asks rather than acting and explaining afterwards. **This is the
+  posture of the adoption, not of the project it produces** — it ends when the baseline lands, and
+  from there forward STEPs implement against that baseline and change these repos like any others,
+  which is the point of bringing a legacy system under the method in the first place.
 - **`throughstone:` field on repo rows** (`registries/repos.yml`) — records how the method relates to
   each repo (`managed` today; `external` reserved for a later partial-adoption feature). Inert
   (nothing reads it yet) and read as `managed` when absent, so existing inventories are unaffected.

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -19,6 +19,27 @@ original intent are secondary evidence that may be stale — settle every diverg
 code, recording reality *plus* any drift/debt, never re-deciding. **No fabricated history, no
 reconstructed ADRs** (a *forward* decision made during adoption may be a normal ADR).
 
+**Permission, not forgiveness — for the intake.** Adoption is **additive**. Nearly everything it
+produces is new and lands where nothing was — the `architecture/` baseline, the STEP process, the
+registries, the recon map — so that ordinary {{PROJECT}} can run from here forward. The intake is not
+a pass over the team's prior work: their code is read and never rewritten, and what they already have
+stays theirs. The few places where the two would meet are handled the same way every time — **ask,
+and wait for a yes**, for that file, in that repo, with the exact text in front of them. A repo's
+README, its licensing, its CI, its remote, its visibility: there is a rule below for each, and those
+rules are this principle applied, not the extent of it. **When you meet something you did not create
+and nothing here says what to do, ask** — never act now and explain after. You are moving quickly
+through a codebase someone else built and still runs, describing it rather than working on it, and
+nothing has been agreed yet; the question costs a message, and the change nobody agreed to costs
+their trust in the whole baseline.
+
+**This is the posture of the adoption, and it ends when the baseline lands.** It is not a permanent
+stance toward these repos, and it is not a mode the project carries around afterwards. Adopting a
+legacy system is precisely so that {{PROJECT}} can change it — once STEP-1 is `Done` and
+`PROJECT-STATUS` flips, forward STEPs implement against the baseline and edit these repos like any
+others, under the ordinary method. Do not carry this restraint past the land, and do not read it back
+into `METHOD.md`: what it governs is a point-in-time intake, taken before there is an architecture to
+work from or a single agreement in place.
+
 ## How this prompt works — one resolver
 
 Retcon runs like greenfield: the next action is always derivable from disk. There is **one


### PR DESCRIPTION
Adoption's intake rules were all in place — an existing README is augmented and proposed before it is written, CI is left alone, licensing is recorded rather than set, remotes and visibility are never touched — but nothing said what they had in common. Each was followable on its own, and a case none of them named had no answer at all.

## What this adds

A two-paragraph philosophy note at the top of `RETCON-PROMPT.md`, beside the existing **Reality is the code**.

**Permission, not forgiveness — for the intake.** Adoption is *additive*: nearly everything it produces is new and lands where nothing was — the `architecture/` baseline, the STEP process, the registries, the recon map — so that the method can run from here forward. The intake is not a pass over the team's prior work; their code is read, never rewritten. Where the two would meet, ask and wait for a yes — for that file, in that repo, with the exact text in front of them. The per-artifact rules are that principle applied, not the extent of it: **something it did not create, that no rule covers, is asked about rather than acted on and explained afterwards.**

**And it ends when the baseline lands.** This is the more important half, because a principle stated the first way invites being carried too far. The restraint belongs to the *intake*, not to the project the intake produces. Adopting a legacy system is precisely so the method can change it — once STEP-1 is `Done` and `PROJECT-STATUS` flips, forward STEPs implement against the baseline and edit these repos like any others. An agent that spends a long adoption internalizing "ask before touching what you didn't create" is exactly the one that would carry it into the first forward STEP, so the prompt says outright that it stops, and says not to read it back into `METHOD.md` — whose in-place rules govern *scaffolding* a repo, not whether the project may later modify it.

## Scope

- `RETCON-PROMPT.md` — the note.
- `CHANGELOG.md` — one Added entry under the 2.0 line.

No behavior change and nothing procedural: no new substep, gate, or artifact. Greenfield never reads this file.

`links.sh`, `init-inplace-repo-rules.sh`, and `init-retcon-mode.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
