### PR TITLE
Close four gaps in what the method writes into a repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,22 @@ any project built with it.
   exactly as before once given, `--license` is unaffected, and no generated project is rewritten.
 
 ### Fixed
+- **`init.sh` still destroyed a repository whose work had never been added to Git.** The bootstrap
+  guard asks three questions — does HEAD resolve, do any refs exist, is anything staged — and a
+  repository created with `git init` (usually with a remote added) whose files have never been
+  `git add`ed answers "no" to all three while holding the whole project as untracked files. That
+  is a fourth store none of the three reads, and it is the one state indistinguishable from the
+  empty repository the mono-repo origin-reuse flow legitimately runs in. Measured: `init.sh`
+  proceeded, and in mono-repo layout wrote a project `LICENSE` beside the repository's own
+  `COPYING`, added a `LICENSING.md` asserting that license over their code, swept their source
+  into a bootstrap commit, and replaced the `.git` holding their origin — the same outcome the
+  guard already refuses for committed and staged work, and the same claim
+  `scripts/apply-project-license.sh` refuses on sight, arriving again by the one path that never
+  calls it. A fourth signal now refuses when nothing is committed, staged, or on a branch but the
+  working tree holds entries the template does not ship, and names them so it is clear the
+  refusal came from the user's own files. Origin-reuse is unaffected: a folder holding only the
+  template still initializes. A maintainer test pins the entry list against the template's real
+  top level, so a top-level file added later fails there rather than silently refusing real runs.
 - **An accepted README addition landed without the notice that explains it.** Two files go into a
   repo registered in place when its owners accept the `Role in <project>` section: the README, and
   the `LICENSE-THROUGHSTONE` / `LICENSING.md` that `apply-project-license.sh --notice-only` places

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@ any project built with it.
   exactly as before once given, `--license` is unaffected, and no generated project is rewritten.
 
 ### Fixed
+- **The licensing backstop read package metadata by shape, and three ecosystems don't use that
+  shape.** Before stamping the project license into a repo, `scripts/apply-project-license.sh`
+  checks whether the repo already states terms of its own — including in root package metadata.
+  It matched a `license` key followed by `:` or `=`, which is one way of many to say it. Gradle's
+  standard form is a nested block (`licenses { license { name "Apache-2.0" } }`) with no
+  separator at all; `build.gradle.kts` and `setup.py` were not read in the first place. Measured:
+  four such repos were all treated as stating nothing, and each took a project `LICENSE` plus a
+  `LICENSING.md` asserting it over their Apache-licensed code. The check now matches **any
+  mention of licensing** in those files rather than a particular shape, and reads
+  `build.gradle.kts` and `setup.py` as well. This deliberately over-refuses: a manifest with an
+  empty license value, one naming a `licenseFile`, and a repo that merely depends on a
+  license-scanning tool now refuse too. That trade is the point — refusing costs one question to
+  someone who can look at their own manifest and say there is nothing there, while serving writes
+  a license claim onto code the method did not author and asks nobody. A repo that states nothing
+  at all is still served, installed dependency trees are still pruned, and `--notice-only` is
+  unaffected: it never reads this at all. Both directions are asserted together in
+  `tests/init-license-validation.sh`.
 - **`init.sh` still destroyed a repository whose work had never been added to Git.** The bootstrap
   guard asks three questions — does HEAD resolve, do any refs exist, is anything staged — and a
   repository created with `git init` (usually with a remote added) whose files have never been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,22 @@ any project built with it.
   exactly as before once given, `--license` is unaffected, and no generated project is rewritten.
 
 ### Fixed
+- **`--registries=no` deleted two registries its own rationale never covered.** The flag pruned
+  `registries/` in mono-repo layout, arguing that a self-contained root repo has no sibling repos
+  to inventory. That argument is about `repos.yml`. The directory also holds `risks.yml` — the
+  accepted risk / tech-debt register `METHOD.md` §7 requires, with no connection to repo layout —
+  and `security-reviews.yml`, which the entire security-review runbook and report-template family
+  reads. Pruning took all three and left the generated project's own documentation citing files it
+  did not have: 98 references across 24 files. None of them are Markdown links, so `links.sh` and
+  `check.sh` both reported such a project clean. The flag is now **deprecated and ignored** —
+  `registries/` is always kept, in both layouts — and prints one line saying so, since silently
+  ignoring it would leave someone expecting a pruned project. Invalid values still error as
+  before. The flag stays accepted for now and is removed in a later release; the deprecation
+  window from a patch release to the next major is too short to fail a scripted bootstrap on.
+  With the directory always present, the declined-README
+  fallback in `METHOD.md` §7, the repo README template, and `runbooks/check-in.md` no longer hedge
+  that a project might not keep an inventory — a caveat that was only ever true because this flag
+  could delete it.
 - **The licensing backstop read package metadata by shape, and three ecosystems don't use that
   shape.** Before stamping the project license into a repo, `scripts/apply-project-license.sh`
   checks whether the repo already states terms of its own — including in root package metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@ any project built with it.
   exactly as before once given, `--license` is unaffected, and no generated project is rewritten.
 
 ### Fixed
+- **An accepted README addition landed without the notice that explains it.** Two files go into a
+  repo registered in place when its owners accept the `Role in <project>` section: the README, and
+  the `LICENSE-THROUGHSTONE` / `LICENSING.md` that `apply-project-license.sh --notice-only` places
+  to mark that section as Throughstone-authored. Only the README is ever proposed — the notice
+  follows automatically and is deliberately not a second question — so the landing rule's
+  instruction to commit "only the file(s) proposed" covered one of the two, and the notice mode was
+  described as running *after* the commit. In practice the branch handed to the owners carried the
+  README alone, the two notice files were left untracked in their working tree after the agent had
+  been told to stop, and the addition merged into their trunk with nothing saying where it came
+  from — while the stray files waited for the next `git add -A` to sweep them into an unrelated
+  commit, the exact accident the landing rule warns about two sentences earlier. The notice is now
+  placed **before** the commit, and the commit covers **every file the method just wrote into that
+  repo**, each path named explicitly, still never `git add -A`. One branch, one commit, so the
+  addition and its notice cannot be separated by whatever the owners do next. `METHOD.md` §7, the
+  repo README template, and the planning session all state it that way; the rules on never pushing,
+  never committing onto the checked-out branch, and stopping if the file already has uncommitted
+  changes are unchanged. No effect on a repo the method creates.
 - **The record that justifies leaving an in-place repo's CI alone had nowhere to go.** The rules
   are settled: the starter gate in `templates/ci/code-repo-ci.yml` fails until configured, so it is
   never installed into a repo the method did not create — and four files (`METHOD.md` §7,

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -556,8 +556,7 @@ permission to label what they already said yes to.
 
 **That addition is proposed before it happens** — show the exact text and where it goes, and wait
 for an answer. A decline is a complete outcome, not a gap: the same information lives in the
-architecture doc — and in the `repos.yml` row where the project keeps an inventory, which a
-mono-repo project may not.
+architecture doc — and in the repo's `repos.yml` row.
 
 **An accepted write is committed and left there. It is never pushed.** A yes settles what the text
 should say; it does not say anything about how that change should reach the repo's trunk, and every

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -529,7 +529,10 @@ project is actually missing. Per artifact that means:
   `Role in <project>` section, or a README written from the template for a repo that had none —
   run `scripts/apply-project-license.sh --notice-only <repo>`, which places `LICENSE-THROUGHSTONE`
   and a `LICENSING.md` that names only what the notice covers and disclaims the rest of the
-  repository. Where the addition was declined, nothing Throughstone-authored is there and nothing
+  repository. Run it **before** the commit below, so the notice rides the same branch as the
+  material it covers; placing it afterwards leaves two untracked files in somebody else's working
+  tree and merges the addition without the notice that explains it. Where the addition was
+  declined, nothing Throughstone-authored is there and nothing
   is owed; do not copy `LICENSE-THROUGHSTONE` into a repo that holds none of it.
 - **Remote and visibility — its owners'.** A repo that predates the method already lives somewhere
   and is already private or public, and both were somebody's decision. Visibility is governed by
@@ -559,8 +562,12 @@ mono-repo project may not.
 **An accepted write is committed and left there. It is never pushed.** A yes settles what the text
 should say; it does not say anything about how that change should reach the repo's trunk, and every
 team has its own answer — a PR, a review, a signed commit, a CI gate, a release train. So make the
-edit on a **branch** created for it, commit **only the file(s) proposed** (name them explicitly;
-never `git add -A`, which would sweep up whatever the owners had in progress), and stop. Then tell
+edit on a **branch** created for it, and
+commit every file the method just wrote into that repo — the addition that was proposed, and
+the `LICENSE-THROUGHSTONE` and `LICENSING.md` the notice mode placed alongside it. Name each
+path explicitly; never `git add -A`, which would sweep up whatever the owners had in progress.
+One branch, one commit, everything Throughstone put there — so whichever way the owners take it,
+the material and the notice that explains it travel together. Then stop, and tell
 them the branch and the commit, and let them take it through their own process. Do not push, do not
 open a pull request, do not merge, and do not commit onto whatever branch happened to be checked
 out — that branch is often `main` on a running system, and often has someone else's work on it. If

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -244,6 +244,19 @@ is rewritten.** Edits to `templates/architecture-sessions/*.md`, documentation f
 added to `scripts/apply-project-license.sh`, all *Templates for future use* under §2, so they
 affect work you do after pulling them.
 
+- **`init.sh --registries=no` is deprecated and now does nothing.** It pruned `registries/` in
+  mono-repo layout, on the argument that a self-contained root repo has no sibling repos to
+  inventory. That argument is about `repos.yml`; the directory also holds `risks.yml`, the
+  accepted risk / tech-debt register §7 requires, and `security-reviews.yml`, which the
+  security-review runbooks and their report templates read. Pruning removed all three and left
+  the generated project's own docs citing files it did not have — and because those citations are
+  prose rather than Markdown links, `scripts/links.sh` and `scripts/check.sh` both reported the
+  project clean. The flag is still accepted so existing scripts keep working, prints one
+  deprecation line, and is removed in a later release. **One thing to check:** if you generated a project
+  with `--registries=no`, it is missing all three registries. Copy `registries/` from a freshly
+  generated project (or from the template) into your docs hub — the two seed rows in `repos.yml`
+  describe the docs hub and `prompts/`, and the other two files start empty.
+
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
   here to run this session…" and ends by releasing a reader who wasn't sent to run it. When you
   invoke a session normally, behavior is unchanged — you type `Run STEP-1.N` and get the first

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -151,8 +151,7 @@ Beyond the architecture docs, sweep four things that rot just as quietly:
   wrote from the template, so that file is Throughstone-authored like a created repo's — check its
   **Overview** the same way, and still scaffold nothing else there. If the addition was declined,
   or the repo has no README, that is not a gap to close here — the framing lives in its
-  architecture doc, and in its `repos.yml` row where the project keeps an inventory
-  (`METHOD.md` §7).
+  architecture doc, and in its `repos.yml` row (`METHOD.md` §7).
 - **Interface contract artifacts** — any artifact named by `architecture/*-interface-contracts.md` (OpenAPI /
   GraphQL / protobuf / event schema / JSON Schema / public package interface, etc.) still
   matches what the service, worker, CLI, library, or import/export path actually exposes. A

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -83,7 +83,9 @@ fi
 #   2. The same names further down — a monorepo licenses per package (packages/*/LICENSE), and a
 #      vendored tree carries the terms it arrived under. Depth-limited and pruned of the
 #      directories that hold installed dependencies rather than the repo's own code.
-#   3. A license field in root package metadata. Plenty of repos state their license only there.
+#   3. Any mention of licensing in root package metadata. Plenty of repos state their license
+#      only there, in whatever shape their ecosystem uses — a key, a nested block, a keyword
+#      argument — so this matches the word rather than a shape, and over-refuses by design.
 #
 # Plain root LICENSE is deliberately still not listed: verify_compatible already rejects a
 # differing one, and an identical one is this helper's own idempotent re-run.
@@ -118,20 +120,29 @@ find_pre_existing_licensing() {
           [ "$(dirname "$found")" = "$target" ] || printf '%s\n' "$found"
         done
 
-    # A license field in root package metadata. Matched loosely on purpose: any of these files
-    # carrying a populated license key is a repo saying something about its terms.
+    # Any mention of licensing in root package metadata. This matches the bare word, not a
+    # key/value shape, and that is deliberate.
+    #
+    # Matching on shape asks a manifest for something it is under no obligation to have. Gradle
+    # states a license as a nested block (`licenses { license { name "Apache-2.0" } }`) with no
+    # separator to key on; setup.py states it as a keyword argument. Both were measured taking a
+    # project LICENSE over their own terms while a pattern that wanted `license = value` looked
+    # straight past them. Every shape invented later would need another pattern, and the failure
+    # is silent: the repo is served, and a license claim lands on code the method did not write.
+    #
+    # So the question is "does this file mention licensing at all", and anything found is a
+    # refusal. That over-refuses on purpose. A manifest whose license field is empty, one naming
+    # a `licenseFile` instead of a license, and a repo that merely depends on a license-scanning
+    # tool all refuse now. Each costs one question to someone who can look at their own manifest
+    # and say there is nothing there. The other direction asks nobody anything and writes a
+    # license over somebody else's work.
     local manifest
     for manifest in "$target"/package.json "$target"/pyproject.toml "$target"/setup.cfg \
-                    "$target"/Cargo.toml "$target"/composer.json "$target"/*.gemspec \
-                    "$target"/build.gradle "$target"/pom.xml; do
+                    "$target"/setup.py "$target"/Cargo.toml "$target"/composer.json \
+                    "$target"/*.gemspec "$target"/build.gradle "$target"/build.gradle.kts \
+                    "$target"/pom.xml; do
       [ -f "$manifest" ] || continue
-      # Two shapes: a key/value pair (JSON quotes the key, so allow a quote before the separator;
-      # TOML and Gradle use `=`; npm's legacy form is a `licenses` array), and an XML <license>
-      # element for pom.xml. A populated value is required, so an empty license field reads as
-      # saying nothing.
-      if grep -Eiq \
-        '(^|[^A-Za-z_-])licen[cs]es?["'"'"']?[[:space:]]*[:=][^[:alnum:]]*[[:alnum:]]|<licen[cs]es?[[:space:]>]' \
-           "$manifest" 2>/dev/null; then
+      if grep -Eiq 'licen[cs]e' "$manifest" 2>/dev/null; then
         printf '%s\n' "$manifest"
       fi
     done

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -119,18 +119,21 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    not the `ARCHITECTURE.md` its Overview comment suggests for a complex repo; an in-place repo's
    internal design is written up in the docs hub's `architecture/`, not as a new file at its root.
    Either way it is the user's repo, so show them what you intend to add and where, and wait for a
-   yes. **On a yes, commit it on a branch and stop** — commit only the file you proposed, never
-   `git add -A`, and **never push, open a PR, or merge**. Tell them the branch and commit and let
+   yes. **On a yes, place the notice, then commit both on a branch and stop.** The accepted text is
+   Throughstone-authored, so run
+   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <repo-path>` first, then
+   commit every file the method just wrote into that repo — the README file you proposed, and the
+   `LICENSE-THROUGHSTONE` and `LICENSING.md` it placed — naming each, never
+   `git add -A`, and **never push, open a PR, or merge**. One branch, one commit, so the addition
+   and the notice explaining it can't be separated. Tell them the branch and commit and let
    them take it through their own process; how a change reaches their trunk is theirs to decide
-   (`METHOD.md` §7). **Its CI is
+   (`METHOD.md` §7). If the addition was declined, nothing Throughstone-authored is in that repo
+   and nothing is owed. **Its CI is
    its own** — never install `templates/ci/code-repo-ci.yml` into it; record what it runs in the
    Test Strategy doc. **Its remote and its visibility are its own too** — it already lives
    somewhere and is already private or public, so create no remote for it, repoint no existing one,
    and **never change its visibility**. Record the cloneable URL it already has in its `remote:`
-   field so `scripts/setup-workspace.sh` can find it, and change nothing about the repo. If the
-   README addition is accepted, run
-   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <repo-path>` to place the
-   Throughstone notice for that retained material; if it was declined, nothing is owed.
+   field so `scripts/setup-workspace.sh` can find it, and change nothing about the repo.
    Confirm the repo list with the user — on a first run they're all new; note any
    that already exist (registered and present, by either of the tests above) so you scaffold only
    the new ones.

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -34,8 +34,7 @@
   never stamp the Licensing section below into it (that describes a repo the method created).
   Show the exact text and where it will go, and get agreement before writing into someone
   else's repo; if they decline, that is a complete outcome — the same information already lives
-  in the repo's architecture doc, and in its `registries/repos.yml` row where the project keeps
-  an inventory.
+  in the repo's architecture doc, and in its `registries/repos.yml` row.
 
   ON A YES, COMMIT IT ON A BRANCH AND STOP. A yes settles what the text says, not how it should
   reach their trunk — every team has its own answer to that. Place the notice first (below), then

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -38,9 +38,14 @@
   an inventory.
 
   ON A YES, COMMIT IT ON A BRANCH AND STOP. A yes settles what the text says, not how it should
-  reach their trunk — every team has its own answer to that. So make a branch, commit only the
-  file(s) you proposed (name them; never `git add -A`, which sweeps up whatever they had in
-  progress), and tell them the branch and commit. NEVER push, open a pull request, merge, or
+  reach their trunk — every team has its own answer to that. Place the notice first (below), then
+  make a branch and
+  commit every file the method just wrote into that repo — the README file you proposed, and the
+  `LICENSE-THROUGHSTONE` and `LICENSING.md` the notice mode placed alongside it. Name each path;
+  never `git add -A`, which sweeps up whatever they had in progress. One branch, one commit,
+  everything Throughstone put there, so the addition and the notice explaining it can't be
+  separated by whatever the owners do next. Then tell them the branch and commit. NEVER push, open
+  a pull request, merge, or
   commit onto whatever branch is checked out — that is usually `main` on a running system. If the
   working tree already has uncommitted changes to that file, stop and say so instead of committing
   around them.
@@ -87,7 +92,9 @@
   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <this-repo-path>`. It
   places `LICENSE-THROUGHSTONE` and a `LICENSING.md` naming only what the notice covers, writes
   no project `LICENSE`, and makes no claim about the rest of the repository — which is why it is
-  allowed here when the plain invocation above is not. If the addition was declined, nothing
+  allowed here when the plain invocation above is not. Run it before the branch commit above, so
+  those two files go in with the README change rather than being left untracked in their working
+  tree after you have stopped. If the addition was declined, nothing
   Throughstone-authored is in the repo and nothing is owed: a notice pointing at absent material
   only misleads a later reader.
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ matching environment variables.
 | `--license=NAME` | `INIT_LICENSE` | `mit`, `bsd-3`, `apache-2.0`, `private` | Project license posture. |
 | `--holder=NAME` | `INIT_HOLDER` | text | Copyright holder for open-source licenses. |
 | `--layout=LAYOUT` | `INIT_LAYOUT` | `multi`, `mono` | Repo layout; default is `multi`. |
-| `--registries=yes\|no` | `INIT_REGISTRIES` | `yes`, `no` | Keep `registries/` in mono-repo mode; default is `yes`. |
+| `--registries=yes\|no` | `INIT_REGISTRIES` | `yes`, `no` | **Deprecated, ignored.** `registries/` is always kept. |
 | `--collab=MODE` | `INIT_COLLAB` | `solo`, `team` | Collaboration wording and ADR authority defaults; default is `solo`. |
 | `--adr-authority=TEXT` | `INIT_ADR_AUTHORITY` | text | Who accepts ADRs in team mode. |
 | `--trunk-branch=NAME` | `INIT_TRUNK_BRANCH` | valid Git branch name | Generated repo trunk branch; default is `main`. |

--- a/init.sh
+++ b/init.sh
@@ -287,9 +287,10 @@ fi
 # That is the claim scripts/apply-project-license.sh refuses outright; nothing should be able to
 # make it here instead.
 #
-# What separates the cases is HISTORY, and it needs no list of template paths. What this refusal
-# protects is work its owner cannot get back — and a repository can be holding that in more than
-# one place. Asking git a single question about a single one of them is how the first version of
+# Three of the four questions below separate the cases by HISTORY alone and need no list of
+# template paths. The fourth exists because one state has no history to read at all. What this
+# refusal protects is work its owner cannot get back — and a repository can be holding that in
+# more than one place. Asking git a single question about a single one of them is how the first version of
 # this guard let a live repository through: it asked what HEAD points at, and a repository whose
 # HEAD is unborn is still holding every commit made on its other branches.
 #
@@ -302,16 +303,77 @@ fi
 #      commit under HEAD, every earlier commit still on the branch it was made on.
 #   3. Nothing is committed anywhere, but files are staged and the staged AGENTS.md is not the
 #      template's — work that so far exists only in the index.
-# Each reads a different store, and each reads the repository rather than the working files, which
-# the extraction just overwrote.
+#   4. Nothing is committed, no refs exist, and nothing is staged, but the working tree holds
+#      entries this template does not ship. This is the one state the three questions above
+#      cannot tell apart from an empty repository: `git init` — often with a remote added, and
+#      no commit yet — leaves everything its owner has written as untracked files, which is a
+#      store none of the three reads. It is also the only question that has to know what the
+#      template ships, so the list it compares against is pinned by a maintainer test.
+# The first three read a different store each, and read the repository rather than the working
+# files, which the extraction just overwrote. The fourth reads the working files precisely
+# because in that state the repository itself holds nothing to read.
 #   - template in a plain folder            -> not a work tree, proceeds
 #   - template cloned or committed          -> HEAD's AGENTS.md carries the sentinel, proceeds
 #   - template staged, not yet committed     -> the staged AGENTS.md carries it, proceeds
 #   - `git init` + an empty origin, no commit yet, the mono-repo origin-reuse flow in section 4
-#                                           -> no HEAD, no refs, nothing staged, proceeds
+#                                           -> no HEAD, no refs, nothing staged, and the working
+#                                              tree holds only what the template ships, proceeds
 #   - extracted over a repo with history    -> refused by 1
 #   - extracted onto an orphan branch       -> refused by 2
 #   - extracted over staged, uncommitted work -> refused by 3
+#   - extracted over `git init` + untracked work, nothing added yet -> refused by 4
+# Every top-level entry this template ships, one per line. Signal 4 below treats anything else in
+# the working tree as its owner's, so this list is what stands between "an empty repo the user
+# prepared for us" and "a project with everything still untracked". It is deliberately generous:
+# entries a maintainer checkout carries but a download does not (.dev/, marketing/, TODO.md,
+# local-testing/) are listed too, because listing one that is absent costs nothing while omitting
+# one that is present would refuse a legitimate run. tests/init-fresh-template-guard.sh asserts it
+# covers the template's real top level, so adding a top-level file fails there rather than here.
+TEMPLATE_TOP_LEVEL="$(cat <<'TEMPLATE_ENTRIES'
+.DS_Store
+.claude
+.dev
+.git
+.github
+.gitignore
+.test-fixtures
+AGENTS.md
+ARTIFACT-TRAIL.md
+CHANGELOG.md
+CLAUDE.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+Code
+LICENSE
+README.md
+SECURITY.md
+TODO.md
+TRADEMARK.md
+Upcoming Prompts
+brand
+docs
+doctor.sh
+init.sh
+local-testing
+marketing
+prompts
+tests
+TEMPLATE_ENTRIES
+)"
+
+# bootstrap_foreign_entries — print each top-level working-tree entry the template does not ship.
+# Reads: ROOT, TEMPLATE_TOP_LEVEL.
+# Writes: nothing (prints one name per line).
+# Returns: 0 always.
+bootstrap_foreign_entries() {
+  local entry name
+  for entry in "$ROOT"/* "$ROOT"/.[!.]*; do
+    [ -e "$entry" ] || continue
+    name="${entry##*/}"
+    printf '%s\n' "$TEMPLATE_TOP_LEVEL" | grep -qxF -- "$name" || printf '%s\n' "$name"
+  done
+}
+
 BOOTSTRAP_GUARD_REASON=""
 if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
   if git -C "$ROOT" rev-parse --verify HEAD >/dev/null 2>&1; then
@@ -319,9 +381,14 @@ if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
       || BOOTSTRAP_GUARD_REASON="its committed history is not this template's"
   elif git -C "$ROOT" show-ref --quiet 2>/dev/null; then
     BOOTSTRAP_GUARD_REASON="it holds commits on branches or tags that HEAD is not currently on"
-  elif [ -n "$(git -C "$ROOT" ls-files 2>/dev/null)" ] \
-       && ! git -C "$ROOT" show :./AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD'; then
-    BOOTSTRAP_GUARD_REASON="it has staged files that are not this template's"
+  elif [ -n "$(git -C "$ROOT" ls-files 2>/dev/null)" ]; then
+    git -C "$ROOT" show :./AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD' \
+      || BOOTSTRAP_GUARD_REASON="it has staged files that are not this template's"
+  else
+    BOOTSTRAP_FOREIGN="$(bootstrap_foreign_entries)"
+    if [ -n "$BOOTSTRAP_FOREIGN" ]; then
+      BOOTSTRAP_GUARD_REASON="it holds files this template does not ship, none of them committed, staged, or on a branch yet: $(printf '%s' "$BOOTSTRAP_FOREIGN" | tr '\n' ' ')"
+    fi
   fi
 fi
 if [ -n "$BOOTSTRAP_GUARD_REASON" ]; then

--- a/init.sh
+++ b/init.sh
@@ -166,7 +166,7 @@ Options:
   --license=NAME        mit | bsd-3 | apache-2.0 | private
   --holder=NAME         Copyright holder (required for open-source licenses)
   --layout=LAYOUT       multi | mono                    (default: multi)
-  --registries=yes|no   Keep registries/ (mono-repo only; default: yes)
+  --registries=yes|no   DEPRECATED, ignored: registries/ is always kept.
   --collab=MODE         solo | team                     (default: solo)
   --adr-authority=TEXT  Who accepts ADRs (team only; default: consensus of maintainers)
   --trunk-branch=NAME   Generated repo trunk branch     (default: main)
@@ -493,19 +493,24 @@ else
   LAYOUT="$(ask 'Choose 1 or 2' '1')"
 fi
 
-# registries/ is always kept in multi-repo because setup-workspace.sh and remote recording use
-# it as the sibling-repo inventory. Mono can prune it because the root repo is self-contained.
-KEEP_REGISTRIES=1
-if [ "$LAYOUT" = "2" ]; then
-  if [ -n "$REGISTRIES_IN" ]; then
-    case "$(printf '%s' "$REGISTRIES_IN" | tr '[:upper:]' '[:lower:]')" in
-      y|yes|true|1) KEEP_REGISTRIES=1 ;;
-      n|no|false|0) KEEP_REGISTRIES=0 ;;
-      *) echo "init.sh: invalid --registries '$REGISTRIES_IN' (yes | no)." >&2; exit 2 ;;
-    esac
-  elif [ "$NONINTERACTIVE" != "1" ]; then
-    yesno "Include registries/ (repo inventory; useful for multi-repo)?" || KEEP_REGISTRIES=0
-  fi
+# registries/ is always kept. --registries=no used to prune it in mono-repo layout, on the
+# argument that a self-contained root repo has no sibling repos to inventory. That argument was
+# about repos.yml, and the directory holds two more registries it never covered: risks.yml, the
+# accepted risk / tech-debt register METHOD.md §7 requires, and security-reviews.yml, which the
+# whole security-review runbook family reads. Pruning took all three, and left the generated
+# project's own docs referring to files it no longer had — 98 references across 24 files, none of
+# them a Markdown link, so scripts/links.sh and scripts/check.sh both reported it clean.
+#
+# The flag is accepted and ignored so existing scripts keep working, and says so once. It is
+# removed in a later release. Nothing is pruned in either layout.
+if [ -n "$REGISTRIES_IN" ]; then
+  case "$(printf '%s' "$REGISTRIES_IN" | tr '[:upper:]' '[:lower:]')" in
+    y|yes|true|1|n|no|false|0) ;;
+    *) echo "init.sh: invalid --registries '$REGISTRIES_IN' (yes | no)." >&2; exit 2 ;;
+  esac
+  echo "init.sh: --registries is deprecated and ignored; registries/ is always kept." >&2
+  echo "        It also held risks.yml and security-reviews.yml, which pruning removed and the" >&2
+  echo "        method's own runbooks still referenced. The flag is a no-op, not an error." >&2
 fi
 
 # Solo vs. team. This does NOT create a behavioral mode: branch-per-STEP, STEP-number
@@ -885,15 +890,6 @@ fi
 # --- 4. Prune optional pieces -----------------------------------------------
 # runbooks/ is kept: it now ships method-level runbooks (check-in, collaboration) that
 # AGENTS.md and METHOD.md reference.
-if [ "$KEEP_REGISTRIES" = "0" ]; then
-  rm -rf "$DOCS/registries"
-  # The docs hub README indexes every directory it ships, so pruning the directory without
-  # pruning its row leaves a link to a file that is not there — which scripts/links.sh reports
-  # as a hard failure on the generated project's very first run. Drop the row with the directory.
-  perl -ni -e 'print unless m{^\| \[`registries/`\]}' "$DOCS/README.md"
-  echo "  pruned registries/"
-fi
-
 # Replace the visible ADR authority marker, not arbitrary prose. Solo records the default
 # single-author posture; team records the selected acceptance authority for future handoffs.
 if [ -f "$DOCS/adr/README.md" ]; then

--- a/tests/init-fresh-template-guard.sh
+++ b/tests/init-fresh-template-guard.sh
@@ -53,6 +53,32 @@ init_once() { # DIR EXTRA_ARGS...
       --license=private --collab=solo --remotes=no "$@" )
 }
 
+# --- 0. Signal 4's template list must cover the template's real top level. ---------------------
+# Signal 4 is the one check that has to know what the template ships: anything else at the root is
+# read as its owner's. A top-level file added to the template and not added to that list turns
+# every legitimate origin-reuse run into a refusal, and the failure would look like the guard
+# over-firing rather than like a stale list. This runs FIRST: a stale list also breaks the
+# origin-reuse case below, and that failure reads as the guard over-firing. Failing here first
+# names the missing entry instead. Derived from the template, never asserted as a literal.
+TEMPLATE_TOP_LEVEL_LIST="$(sed -n "/^TEMPLATE_TOP_LEVEL=/,/^TEMPLATE_ENTRIES\$/p" "$ROOT/init.sh" \
+  | sed '1d;$d')"
+[ -n "$TEMPLATE_TOP_LEVEL_LIST" ] || {
+  echo "FAIL: could not read TEMPLATE_TOP_LEVEL out of init.sh — signal 4 is unverifiable" >&2
+  exit 1
+}
+missing=""
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  printf '%s\n' "$TEMPLATE_TOP_LEVEL_LIST" | grep -qxF -- "$entry" || missing="$missing $entry"
+done <<EOF
+$(git -C "$ROOT" ls-tree --name-only HEAD)
+EOF
+[ -z "$missing" ] || {
+  echo "FAIL: init.sh's TEMPLATE_TOP_LEVEL does not list:$missing" >&2
+  echo "       add them there, or signal 4 will refuse a legitimate origin-reuse run" >&2
+  exit 1
+}
+
 # --- 1. A fresh template initializes normally (the guard must not over-fire). -----------------
 fresh="$TMP_ROOT/fresh"
 copy_template "$fresh"
@@ -222,10 +248,41 @@ git -C "$staged_only" ls-files --error-unmatch src.txt >/dev/null 2>&1 \
 grep -Fxq "not committed yet" "$staged_only/src.txt" \
   || { echo "FAIL: init.sh disturbed the staged file's content" >&2; exit 1; }
 
+# --- 8b. Work that exists only as untracked files is refused. ---------------------------------
+# The fourth store. A repo whose owner ran `git init` (and usually `git remote add`) but has never
+# added or committed anything answers "nothing" to HEAD, to refs, and to the index, while the whole
+# project sits beside them as untracked files. Signals 1-3 each read the repository; in this state
+# the repository holds nothing to read, so the working tree is the only place the work is.
+# Measured before signal 4 existed: init.sh proceeded, and in mono layout wrote a project LICENSE
+# next to the repo's own COPYING, asserted it over their code in LICENSING.md, swept their source
+# into a bootstrap commit, and replaced the .git holding their origin.
+untracked_only="$TMP_ROOT/untracked-only"
+mkdir -p "$untracked_only/src"
+( cd "$untracked_only" && git init -q && git remote add origin "$TMP_ROOT/untracked-only.git" )
+printf 'years of it\n' > "$untracked_only/src/engine.py"
+printf 'GNU GENERAL PUBLIC LICENSE\n' > "$untracked_only/COPYING"
+copy_template "$untracked_only"
+if init_once "$untracked_only" --layout=mono --registries=yes >"$TMP_ROOT/untracked-only.out" 2>&1; then
+  echo "FAIL: init.sh ran on top of untracked, uncommitted work" >&2
+  cat "$TMP_ROOT/untracked-only.out" >&2
+  exit 1
+fi
+[ -d "$untracked_only/.git" ] || { echo "FAIL: init.sh deleted .git in the untracked-only case" >&2; exit 1; }
+grep -Fxq "years of it" "$untracked_only/src/engine.py" \
+  || { echo "FAIL: init.sh disturbed untracked work before refusing" >&2; exit 1; }
+[ -f "$untracked_only/COPYING" ] || { echo "FAIL: init.sh removed the repo's own COPYING" >&2; exit 1; }
+[ -f "$untracked_only/LICENSING.md" ] \
+  && { echo "FAIL: init.sh asserted a license over untracked work it refused to run on" >&2; exit 1; }
+git -C "$untracked_only" remote get-url origin >/dev/null 2>&1 \
+  || { echo "FAIL: init.sh dropped the repo's remote before refusing" >&2; exit 1; }
+# The refusal names what it found, so the user can see it is their own files talking.
+grep -Fq "COPYING" "$TMP_ROOT/untracked-only.out" \
+  || { echo "FAIL: the untracked-only refusal did not name what it found" >&2; exit 1; }
+
 # --- 9. Every refusal names which check fired. -------------------------------------------------
-# Three signals with one message is a support problem: the user cannot tell whether they hit a
-# stale branch, a stray index, or the wrong folder entirely.
-for out in extracted orphaned staged-only; do
+# Four signals with one message is a support problem: the user cannot tell whether they hit a
+# stale branch, a stray index, untracked work, or the wrong folder entirely.
+for out in extracted orphaned staged-only untracked-only; do
   grep -Fq "Refusing because" "$TMP_ROOT/$out.out" \
     || { echo "FAIL: the $out refusal did not say which check fired" >&2; cat "$TMP_ROOT/$out.out" >&2; exit 1; }
 done

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -168,11 +168,36 @@ run_case() {
     "**An accepted write is committed and left there. It is never pushed.**" \
     "METHOD.md §7 does not say how an accepted write into an in-place repo lands"
   assert_contains "$docs/METHOD.md" "never \`git add -A\`, which would sweep up whatever the" \
-    "METHOD.md §7 does not scope the commit to the files that were proposed"
+    "METHOD.md §7 does not scope the commit to the files it names"
   assert_contains "$readme_tpl" "ON A YES, COMMIT IT ON A BRANCH AND STOP." \
     "repo README template does not carry the landing rule to the point of the write"
-  assert_contains "$planning" "**On a yes, commit it on a branch and stop**" \
+  assert_contains "$planning" "**On a yes, place the notice, then commit both on a branch and stop.**" \
     "planning session does not say how an accepted write into an in-place repo lands"
+  # The commit covers the WRITE, not the PROPOSAL. Two things land on an accepted addition — the
+  # README file, and the LICENSE-THROUGHSTONE / LICENSING.md the notice mode places — but only the
+  # README is ever proposed, so a commit scoped to "the file(s) proposed" carried one of the two.
+  # Measured: the branch held README.md alone and the two notice files sat untracked in the owners'
+  # working tree after the agent had been told to stop, so the addition merged without the notice
+  # that explains it and the next `git add -A` anyone ran swept them into an unrelated commit.
+  # Pinned in all three files: an agent following any one of them alone must still land both.
+  for f in "$docs/METHOD.md" "$readme_tpl" "$planning"; do
+    assert_contains "$f" "commit every file the method just wrote into that repo" \
+      "$(basename "$f") scopes the landing commit to the proposal, not to everything written"
+  done
+  assert_absent "$docs/METHOD.md" "commit **only the file(s) proposed**" \
+    "METHOD.md §7 still scopes the landing commit to the file that was proposed"
+  assert_absent "$readme_tpl" "file(s) you proposed (name them; never \`git add -A\`" \
+    "repo README template still scopes the landing commit to the file that was proposed"
+  assert_absent "$planning" "commit only the file you proposed, never" \
+    "planning session still scopes the landing commit to the file that was proposed"
+  # ORDER, not just scope. The notice mode has to run before the commit, or its two files are
+  # written after the agent has stopped and there is nothing left to put them on a branch. Both
+  # files that sequence the two steps say so; the planning session states them in order instead.
+  assert_contains "$docs/METHOD.md" \
+    "repository. Run it **before** the commit below, so the notice rides the same branch as the" \
+    "METHOD.md §7 does not place the Throughstone notice before the landing commit"
+  assert_contains "$readme_tpl" "Run it before the branch commit above, so" \
+    "repo README template does not place the Throughstone notice before the landing commit"
   # ARCHITECTURE.md is a write at the root of somebody else's repository. It was stated unscoped in
   # §7's general repo paragraph, and the template comment suggesting it is inside the Overview
   # section — which an in-place repo with no README gets written from.

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -350,14 +350,16 @@ run_case() {
   }
 }
 
-# run_pruned_registries_case — a mono-repo project can decline registries/ entirely, and the rules
-# above have to survive that. Two ways they did not. The docs hub README indexes every directory it
-# ships, so pruning the directory but not its row left a link to a file that is not there — a hard
-# links.sh failure on the generated project's first run, before anyone had touched it. And the
-# rules named the repos.yml row flatly as the place a declined README's information still lives,
-# which is a promise this configuration cannot keep.
-run_pruned_registries_case() {
-  local name="inplace-pruned"
+# run_deprecated_registries_case — --registries=no no longer prunes anything, and this pins that.
+# The flag's argument was that a self-contained mono-repo root has no sibling repos to inventory,
+# which is an argument about repos.yml; the directory also holds risks.yml, the accepted risk
+# register METHOD.md §7 requires, and security-reviews.yml, which the security-review runbooks
+# read. Pruning removed all three and left the generated project's own docs citing files it did
+# not have — 98 references across 24 files, none of them Markdown links, so links.sh and check.sh
+# both called it clean. The flag is accepted and ignored so existing scripts keep working, and
+# removed in a later release.
+run_deprecated_registries_case() {
+  local name="inplace-registries-flag"
   local work="$TMP_ROOT/$name"
 
   copy_template "$work"
@@ -376,7 +378,14 @@ run_pruned_registries_case() {
   ) >"$TMP_ROOT/$name.out" 2>&1
 
   local docs="$work/Code/$name-docs"
-  [ ! -d "$docs/registries" ] || { echo "FAIL: --registries=no did not prune registries/" >&2; return 1; }
+  # All three registries survive the flag, and the one it was ever argued about is named first.
+  for reg in repos.yml risks.yml security-reviews.yml; do
+    [ -f "$docs/registries/$reg" ] \
+      || { echo "FAIL: --registries=no pruned registries/$reg" >&2; return 1; }
+  done
+  # Ignoring a flag silently is its own defect: a user who passed it is expecting a pruned project.
+  grep -Fq -- "--registries is deprecated and ignored" "$TMP_ROOT/$name.out" \
+    || { echo "FAIL: --registries=no was ignored without saying so" >&2; return 1; }
 
   # The generated project must be link-clean the moment it exists.
   ( cd "$docs" && ./scripts/links.sh ) >"$TMP_ROOT/$name-links.out" 2>&1 || {
@@ -384,19 +393,20 @@ run_pruned_registries_case() {
     grep -E "FAIL\]" "$TMP_ROOT/$name-links.out" >&2
     return 1
   }
-  assert_absent "$docs/README.md" '| [`registries/`](registries/README.md) |' \
-    "docs hub README still indexes a directory that was pruned"
+  assert_contains "$docs/README.md" '| [`registries/`](registries/README.md) |' \
+    "docs hub README no longer indexes the registries/ directory it ships"
 
-  # The declined-README fallback must not promise a row this project has no file to hold.
-  assert_contains "$docs/METHOD.md" "where the project keeps an inventory" \
-    "METHOD.md §7 still names the repos.yml row unconditionally as the declined-README fallback"
-  assert_contains "$docs/templates/repo-readme-template.md" "where the project keeps" \
-    "repo README template still names the repos.yml row unconditionally"
-  assert_contains "$docs/runbooks/check-in.md" 'and in its `repos.yml` row where' \
-    "check-in README sweep still names the repos.yml row unconditionally"
+  # The declined-README fallback names the inventory row plainly now. It used to hedge that a
+  # mono-repo project might not keep one, which was true only because this flag could delete it.
+  assert_absent "$docs/METHOD.md" "where the project keeps an inventory" \
+    "METHOD.md §7 still hedges that a project may not keep an inventory"
+  assert_contains "$docs/METHOD.md" "architecture doc — and in the repo's \`repos.yml\` row." \
+    "METHOD.md §7's declined-README fallback no longer names the inventory row"
+  assert_contains "$docs/runbooks/check-in.md" 'and in its `repos.yml` row (`METHOD.md` §7).' \
+    "check-in README sweep no longer names the inventory row plainly"
 }
 
 run_case
-run_pruned_registries_case
+run_deprecated_registries_case
 
 echo "init.sh registered-in-place repo rules: PASS"

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -545,6 +545,13 @@ run_licensing_evidence_case() {
         return 1
       }
     done
+  # The manifest cases match the bare word `license`, not a key/value shape, so several of these
+  # state nothing usable and refuse anyway: an empty license value, a `licenseFile` key, a Gradle
+  # block with no separator, a setup.py keyword argument. That is the intended trade — shape-
+  # matching missed the Gradle block and setup.py entirely and served them a project LICENSE over
+  # their own terms, and each new ecosystem would need another pattern to fail silently in. These
+  # two directions are asserted together on purpose: over-refusing is an outage on the path this
+  # helper exists for, and under-refusing writes a licence claim onto somebody else's code.
   done <<'EVIDENCE'
 npm-manifest|package.json|{"name":"svc","license":"GPL-3.0"}
 npm-legacy-array|package.json|{"name":"svc","licenses":[{"type":"MIT"}]}
@@ -554,6 +561,11 @@ pyproject-manifest|pyproject.toml|license = "Apache-2.0"
 setupcfg-manifest|setup.cfg|license = MPL-2.0
 gemspec-manifest|svc.gemspec|Gem::Specification.new { |s| s.license = "MPL-2.0" }
 gradle-manifest|build.gradle|license = 'EPL-2.0'
+gradle-block|build.gradle|licenses { license { name "Apache-2.0" } }
+gradle-kotlin-dsl|build.gradle.kts|licenses { license { name.set("Apache-2.0") } }
+setuppy-manifest|setup.py|from setuptools import setup; setup(name="svc", license="MPL-2.0")
+manifest-empty-license|package.json|{"name":"svc","license":""}
+manifest-license-file-key|package.json|{"name":"svc","licenseFile":"docs/terms.txt"}
 maven-manifest|pom.xml|<project><licenses><license><name>Apache-2.0</name></license></licenses></project>
 monorepo-package|packages/api/LICENSE|GNU General Public License v3
 vendored-tree|third_party/zlib/LICENSE|zlib License
@@ -581,8 +593,6 @@ EVIDENCE
     }
   done <<'NOEVIDENCE'
 manifest-without-license|package.json|{"name":"svc","version":"1.0.0"}
-manifest-empty-license|package.json|{"name":"svc","license":""}
-manifest-license-file-key|package.json|{"name":"svc","licenseFile":"docs/terms.txt"}
 installed-dependency|node_modules/left-pad/LICENSE|MIT License
 plain-source-file|src/main.js|export const x = 1;
 NOEVIDENCE


### PR DESCRIPTION
Four fixes to what the method writes into a repository, found by walking the paths with simulated
repos rather than by reading the rules. Each is a separate commit with its own regression coverage.

### An accepted README addition landed without the notice that explains it

Two files go into a repo registered in place when its owners accept the `Role in <project>`
section: the README, and the `LICENSE-THROUGHSTONE` / `LICENSING.md` that `--notice-only` places to
mark that section as Throughstone-authored. Only the README is ever proposed — the notice follows
automatically and is deliberately not a second question — so the landing rule's instruction to
commit "only the file(s) proposed" covered one of the two, and the notice was described as running
*after* the commit.

Measured: the branch handed to the owners carried `README.md` alone, and the two notice files were
left untracked in their working tree after the agent had been told to stop. The addition merges
with nothing saying where it came from, and the stray files wait for the next `git add -A` to sweep
them into an unrelated commit — the accident the landing rule warns about two sentences earlier.

The notice is now placed **before** the commit, and the commit covers every file the method just
wrote into that repo, each path named, still never `git add -A`.

### `init.sh` destroyed a repository whose work had never been added to Git

The bootstrap guard reads three stores — HEAD, refs, the index. A repository created with
`git init` (usually with a remote added) whose files have never been `git add`ed answers "no" to
all three while holding the whole project as untracked files. That state is also the one the
mono-repo origin-reuse flow legitimately runs in, so the three questions cannot separate them.

Measured: `init.sh` proceeded. In mono layout it wrote a project `LICENSE` beside the repository's
own `COPYING`, added a `LICENSING.md` asserting that license over their code, swept their source
into a bootstrap commit, and replaced the `.git` holding their origin — the outcome the guard
already refuses for committed and staged work, reached through a door it did not watch.

A fourth signal refuses that state and names the files it found. A folder holding only the template
still initializes. The list of what the template ships is derived from the template in the test, so
it fails there rather than silently refusing real runs.

### The licensing backstop read package metadata by shape

Before stamping, `apply-project-license.sh` checks whether a repo already states its own terms,
including in package metadata. It matched a `license` key followed by `:` or `=` — one way of many.
Gradle's standard form is a nested block with no separator; `build.gradle.kts` and `setup.py` were
not read at all. Measured: four such repos were treated as stating nothing and each took a project
`LICENSE` plus a `LICENSING.md` asserting it over their Apache-licensed code.

It now matches any mention of licensing in those files rather than a shape, and reads
`build.gradle.kts` and `setup.py`. This deliberately over-refuses — an empty license value, a
`licenseFile` key, and a repo that merely depends on a license-scanning tool now refuse too.
Refusing costs one question to someone who can read their own manifest; serving asks nobody and
writes a licence claim onto work the method did not do. Both directions are asserted together.

### `--registries=no` deleted two registries its own rationale never covered

The flag pruned `registries/` in mono layout, arguing a self-contained root repo has no sibling
repos to inventory. That argument is about `repos.yml`. The directory also holds `risks.yml` — the
accepted risk register §7 requires — and `security-reviews.yml`, which the whole security-review
runbook and report-template family reads. Pruning took all three and left the generated project
citing files it did not have: 98 references across 24 files, none of them Markdown links, so
`links.sh` and `check.sh` both called such a project clean.

`registries/` is now always kept. The flag is accepted and ignored, says so once, and is removed in
a later release — removing it now would fail a scripted bootstrap outright, and a patch release to
the next major is too short a warning. With the directory always present, the declined-README
fallback in `METHOD.md` §7, the repo README template and `check-in.md` drop the caveat that a
project might not keep an inventory.

## Verification

- Full suite **13/13** at `ba9ae5d`, the shipping commit.
- Fixtures built from `git archive` of the shipping ref across both layouts and four postures
  (MIT, Apache-2.0, BSD-3, proprietary), every one `check.sh` 0/0 and `links.sh` clean.
- Guard matrix: four must-proceed cases proceed, four must-refuse cases refuse, and the new refusal
  leaves the target untouched — `.git`, remote, `COPYING` and source all intact, nothing written.
- Licensing backstop: 18 must-refuse shapes still refuse, the previously-missed four now refuse,
  repos that state nothing are still served, and `--notice-only` works on all 24 shapes.
- Greenfield-inert where it should be: for the first commit a generated project differs from one
  built at `main`'s tip in exactly the three intended files; the guard commit's output is
  byte-identical.
- Every new assertion bitten individually by reverting one thing at a time and checking exit status.
- Forward merge to the 2.0 line trialled from a clean clone: three conflicts, all resolved per hunk,
  merged suite 15/15.
