### PR TITLE
Land an adopted repo's README addition with its notice, and stop losing repos in the license answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,12 +141,17 @@ error/corruption and re-run paths, not normal operation.
     file — so the obvious next move was a commit on whatever branch was checked out, which on a
     repo you already run is usually `main`, and a push to your remote. Your yes was about the
     text, not about how a change reaches your trunk; that is your review process, not the
-    method's. It now makes a branch, commits **only the file it proposed** (never `git add -A`,
-    which would sweep up work in progress), tells you the branch and commit, and stops — no push,
-    no pull request, no merge. If that file already has uncommitted changes, it says so and leaves
-    it alone. The same goes for a README written from the template where a repo had none: one
-    file, on a branch — and never an `ARCHITECTURE.md` at your repo's root, which is where the
-    template's Overview comment would otherwise point. That write-up goes in the docs hub.
+    method's. It now places the Throughstone notice for that section first, then makes a branch and
+    commits **every file it just wrote into that repo** — the README addition plus the
+    `LICENSE-THROUGHSTONE` and `LICENSING.md` marking it as scaffold material — naming each path
+    and never `git add -A`,
+    which would sweep up work in progress; then tells you the branch and commit, and stops — no push,
+    no pull request, no merge. One branch, one commit, so the section and the notice explaining it
+    cannot be separated by whatever you do with that branch. If that file already has uncommitted
+    changes, it says so and leaves
+    it alone. The same goes for a README written from the template where a repo had none: that
+    file and its notice, on a branch — and never an `ARCHITECTURE.md` at your repo's root, which is
+    where the template's Overview comment would otherwise point. That write-up goes in the docs hub.
   - **Your repos are never published, and their remotes are never touched.** Adoption said nothing
     about either — every repo it registers already lives somewhere and is already private or
     public, both decisions made before the project existed. It now says so outright: no remote is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,24 @@ error/corruption and re-run paths, not normal operation.
     observation, not a gate: nothing asks for a blanket yes before any text exists, because the
     text is what you are agreeing to. And a decline can stand for the rest, so you say no once
     rather than once per repo.
+  - **A generated repo is never left out of the license answer in silence.** Which repos
+    `scripts/set-project-license.sh` settled was decided by a marker string inside each one's
+    `LICENSING.md`. A repo whose copy had been edited or deleted matched nothing and was skipped
+    without a word — the posture was written and the inventory rewritten, while that repo kept no
+    `LICENSE` and nothing recording why. It could not be fixed afterwards either: a second run is
+    refused as an answer already given, and `apply-project-license.sh` refuses a target whose
+    `LICENSING.md` differs. Membership is now decided by what the directory *is* — its own Git
+    work tree, which is also what tells the mono and multi layouts apart — and the state of its
+    `LICENSING.md` decides what happens to it: a missing one is written, a deferred one replaced,
+    and one somebody rewrote is left untouched and named in a closing report, with what to do
+    about it. A project nobody has tampered with sees no change.
+  - **`scripts/check.sh` reports an unanswered license question.** Adoption defers it deliberately,
+    so nothing was wrong with an `Unset` posture — but nothing reported it either, and it is not
+    inert: `apply-project-license.sh` refuses to stamp any repo while it stands, so a project left
+    that way could not create a licensed repo and the first sign of it was that refusal. A new
+    check names the posture on every run: a **warning** while it is `Unset` (with the helper that
+    answers it), a pass once it is answered, and a warning if the file is empty rather than
+    unanswered. It is never a failure — deferring is a legitimate state, not drift.
   - **An accepted README addition is committed on a branch and left for you.** Adoption told the
     agent to show you the text and wait for a yes, then said nothing about what happens to the
     file — so the obvious next move was a commit on whatever branch was checked out, which on a

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -365,15 +365,29 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   writing into a repo they own. **A no is a complete answer, not a gap:** the same information is
   already in the recon map, the repo's `architecture/` doc, and its `repos.yml` row, so record
   that the repo documents itself and move on.
+  **Place the Throughstone notice only if something Throughstone-authored landed.** If the README
+  addition was accepted, that section is BSD-3-Clause scaffold material, so run
+  `scripts/apply-project-license.sh --notice-only <repo-path>` — it writes `LICENSE-THROUGHSTONE`
+  and a `LICENSING.md` scoped to that material, disclaiming the rest of the repo, and never a
+  project `LICENSE`. Do **not** run the helper without that flag; it will refuse, and correctly.
+  Run it **now**, before the commit below, so those two files go in with the README change; run
+  afterwards they are written into their working tree at the point you have already stopped, and
+  the addition reaches their trunk with nothing saying where it came from.
+  If the user declined the README addition, nothing Throughstone-authored is in the repo and
+  nothing is owed — placing a notice for absent material would only confuse a later reader.
   **On a yes, commit it on a branch and stop.** The yes was about the text, not about how that
   change should reach their trunk — this is a running system with a review process you did not
-  design. So make a branch in that repo, commit **only the file you proposed** (name it; never
-  `git add -A`, which would sweep up whatever they had in progress), tell them the branch and the
+  design. So make a branch in that repo, and
+  commit every file the method just wrote into that repo — the README file you proposed, and the
+  `LICENSE-THROUGHSTONE` and `LICENSING.md` the notice mode placed alongside it. Name each path;
+  never `git add -A`, which would sweep up whatever they had in progress. One branch, one commit,
+  everything Throughstone put there, so the addition and the notice explaining it cannot be
+  separated by whatever they do next. Then tell them the branch and the
   commit, and stop there. **Never push, open a pull request, or merge**, and never commit onto
   whatever branch happens to be checked out — on an adopted repo that is usually `main`. If the
   working tree already has uncommitted changes to that file, say so and leave it rather than
   committing around them (`METHOD.md` §7). Writing a repo's README from the template where it had
-  none is the same: that one file, on a branch, committed and left — and **not** an
+  none is the same: that file and its notice, on a branch, committed and left — and **not** an
   `ARCHITECTURE.md` alongside it. The template calls for one in a repo with real internal
   complexity **that this method created**, and adoption creates none: these repos have the
   complexity and other people own them. So an adopted repo's internal design is written up in the
@@ -407,13 +421,6 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   its entire history to forks, caches, and crawlers and making it private again retrieves none of
   it. Adoption is the exact circumstance where this matters most: you are working across a stranger's
   private codebase, at speed, with more repos in flight than anyone is tracking closely.
-  **Place the Throughstone notice only if something Throughstone-authored landed.** If the README
-  addition was accepted, that section is BSD-3-Clause scaffold material, so run
-  `scripts/apply-project-license.sh --notice-only <repo-path>` — it writes `LICENSE-THROUGHSTONE`
-  and a `LICENSING.md` scoped to that material, disclaiming the rest of the repo, and never a
-  project `LICENSE`. Do **not** run the helper without that flag; it will refuse, and correctly.
-  If the user declined the README addition, nothing Throughstone-authored is in the repo and
-  nothing is owed — placing a notice for absent material would only confuse a later reader.
   **Never license an adopted repo.** Every repo here is registered in place, so its licensing is
   its owner's and the method only records it — the same rule that leaves its README augmented and
   its CI alone (`METHOD.md` §7: a repo the method did not create keeps what it already has).

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -385,8 +385,10 @@ All but the last are documentation only; nothing you already produced is rewritt
 - **An accepted README addition is committed on a branch and left there.** `RETCON-PROMPT.md` told
   the agent to show you the text and wait for a yes, then said nothing about the file afterwards —
   no branch, no commit, no push. On an adopted repo the obvious continuation is a commit on
-  whichever branch is checked out, usually `main`, followed by a push. It now makes a branch,
-  commits only the file it proposed, reports the branch and commit, and stops; never pushes, opens
+  whichever branch is checked out, usually `main`, followed by a push. It now places the
+  Throughstone notice first, then makes a branch, commits every file it just wrote into that repo
+  — the README addition plus the `LICENSE-THROUGHSTONE` and `LICENSING.md` the notice mode placed
+  — reports the branch and commit, and stops; never pushes, opens
   a PR, or merges; and leaves the file alone if it already has uncommitted changes. A README
   written from the template for a repo that had none follows the same path, and never brings an
   `ARCHITECTURE.md` with it — an adopted repo's internal design is written up in the docs hub's

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -403,6 +403,33 @@ else
   pass "no overview.md yet (project not initialized?) — skipping check-in cadence check"
 fi
 
+hdr "11. Project license posture (.throughstone/project-license)"
+# Adoption defers the license question: init.sh --mode=existing writes `Unset` and the recon-map
+# checkpoint answers it with scripts/set-project-license.sh, once the repos' own licensing has been
+# read. That deferral is legitimate, so this is a WARN and never a FAIL — but nothing else reports
+# it, and an Unset posture is not inert: scripts/apply-project-license.sh refuses to stamp any repo
+# while it stands, so a project left this way quietly cannot create a licensed repo. Say it here so
+# the open question is visible on every run rather than discovered at the first refusal.
+POSTURE_FILE="$DOCS_DIR/.throughstone/project-license"
+if [ -f "$POSTURE_FILE" ]; then
+  POSTURE="$(head -n 1 "$POSTURE_FILE" | tr -d '[:space:]')"
+  case "$POSTURE" in
+    Unset)
+      warn "the project's license has not been chosen yet (posture: Unset)"
+      hint "answer it with scripts/set-project-license.sh <license> [--holder NAME]; until then apply-project-license.sh refuses to stamp a repo"
+      ;;
+    "")
+      warn ".throughstone/project-license is empty — the license posture cannot be read"
+      hint "restore it with the project's license id, or scripts/set-project-license.sh if it was never answered"
+      ;;
+    *)
+      pass "project license posture recorded ($POSTURE)"
+      ;;
+  esac
+else
+  pass "no .throughstone/project-license yet (project not initialized?) — skipping license posture check"
+fi
+
 # --- Summary ------------------------------------------------------------------
 hdr "Summary"
 printf '  %d fail(s), %d warning(s)\n' "$fails" "$warns"

--- a/Code/{{PROJECT}}-docs/scripts/set-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/set-project-license.sh
@@ -125,21 +125,82 @@ if [ "$PROJECT_IS_OPEN_SOURCE" = "1" ]; then
   fi
 fi
 
-# generated_repos — print each directory holding a LICENSING.md this project has not settled yet.
+# is_generated_repo DIR — true when DIR is a repo init.sh created, rather than a folder inside one.
+# Reads: DIR's git metadata.
+# Writes: nothing.
+# Returns: 0 when DIR is the top level of its own work tree.
+#
+# This is what tells the layouts apart without being told which one is in use. Multi-repo makes the
+# docs hub and prompts/ their own repos and leaves the workspace root a plain shell; mono-repo makes
+# the root the one repo, so the docs hub inside it reports the root as its top level, not itself.
+# Both sides are compared as PHYSICAL paths: `git rev-parse --show-toplevel` resolves symlinks,
+# and a logical `pwd` does not, so on a system whose temp or home path is a symlink the two never
+# match and every repo looks like a folder inside another one.
+is_generated_repo() {
+  local top
+  top="$(git -C "$1" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  top="$(cd "$top" 2>/dev/null && pwd -P)" || return 1
+  [ "$top" = "$(cd "$1" && pwd -P)" ]
+}
+
+# generated_repos — print each generated repo this answer should settle.
 # Reads: the docs hub, its sibling prompts/, and the workspace root.
 # Writes: nothing (prints one path per line).
 # Returns: 0 always.
 #
-# Those three are every directory init.sh can turn into a generated repo: multi-repo makes the docs
-# hub and prompts/ repos, mono-repo makes the workspace root one. Selecting by the marker rather
-# than by layout means this stays correct whichever one the project used, and skips a directory
-# that is not a generated repo — the marker is only ever written by init.sh's deferred path.
+# Those three are every directory init.sh can turn into a generated repo. Selection used to key on
+# the deferred marker inside LICENSING.md, which silently skipped any repo whose copy had been
+# edited or deleted: the posture was written, the inventory rewritten, and that repo was left with
+# no LICENSE and no mention of it — unrecoverable afterwards, since a second run is refused as an
+# answer already given and apply-project-license.sh refuses a target whose LICENSING.md differs.
+#
+# So membership is decided by what the directory IS, and the state of its LICENSING.md decides what
+# happens to it: a missing one is written (a generated repo is owed it either way), a deferred one
+# is replaced, and one that is neither is left alone and reported by unsettled_repos below. A repo
+# is never skipped without saying so.
 generated_repos() {
   local dir
   for dir in "$DOCS_ROOT" "$DOCS_ROOT/../../prompts" "$DOCS_ROOT/../.."; do
+    [ -d "$dir" ] || continue
+    is_generated_repo "$dir" || continue
+    if [ -f "$dir/LICENSING.md" ] && ! grep -Fq "$DEFERRED_MARKER" "$dir/LICENSING.md"; then
+      settled_licensing_matches "$dir" || continue
+    fi
+    ( cd "$dir" && pwd -P )
+  done
+}
+
+# settled_licensing_matches DIR — true when DIR/LICENSING.md is already the summary this answer
+# would write, i.e. a re-run rather than something a person edited.
+# Reads: DIR/LICENSING.md, PROJECT_LICENSE_ID, PROJECT_IS_OPEN_SOURCE.
+# Writes: a temp file, removed before returning.
+# Returns: 0 when the existing file is byte-identical to the settled form.
+settled_licensing_matches() {
+  local probe rc
+  probe="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-probe.XXXXXX")"
+  write_licensing_summary "$probe"
+  cmp -s "$probe/LICENSING.md" "$1/LICENSING.md"; rc=$?
+  rm -rf "$probe"
+  return "$rc"
+}
+
+# unsettled_repos — print each generated repo this answer must not touch and did not settle.
+# Reads: the same three candidates.
+# Writes: nothing (prints one path per line).
+# Returns: 0 always.
+#
+# Only one case reaches here: a generated repo whose LICENSING.md is neither the deferred text nor
+# the settled one, which means somebody wrote it. Overwriting it would destroy that; saying nothing
+# is what this whole change exists to stop.
+unsettled_repos() {
+  local dir
+  for dir in "$DOCS_ROOT" "$DOCS_ROOT/../../prompts" "$DOCS_ROOT/../.."; do
+    [ -d "$dir" ] || continue
+    is_generated_repo "$dir" || continue
     [ -f "$dir/LICENSING.md" ] || continue
-    grep -Fq "$DEFERRED_MARKER" "$dir/LICENSING.md" || continue
-    ( cd "$dir" && pwd )
+    grep -Fq "$DEFERRED_MARKER" "$dir/LICENSING.md" && continue
+    settled_licensing_matches "$dir" && continue
+    ( cd "$dir" && pwd -P )
   done
 }
 
@@ -221,4 +282,24 @@ EOF
 if [ "$PROJECT_IS_OPEN_SOURCE" = "0" ]; then
   echo "project license: Proprietary (no LICENSE created)"
 fi
+
+# A generated repo whose LICENSING.md somebody rewrote is the one thing this cannot settle without
+# destroying their text. It is reported rather than skipped, because the answer has now been given
+# and cannot be given again — leaving a repo out of it quietly is how one ends up with no LICENSE
+# and nothing recording that.
+UNSETTLED="$(unsettled_repos)"
+if [ -n "$UNSETTLED" ]; then
+  echo "" >&2
+  echo "set-project-license.sh: these generated repos were NOT settled — their LICENSING.md has" >&2
+  echo "        been edited, and overwriting it would discard what someone wrote there:" >&2
+  printf '%s\n' "$UNSETTLED" | while IFS= read -r repo; do
+    [ -n "$repo" ] || continue
+    echo "  $repo/LICENSING.md" >&2
+  done
+  echo "        The project's license is now $PROJECT_LICENSE_ID and this helper answers once, so" >&2
+  echo "        re-running will not pick them up. Bring each into line by hand: state" >&2
+  echo "        $PROJECT_LICENSE_ID in that file, and for an open-source posture copy" >&2
+  echo "        $DOCS_ROOT/LICENSE to the repo root." >&2
+fi
+
 echo "Commit these changes in each repo they touched."

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -187,6 +187,28 @@ run_existing_case() {
     "**Never push, open a pull request, or merge**"
   assert_file_contains "$docs/RETCON-PROMPT.md" \
     "which would sweep up whatever they had in progress"
+  # The commit covers everything the method wrote, not just the file that was proposed. An accepted
+  # addition leaves the README plus the two files --notice-only places, and only the README is ever
+  # proposed — so a commit scoped to the proposal handed the owners a branch carrying the section
+  # without the notice that explains it, and left the other two untracked in their working tree at
+  # the point the agent had been told to stop.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "commit every file the method just wrote into that repo"
+  # Which means the notice mode runs BEFORE the commit. Its paragraph is placed ahead of the
+  # landing paragraph so the resolver reads in the order it is meant to execute; an agent working
+  # top-to-bottom that hits the commit first has already stopped by the time it reaches the notice.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "Run it **now**, before the commit below, so those two files go in with the README change; run"
+  local notice_line landing_line
+  notice_line="$(grep -n -F -- "**Place the Throughstone notice only if something Throughstone-authored landed.**" \
+    "$docs/RETCON-PROMPT.md" | head -1 | cut -d: -f1)"
+  landing_line="$(grep -n -F -- "**On a yes, commit it on a branch and stop.**" \
+    "$docs/RETCON-PROMPT.md" | head -1 | cut -d: -f1)"
+  [ -n "$notice_line" ] && [ -n "$landing_line" ] && [ "$notice_line" -lt "$landing_line" ] || {
+    echo "FAIL: $name RETCON-PROMPT.md states the landing commit before the notice that rides on it" >&2
+    echo "       notice at line ${notice_line:-none}, landing commit at line ${landing_line:-none}" >&2
+    return 1
+  }
   # An ARCHITECTURE.md at an adopted repo's root is a file appearing in somebody else's repository,
   # and the template comment suggesting one is inside the Overview section a README-less repo gets
   # written from. Adopted repos are exactly the ones with real internal complexity.

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -531,6 +531,113 @@ run_set_project_license_case() {
   }
 }
 
+# run_license_marker_tamper_case — no generated repo is skipped in silence.
+#
+# Which repos this helper settles used to be decided by a marker string inside each one's
+# LICENSING.md. A repo whose copy had been deleted or edited matched nothing and was skipped
+# without a word: the posture was written and the inventory rewritten, while that repo kept no
+# LICENSE and no record of why. Unrecoverable afterwards — a second run is refused as an answer
+# already given, and apply-project-license.sh refuses a target whose LICENSING.md differs.
+#
+# Membership is decided by what the directory is (its own git work tree), and the state of its
+# LICENSING.md decides what happens: a missing one is written, a deferred one replaced, an edited
+# one left alone and named. Both halves are asserted, because recovering the deleted case by
+# overwriting the edited one would be a worse bug than the one being fixed.
+run_license_marker_tamper_case() {
+  local name deleted edited docs
+
+  # (a) LICENSING.md deleted from prompts/ — the repo is still settled.
+  name="retcon-license-marker-deleted"
+  deleted="$TMP_ROOT/$name"
+  copy_template "$deleted"
+  ( cd "$deleted" && ./init.sh --non-interactive --mode=existing --slug="$name" \
+      --desc="Marker deleted" --layout=multi --collab=solo --remotes=no ) >"$TMP_ROOT/$name.out" 2>&1
+  docs="$deleted/Code/$name-docs"
+  rm -f "$deleted/prompts/LICENSING.md"
+  "$docs/scripts/set-project-license.sh" mit --holder "Acme Corp" >"$TMP_ROOT/$name.set" 2>&1 || {
+    echo "FAIL: $name failed after its LICENSING.md was deleted" >&2
+    return 1
+  }
+  [ -f "$deleted/prompts/LICENSE" ] || {
+    echo "FAIL: $name left a generated repo unlicensed after its LICENSING.md was deleted" >&2
+    return 1
+  }
+  [ -f "$deleted/prompts/LICENSING.md" ] || {
+    echo "FAIL: $name did not restore the licensing summary it had to rewrite anyway" >&2
+    return 1
+  }
+
+  # (b) LICENSING.md rewritten by hand — left alone, and said out loud.
+  name="retcon-license-marker-edited"
+  edited="$TMP_ROOT/$name"
+  copy_template "$edited"
+  ( cd "$edited" && ./init.sh --non-interactive --mode=existing --slug="$name" \
+      --desc="Marker edited" --layout=multi --collab=solo --remotes=no ) >"$TMP_ROOT/$name.out" 2>&1
+  docs="$edited/Code/$name-docs"
+  printf '# Licensing\n\nTBD - ask legal.\n' > "$edited/prompts/LICENSING.md"
+  "$docs/scripts/set-project-license.sh" mit --holder "Acme Corp" >"$TMP_ROOT/$name.set" 2>&1 || {
+    echo "FAIL: $name failed on a hand-edited licensing summary" >&2
+    return 1
+  }
+  assert_file_contains "$TMP_ROOT/$name.set" "were NOT settled"
+  # Named by repo-relative path: the helper reports physical paths, and a fixture under a symlinked
+  # temp dir would never match the logical one this test holds.
+  assert_file_contains "$TMP_ROOT/$name.set" "$name/prompts/LICENSING.md"
+  grep -Fq "ask legal" "$edited/prompts/LICENSING.md" || {
+    echo "FAIL: $name overwrote a licensing summary somebody had written" >&2
+    return 1
+  }
+  # And the repos it could settle are still settled — the report is not an abort.
+  grep -Fq "has not chosen its license yet" "$docs/LICENSING.md" && {
+    echo "FAIL: $name stopped settling the other repos when one was reported" >&2
+    return 1
+  }
+
+  # (c) An untampered project reports nothing — the warning must not fire on the normal path.
+  grep -Fq "were NOT settled" "$TMP_ROOT/retcon-license-marker-deleted.set" && {
+    echo "FAIL: $name reported an unsettled repo on a project with none" >&2
+    return 1
+  }
+  return 0
+}
+
+# run_posture_visibility_case — an Unset posture is reported by check.sh.
+#
+# Adoption defers the license question, which is legitimate, so this is a warning and never a
+# failure. But nothing reported it at all: a project could sit Unset indefinitely while
+# apply-project-license.sh refused to stamp any repo, and the first sign of it was that refusal.
+run_posture_visibility_case() {
+  local name="retcon-posture-visible"
+  local work="$TMP_ROOT/$name" docs
+  copy_template "$work"
+  ( cd "$work" && ./init.sh --non-interactive --mode=existing --slug="$name" \
+      --desc="Posture visibility" --layout=multi --collab=solo --remotes=no ) >"$TMP_ROOT/$name.out" 2>&1
+  docs="$work/Code/$name-docs"
+
+  bash "$docs/scripts/check.sh" >"$TMP_ROOT/$name.deferred" 2>&1 || {
+    echo "FAIL: $name turned a legitimate deferral into a check.sh failure" >&2
+    return 1
+  }
+  assert_file_contains "$TMP_ROOT/$name.deferred" "has not been chosen yet"
+  assert_file_contains "$TMP_ROOT/$name.deferred" "scripts/set-project-license.sh"
+
+  # Once answered, the warning goes away rather than becoming permanent noise.
+  "$docs/scripts/set-project-license.sh" apache-2.0 --holder "Acme Corp" >"$TMP_ROOT/$name.set" 2>&1 || {
+    echo "FAIL: $name could not answer the deferred question" >&2
+    return 1
+  }
+  bash "$docs/scripts/check.sh" >"$TMP_ROOT/$name.answered" 2>&1 || {
+    echo "FAIL: $name check.sh failed after the license was chosen" >&2
+    return 1
+  }
+  if grep -Fq "has not been chosen yet" "$TMP_ROOT/$name.answered"; then
+    echo "FAIL: $name still warns about the posture after it was answered" >&2
+    return 1
+  fi
+  assert_file_contains "$TMP_ROOT/$name.answered" "project license posture recorded (Apache-2.0)"
+  return 0
+}
+
 # run_new_case NAME EXTRA_ARGS... — greenfield must be untouched (marker, no PLAN, message).
 run_new_case() {
   local name="$1"; shift
@@ -709,6 +816,8 @@ run_existing_case "retcon-mono"  mono
 run_existing_env_case
 run_deferred_license_case
 run_set_project_license_case
+run_license_marker_tamper_case
+run_posture_visibility_case
 run_new_case "green-explicit" --mode=new
 run_new_case "green-default"
 run_invalid_mode_case


### PR DESCRIPTION
The adoption half of the same review. Two commits; the base half is #156, which forward-merges into
this line afterwards.

### An accepted README addition lands together with its notice

An accepted `Role in <project>` section leaves two things in an adopted repo: the README file, and
the `LICENSE-THROUGHSTONE` / `LICENSING.md` that `--notice-only` places to mark it as scaffold
material. The resolver told the agent to commit only the file it proposed, and placed the notice
paragraph *after* the landing paragraph — so an agent working the substep top to bottom committed
the README, stopped, and only then wrote two files into the owners' working tree with nothing left
to put them on a branch.

Measured on a real repo: the branch carried `README.md` alone and `git status` showed
`LICENSE-THROUGHSTONE` and `LICENSING.md` untracked, after the agent had been told to stop. The
owners merge the section with nothing explaining where it came from.

The notice paragraph now precedes the landing paragraph, so the substep reads in the order it
executes, and the commit covers every file just written into that repo — each path named, still
never `git add -A`. A README written from the template where a repo had none follows the same path:
that file and its notice, one branch, one commit. The 2.0 migration note and release entry describe
the corrected behaviour; neither has shipped.

### No generated repo is left out of the license answer in silence

Which repos `set-project-license.sh` settled was decided by a marker string inside each one's
`LICENSING.md`. A repo whose copy had been edited or deleted matched nothing and was skipped without
a word — the posture was written and the inventory rewritten, while that repo kept no `LICENSE` and
nothing recording why. It could not be repaired afterwards either: a second run is refused as an
answer already given, and `apply-project-license.sh` refuses a target whose `LICENSING.md` differs.

Membership is now decided by what the directory *is* — its own Git work tree, which is also what
separates the mono and multi layouts without being told which is in use. The state of its
`LICENSING.md` then decides what happens: a missing one is written, a deferred one replaced, and one
somebody rewrote is left untouched and named in a closing report with what to do about it. A project
nobody has tampered with sees no change.

Paths are compared physically on both sides, since `rev-parse` resolves symlinks and a logical `pwd`
does not — under a symlinked temp or home directory every repo would otherwise look like a folder
inside another one.

### `check.sh` reports an unanswered license question

Adoption defers the question deliberately, so nothing was wrong with an `Unset` posture — but
nothing reported it either, and it is not inert: `apply-project-license.sh` refuses to stamp any
repo while it stands, so a project left that way could not create a licensed repo and the first sign
of it was that refusal. A new check names the posture on every run — a warning while it is `Unset`
(with the helper that answers it), a warning if the file is empty rather than unanswered, a pass
once it is set. Never a failure: deferring is a legitimate state, not drift.

## Verification

- Full suite **15/15** at `c1b1a27`, the shipping commit.
- Fixtures from `git archive` of the shipping ref: adoption multi (deferred posture), adoption mono
  (BSD-3), and greenfield (Apache-2.0), every one `check.sh` 0/0 and `links.sh` clean.
- The landing sequence run end to end against a real repo carrying its own `LICENSE`, its own CI and
  a GPL `COPYING`: notice placed first, one branch, one commit holding all three files, working tree
  clean afterwards, the repo's own terms untouched, and full-mode stamping still refused.
- `set-project-license.sh` exercised across deleted, hand-edited, untampered, deferred and answered
  states, in both layouts.
- Five new checks bitten individually. Writing them is what caught the new `check.sh` check reading
  a path relative to the caller's directory rather than the docs hub — it passed by hand and failed
  the moment a test invoked it the way the runbooks do.
- Forward merge of #156 into this branch trialled from a clean clone: three conflicts, resolved per
  hunk, `UPDATING-THROUGHSTONE.md` verified byte-identical to this line's side so nothing else was
  silently dropped, merged suite 15/15, real merge commit with two parents.

One known limitation: the "don't overwrite a hand-edited summary" assertion cannot be bitten
independently — any mutation that clobbers the file also silences the report, so the report
assertion fires first. They are coupled by construction and both are covered.
