### PR TITLE
Record what the method did to each repo's README in the inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ any project built with it.
 
 ## [Unreleased]
 
+### Added
+- **The repo inventory records what the method did to each repo's README.** `METHOD.md` §7 lets a
+  declined README addition stand for every remaining repo registered in place — rather than putting
+  the same proposal to the same owners once per repo — and three files told an agent to record that
+  answer "in the repo's `repos.yml` row". No field there held it, so the answer lived only in the
+  session that produced it. The periodic check-in then skips a declined repo, and could not tell one
+  from a repo nobody had proposed to, or from one whose section somebody deleted: it either
+  re-proposed into a repo whose owners had already refused, or filed a real gap as settled and
+  stopped looking. Every row now carries a `readme:` value — `stamped`, `augmented`, `written`,
+  `role-stated`, `declined`, or `not-proposed` — defined in the registry's own header, written when
+  the answer comes, and read by the check-in's README sweep instead of re-derived from the repo. A
+  standing decline is recorded as `declined` on each remaining row at the moment it is given. The
+  field is a record, never an instruction: the repo's README is authoritative and this line is a
+  copy that can drift. A missing value means *not recorded* and defaults to nothing, so inventories
+  written before this release keep working and say so.
+- **A README that already states the repo's place is a complete outcome too.** §7 said to "add only
+  the missing piece", which reads as "add it" when the piece is not missing. Where a
+  registered-in-place repo's README already says what the repo is within the system, nothing is
+  proposed — recorded as `role-stated`, so a later sweep does not read it as a repo nobody asked.
+
 ### Changed
 - **A session template's go-ahead now fires on being *invoked*, not on being *read*.** Every
   `templates/architecture-sessions/*.md` closed with "Begin now — in this same reply", which treated

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -131,7 +131,14 @@ creates is **stamped** from `templates/repo-readme-template.md`. For a repo **re
 place**, the rule keys on whether a README is already there: if it is, **augment** — add a short
 `Role in {{PROJECT}}` section and nothing else, and never rewrite a section the repo already has;
 if the repo has none, write one from the template. Either way you are writing into the user's
-repo, so propose it before you do (`METHOD.md` §7). Nothing else about a registered-in-place repo
+repo, so propose it before you do (`METHOD.md` §7) — and where its README
+already says what the repo is within the system, nothing is missing, so propose nothing.
+**Whichever way it goes, record
+it in that repo's `registries/repos.yml` row as its `readme:` value** (`stamped` / `augmented` /
+`written` / `role-stated` / `declined` / `not-proposed`; the registry header defines each). That
+value is what the periodic check-in reads to know how much of each README the method is answerable
+for, and it is the only record that a decline was ever given.
+Nothing else about a registered-in-place repo
 is scaffolded — it already exists, and in particular the CI gate is never installed into one (its
 pipeline is its own). If the README addition is accepted, that leaves Throughstone-authored
 material in the repo, so place its notice with

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -503,9 +503,10 @@ project is actually missing. Per artifact that means:
 - **README — augmented, never stamped over.** It already exists and is usually the repo's
   most-read file, so the template is not copied onto it: add only the missing piece — a short
   `Role in <project>` section naming what the repo is within the system, with a link to its
-  architecture doc — and leave every section the repo already has untouched. The rule keys on
-  whether a README is there, not on how the repo got here: where a registered-in-place repo has
-  **no** README there is nothing to preserve, so write it from the
+  architecture doc — and leave every section the repo already has untouched. Where that README
+  already says what the repo is within the system, nothing is missing: propose nothing, and
+  record that. The rule keys on whether a README is there, not on how the repo got here: where a
+  registered-in-place repo has **no** README there is nothing to preserve, so write it from the
   template — every section but Licensing, which describes a repo the method created and is left
   out here as it is when augmenting. That is the one file; nothing else about the repo is
   scaffolded — in particular no `ARCHITECTURE.md`, which the template calls for in a *created*
@@ -513,7 +514,11 @@ project is actually missing. Per artifact that means:
   would otherwise attract. An in-place repo's internal design is written up in the docs hub's
   `architecture/`, where the project's own docs live, not as a second new file at the root of a
   repository the method does not own. Where such a repo already has an `ARCHITECTURE.md`, it is
-  its owners': read it, link it, leave it.
+  its owners': read it, link it, leave it. **Whichever of those happened, record it in that repo's
+  `registries/repos.yml` row as its `readme:` value** — `augmented`, `written`, `role-stated`, or
+  `declined` for a refusal, and `not-proposed` while the addition is still to be put to them
+  (`stamped` is the created-repo case). That row is the only durable record of what the method did
+  to that file; the branches above all describe a moment, and the value is what survives it.
 - **CI — its own.** `templates/ci/code-repo-ci.yml` fails until configured, so installing it would
   replace or break whatever already gates that repo's merges. Record what it runs instead.
 - **Licensing — recorded as found.** The repo already has a licensing status: a `LICENSE`, a
@@ -556,7 +561,10 @@ permission to label what they already said yes to.
 
 **That addition is proposed before it happens** — show the exact text and where it goes, and wait
 for an answer. A decline is a complete outcome, not a gap: the same information lives in the
-architecture doc — and in the repo's `repos.yml` row.
+architecture doc — and in the repo's `repos.yml` row, whose `readme:` field records the answer as
+`declined`. Write it when the answer comes, not later: an unrecorded decline is indistinguishable
+from an addition nobody has proposed yet, so the next agent to read that row puts the same
+proposal to owners who have already refused it.
 
 **An accepted write is committed and left there. It is never pushed.** A yes settles what the text
 should say; it does not say anything about how that change should reach the repo's trunk, and every
@@ -579,7 +587,10 @@ inspect, amend, or delete.
 put to the same owners repeatedly, and someone who has said no once is
 not asking to be asked again for every remaining repo — so when a proposal is declined, establish
 whether that answer covers this repo or the rest of them, and where it is standing, stop proposing
-and record that those repos document themselves. Ask that once, not per repo — and note which way
+and record that those repos document themselves. Recording it is one edit per row and not a note
+kept in the session: set every remaining registered-in-place repo's `readme:` to `declined` then
+and there. A standing decline held only in the conversation is gone by the next session, and the
+repeated asking it was given to stop begins again. Ask that once, not per repo — and note which way
 it runs: it is the answer that is being reused, never the permission, so a yes for one repo says
 nothing about the next, whose text is its own proposal. Choosing or changing what any of these say
 for an existing repo is its owners' act, taken deliberately by them, never a side effect of adding

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -263,6 +263,19 @@ and what to check.
   generated project (or from the template) into your docs hub — the two seed rows in `repos.yml`
   describe the docs hub and `prompts/`, and the other two files start empty.
 
+- **`registries/repos.yml` rows carry a `readme:` field.** It records what the method did to that
+  repo's README — `stamped` for a repo the method created, `augmented` where a `Role in <project>`
+  section was added to an existing README, `written` where the method wrote a README for a repo
+  that had none, `role-stated` where the README already said what the repo is within the system,
+  `declined` where the owners said no, and `not-proposed` while the addition is still to be put to
+  them. The registry's own header defines each. It exists because `METHOD.md` §7 lets a decline
+  stand for every remaining repo, and told you to record that without naming anywhere to record it
+  — so the periodic check-in, which skips a declined repo, had no way to tell one from a repo
+  nobody had asked. **One thing to check:** your existing rows have no value, which reads as *not
+  recorded* rather than defaulting to anything. Nothing rewrites them. Fill them in at your next
+  check-in — the repos the method created are `stamped`, and only you know what happened to the
+  rest.
+
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
   here to run this session…" and ends by releasing a reader who wasn't sent to run it. When you
   invoke a session normally, behavior is unchanged — you type `Run STEP-1.N` and get the first

--- a/Code/{{PROJECT}}-docs/registries/README.md
+++ b/Code/{{PROJECT}}-docs/registries/README.md
@@ -9,7 +9,7 @@ itself, because tooling and CI parse it. Keep each file the **source of truth**;
 
 | File | What | Consumed by |
 |------|------|-------------|
-| [`repos.yml`](repos.yml) | The repo inventory — which repos exist, what each is, and where its docs live. See its header and `METHOD.md` §7. | `scripts/setup-workspace.sh` (clones from `remote:`); `runbooks/collaboration.md` (STEP-number reservation); CI. |
+| [`repos.yml`](repos.yml) | The repo inventory — which repos exist, what each is, where its docs live, and what the method did to each one's README (`readme:`). See its header and `METHOD.md` §7. | `scripts/setup-workspace.sh` (clones from `remote:`); `runbooks/collaboration.md` (STEP-number reservation); `runbooks/check-in.md` (the README sweep reads `readme:`); CI. |
 | [`risks.yml`](risks.yml) | The accepted risk / tech-debt index — known risks, conscious deferrals, and debt with owners, revisit triggers, and references to the artifact that explains the detail. | Security session deferrals; dependency audits; incident follow-ups; `runbooks/check-in.md`. |
 | [`security-reviews.yml`](security-reviews.yml) | The security review ledger — latest S0/S1/S2 review dates, cadence, report paths, reviewed commit, rough SLOC snapshot, and deltas since the previous run. | `runbooks/security-review.md`; `runbooks/check-in.md` security gate. |
 

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -19,23 +19,74 @@
 # Teams: give each repo a `remote:` field (any cloneable git URL). scripts/setup-workspace.sh clones from
 # it, and the STEP-number reservation in runbooks/collaboration.md relies on a shared remote
 # for prompts/ + this docs hub. Solo with no remotes, it's optional.
+#
+# `readme:` (per row) records what the method did to that repo's README — and therefore what a
+# later check-in is answerable for when it sweeps them (runbooks/check-in.md). It is a RECORD,
+# never an instruction: the repo's own README is authoritative and this line is a copy that can
+# drift, so trust the repo when they disagree and fix the line. One of:
+#
+#   stamped        The method CREATED this repo, so the whole README is the method's own —
+#                  stamped from templates/repo-readme-template.md for a code repo, or written by
+#                  init.sh for this docs hub and prompts/.
+#   augmented      REGISTERED IN PLACE with a README already there, and its owners accepted a
+#                  short `Role in {{PROJECT}}` section. That section is the only part the method
+#                  wrote; the rest of the file is theirs.
+#   written        REGISTERED IN PLACE with NO README, so one was written from the template and
+#                  accepted. The whole file is the method's, as with `stamped` — but nothing else
+#                  in that repo is scaffolded.
+#   role-stated    REGISTERED IN PLACE, and its README already says what the repo is within the
+#                  system. Nothing was missing, so nothing was proposed and nothing is owed.
+#   declined       Proposed and refused. Nothing was written and nothing is owed — a complete
+#                  outcome, not a gap (METHOD.md §7). Do not propose it again.
+#   not-proposed   REGISTERED IN PLACE and the addition has not been put to its owners yet. This
+#                  is the one value that means something is still open.
+#
+# The last three all mean the method wrote nothing, and they are three values rather than one
+# because they tell a later reader to do three different things: leave it, leave it, or ask. A
+# row that cannot tell them apart is why this field exists.
+#
+# A missing value means NOT RECORDED — read the repo, work out which of the six it is, and write
+# it down. It does not default to `stamped` (which hides a real gap behind a repo that was never
+# asked) and it does not default to `not-proposed` (which re-opens a question the owners already
+# answered). Inventories written before this field existed have one on every row.
+#
+# A STANDING decline — one answer covering the remaining repos rather than just this one
+# (METHOD.md §7) — is recorded by writing `declined` on every remaining registered-in-place row
+# at the moment it is given. That is what "record that those repos document themselves" means,
+# and there is no separate value for it: the outcome per repo is identical either way, and these
+# rows are the record. A standing decline that lives only in the conversation is gone by the next
+# session, and the re-asking it was meant to stop starts again.
 
 repos:
   - name: "{{PROJECT}}-docs"
     location: "Code/{{PROJECT}}-docs/"
     type: docs            # docs | service | library | app | infra | tests
+    readme: stamped
     description: "Documentation hub: architecture, ADRs, standards, registries."
 
   - name: "prompts"
     location: "prompts/"
     type: docs
+    readme: stamped
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
   # Service / app / library repos get added here as the architecture names them. A repo the method
   # CREATES is stamped from templates/repo-readme-template.md; a repo REGISTERED IN PLACE is listed
-  # here like any other but scaffolded in none of these ways — see METHOD.md §7. Example:
+  # here like any other but scaffolded in none of these ways — see METHOD.md §7. `readme:` is the
+  # field whose value differs by which kind it is, so one example of each:
+  #
+  # Created by the method — a Code/* sibling, carrying the whole template README:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service
+  #   readme: stamped
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
+  #   description: "..."
+  #
+  # Registered in place — its real location, and the outcome of the one addition it was offered.
+  # Never a value you picked for it: `readme:` records the answer its owners actually gave.
+  # - name: "legacy-billing"
+  #   location: "/srv/src/legacy-billing/"
+  #   type: service
+  #   readme: declined          # or augmented / written / role-stated / not-proposed
   #   description: "..."

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -143,15 +143,26 @@ Beyond the architecture docs, sweep four things that rot just as quietly:
 - **Repo READMEs** — every code repo still explains what it *is*, and its **Setup / Running /
   Testing** steps still work from a clean checkout. They are written once and otherwise never
   re-checked, so they're usually the stalest doc a new contributor or agent hits first (and any
-  `ARCHITECTURE.md` still matches the design). A repo the method **created** carries the full
-  template, so check its **Overview**. For a repo **registered in place** this keys on the same
-  thing the writing rule keyed on — whether a README was already there. **One that had one** owns
-  it: check only that the `Role in {{PROJECT}}` section still describes the repo's place in the
-  system, and leave the rest to its owners. **One that had none** carries a README the method
-  wrote from the template, so that file is Throughstone-authored like a created repo's — check its
-  **Overview** the same way, and still scaffold nothing else there. If the addition was declined,
-  or the repo has no README, that is not a gap to close here — the framing lives in its
-  architecture doc, and in its `repos.yml` row (`METHOD.md` §7).
+  `ARCHITECTURE.md` still matches the design). **How much of each README the method is answerable
+  for is not something to re-derive from the repo — read its `readme:` field in
+  `registries/repos.yml`,** which recorded it at the time (`METHOD.md` §7; that file's header
+  defines every value). Sweep each row by what it says:
+  - `stamped` — a repo the method created, carrying the full template, so check its **Overview**.
+  - `written` — a repo **registered in place** that had no README, so the method wrote the file
+    from the template. That file is Throughstone-authored like a created repo's: check its
+    **Overview** the same way, and still scaffold nothing else there.
+  - `augmented` — the repo owns its README and the method added one section:
+    check only that the `Role in {{PROJECT}}` section still describes the repo's place in the
+    system, and leave the rest to its owners.
+  - `role-stated` and `declined` — the method wrote nothing, and neither is a gap to close here:
+    the framing lives in its architecture doc, and in its `repos.yml` row (`METHOD.md` §7).
+    **Do not re-propose a `declined` repo** — that answer may also have been given for every
+    other repo at once.
+  - `not-proposed` — the one value that means something is still open: the addition has not been
+    put to that repo's owners. Raise it with the user, and write nothing into the repo meanwhile.
+  - **no value at all** — the row predates this field. Read the repo, work out which of the six
+    it is, and write it down; until it is recorded, no later sweep can tell a settled repo from
+    one nobody has asked.
 - **Interface contract artifacts** — any artifact named by `architecture/*-interface-contracts.md` (OpenAPI /
   GraphQL / protobuf / event schema / JSON Schema / public package interface, etc.) still
   matches what the service, worker, CLI, library, or import/export path actually exposes. A

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -108,18 +108,24 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    **Each
    repo's README isn't just stamped — its role one-liner and Overview get filled in** (what
    the repo is and the slice of the system it owns), and the repo gets a row in
-   `registries/repos.yml` with a one-line `description`; a repo isn't scaffolded until it can
-   explain itself.
+   `registries/repos.yml` with a one-line `description` and `readme: stamped` (the whole file is
+   the method's); a repo isn't scaffolded until it can explain itself.
    **A repo registered in place is not scaffolded at all.** Everything above describes creating a
    repo, and this one already exists — so it is not created, and the license helper is not run on
    it (above). The one thing it may still be owed is the role-and-place framing its README
    probably lacks, and what to do keys on whether a README is there. **If it has one:** add a
    short `Role in {{PROJECT}}` section and leave every existing section alone — never stamp the
-   template over it. **If it has none:** write its README from the template — that one file, and
-   not the `ARCHITECTURE.md` its Overview comment suggests for a complex repo; an in-place repo's
-   internal design is written up in the docs hub's `architecture/`, not as a new file at its root.
+   template over it — and where that README already says what the repo is within the system,
+   nothing is missing, so propose nothing. **If it has none:** write its README from the
+   template — that one file, and not the `ARCHITECTURE.md` its Overview comment suggests for a
+   complex repo; an in-place repo's internal design is written up in the docs hub's
+   `architecture/`, not as a new file at its root.
    Either way it is the user's repo, so show them what you intend to add and where, and wait for a
-   yes. **On a yes, place the notice, then commit both on a branch and stop.** The accepted text is
+   yes. **Record how it went in that repo's `registries/repos.yml` row** as its `readme:` value —
+   `augmented`, `written`, `role-stated`, `declined`, or `not-proposed` while it is still to be
+   asked (the registry header defines each). That row is what a later check-in reads to tell a
+   settled repo from one still owed the question.
+   **On a yes, place the notice, then commit both on a branch and stop.** The accepted text is
    Throughstone-authored, so run
    `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <repo-path>` first, then
    commit every file the method just wrote into that repo — the README file you proposed, and the

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -8,7 +8,8 @@
   must carry a README. Keep the section headings consistent across all repos so the project
   reads uniformly. Sections that don't apply can be dropped (e.g. no "API / interface" for a
   library), but keep the order — and never drop the role one-liner above or the Overview
-  below: explaining what the repo *is* is the one non-negotiable part.
+  below: explaining what the repo *is* is the one non-negotiable part. Record it in that repo's
+  `Code/{{PROJECT}}-docs/registries/repos.yml` row as `readme: stamped`.
 
   AUGMENT a repo REGISTERED IN PLACE — one that existed before this project did — WHEN IT ALREADY
   HAS A README. The rule keys on whether that file exists, not on how the repo got here: a
@@ -32,9 +33,19 @@
   three sentences on the slice of the system this repo owns, and links to its architecture doc
   and the docs hub. Never replace, reorder, or rewrite a section the repo already has, and
   never stamp the Licensing section below into it (that describes a repo the method created).
-  Show the exact text and where it will go, and get agreement before writing into someone
-  else's repo; if they decline, that is a complete outcome — the same information already lives
-  in the repo's architecture doc, and in its `registries/repos.yml` row.
+  Where the README already says what the repo is within the system nothing is missing, so propose
+  nothing. Otherwise show the exact text and where it will go, and get agreement before writing
+  into someone else's repo; if they decline, that is a complete outcome — the same information
+  already lives in the repo's architecture doc, and in its `registries/repos.yml` row.
+
+  RECORD THE OUTCOME IN THAT REPO'S INVENTORY ROW, whichever way it went — the `readme:` field in
+  `Code/{{PROJECT}}-docs/registries/repos.yml`, whose header defines every value. `augmented`
+  when you added the Role section, `written` when you wrote the file for a repo that had none,
+  `role-stated` when its README already said the repo's place and you proposed nothing,
+  `declined` when they said no, and `not-proposed` until you have actually asked. Write it when
+  the answer comes. Nothing else records this: months later a check-in reads that row to decide
+  whether this repo is settled or still owed a question, and a row that does not say cannot tell
+  a refusal from an addition nobody has proposed.
 
   ON A YES, COMMIT IT ON A BRANCH AND STOP. A yes settles what the text says, not how it should
   reach their trunk — every team has its own answer to that. Place the notice first (below), then
@@ -53,7 +64,9 @@
   the same people repo after repo, and someone who has already said no is not asking to be asked
   again for each remaining one. So on a decline, establish whether it covers this repo or the
   rest — and where it is standing, stop proposing and record that those repos document
-  themselves. Ask that once, not per repo. The permission is never what carries forward, only
+  themselves: set every remaining registered-in-place repo's `readme:` to `declined` now, one
+  edit per row, rather than keeping the answer in the session where it does not survive the
+  session. Ask that once, not per repo. The permission is never what carries forward, only
   the refusal: a yes for one repo says nothing about the next, whose text is its own proposal.
 
   For a repo this method CREATES, stamp the CI gate named by the Test Strategy architecture doc

--- a/tests/init-inplace-repo-rules.sh
+++ b/tests/init-inplace-repo-rules.sh
@@ -113,7 +113,7 @@ run_case() {
     "METHOD.md §7 lost the single rule the per-artifact consequences hang off"
   local claimed bullets
   claimed="$(sed -n 's/.*This is one rule, not \([a-z]*\)\..*/\1/p' "$docs/METHOD.md")"
-  bullets="$(sed -n '/A repo the method did \*not\* create keeps/,/^Every write above/p' \
+  bullets="$(sed -n '/A repo the method did \*not\* create keeps/,/^\*\*Exactly two of those five/p' \
     "$docs/METHOD.md" | grep -c '^- \*\*')"
   case "$bullets" in
     3) expected=three ;; 4) expected=four ;; 5) expected=five ;;
@@ -243,7 +243,8 @@ run_case() {
   # file under "declined" and stops checking the one README there the method is answerable for.
   assert_contains "$check_in" "check only that the \`Role in $name\` section" \
     "check-in README sweep does not scope the Role-section check to an augmented repo"
-  assert_contains "$check_in" "**One that had none** carries a README the method" \
+  assert_contains "$check_in" \
+    "- \`written\` — a repo **registered in place** that had no README, so the method wrote the file" \
     "check-in README sweep has no branch for a README the method wrote for an in-place repo"
   assert_contains "$check_in" "**Overview** the same way, and still scaffold nothing else there" \
     "check-in README sweep does not check that written README the way a created repo's is checked"
@@ -326,6 +327,81 @@ run_case() {
   assert_absent "$repos" "as the architecture names them and they" \
     "repo inventory comment still says every repo listed here is stamped"
 
+  # --- The `readme:` field. Three files told an agent to record a declined README addition "in the
+  # repo's repos.yml row" and the row had nothing to record it in, so the outcome lived only in the
+  # conversation that produced it. Months later the check-in below branches on that fact and could
+  # not tell a refusal from a proposal nobody had made — so it either re-proposed into a repo whose
+  # owners had already said no, or filed a real gap under "declined" and stopped checking.
+  #
+  # The vocabulary is pinned value by value because each one exists to make a distinction some
+  # consumer acts on, and dropping any of them silently restores the ambiguity: `stamped`/`written`
+  # are Throughstone-authored files, `augmented` is one section of somebody else's, and the last
+  # three all mean "nothing was written" while telling a later reader to do three different things.
+  for value in stamped augmented written role-stated declined not-proposed; do
+    assert_contains "$repos" "#   $value" \
+      "repo inventory header does not define the \`readme: $value\` value"
+  done
+  # Every row carries it, including the two the bootstrap writes — the field is on every repo, not
+  # only the registered-in-place ones, so a sweep never has to work out which kind a row is first.
+  [ "$(grep -c '^    readme: stamped$' "$repos")" = 2 ] || {
+    echo "FAIL: the bootstrap repo rows do not both carry \`readme: stamped\`" >&2
+    return 1
+  }
+  # A missing value must not default to anything. Reading it as `stamped` hides a repo nobody
+  # asked; reading it as `not-proposed` re-opens a question the owners already answered.
+  assert_contains "$repos" "# A missing value means NOT RECORDED" \
+    "repo inventory header lets a missing \`readme:\` default instead of meaning not recorded"
+  # The standing decline's destination. This is the finding the field closes: METHOD.md says to
+  # record that the remaining repos document themselves, and until now said nowhere.
+  assert_contains "$repos" "# A STANDING decline" \
+    "repo inventory header does not say where a standing decline is recorded"
+  assert_contains "$docs/METHOD.md" \
+    "and there. A standing decline held only in the conversation is gone by the next session, and" \
+    "METHOD.md §7 still leaves a standing decline with nowhere durable to live"
+  # The decline paragraph named the row; it has to name the field in it, and say when to write it.
+  assert_contains "$docs/METHOD.md" \
+    "architecture doc — and in the repo's \`repos.yml\` row, whose \`readme:\` field records the answer as" \
+    "METHOD.md §7's declined-README fallback does not name the field that records it"
+  assert_absent "$docs/METHOD.md" \
+    "architecture doc — and in the repo's \`repos.yml\` row." \
+    "METHOD.md §7 still points a decline at a row with no field to hold it"
+  # Both files an agent has open at the moment of the write must say to record the outcome —
+  # following either one alone has to be enough.
+  assert_contains "$readme_tpl" "RECORD THE OUTCOME IN THAT REPO'S INVENTORY ROW" \
+    "repo README template does not tell you to record the README outcome in the inventory row"
+  assert_contains "$planning" \
+    "**Record how it went in that repo's \`registries/repos.yml\` row**" \
+    "planning session does not record an in-place repo's README outcome in its inventory row"
+  assert_contains "$planning" "\`readme: stamped\` (the whole file is" \
+    "planning session does not record a created repo's README as the method's own"
+  # A README that already states the repo's place needs no addition. Every file that describes the
+  # augment branch says so now, because "add only the missing piece" reads as "add it" when the
+  # piece is not missing — and the outcome has a value of its own so it is not filed as a decline.
+  for f in "$docs/METHOD.md" "$readme_tpl" "$planning" "$docs/AGENTS.md"; do
+    assert_contains "$f" "already says what the repo is within the system" \
+      "$(basename "$f") does not exempt a README that already states the repo's place"
+  done
+  # The check-in reads the field rather than re-deriving the history from the repo, which is what
+  # it could not do. Each branch is pinned: the two Throughstone-authored values, the augmented
+  # one, the two settled ones, the one open one, and the unrecorded row.
+  assert_contains "$check_in" "read its \`readme:\` field in" \
+    "check-in README sweep does not read the inventory field that records what the method wrote"
+  assert_contains "$check_in" \
+    "- \`not-proposed\` — the one value that means something is still open" \
+    "check-in README sweep cannot tell an unproposed README addition from a declined one"
+  assert_contains "$check_in" "**Do not re-propose a" \
+    "check-in README sweep does not keep a declined repo from being proposed to again"
+  assert_contains "$check_in" "- **no value at all** — the row predates this field" \
+    "check-in README sweep has no branch for a row written before the field existed"
+  assert_absent "$check_in" "If the addition was declined," \
+    "check-in README sweep still lumps a declined repo in with one that has no README"
+  # The worked examples teach the field, and a single created-repo example teaches half of it —
+  # `readme:` is precisely the field whose value differs by which kind of repo the row describes.
+  assert_contains "$repos" "  #   readme: stamped" \
+    "repo inventory's created-repo example does not carry the field"
+  assert_contains "$repos" "  #   readme: declined" \
+    "repo inventory has no registered-in-place example showing a recorded outcome"
+
   # --- The fallback. Every rule above enumerates cases, and three rounds of review each turned up
   # one nobody had enumerated. What an agent does with the next such case is the thing worth
   # pinning: ask, and write nothing meanwhile. It has to ship in the file being read at the moment
@@ -400,7 +476,8 @@ run_deprecated_registries_case() {
   # mono-repo project might not keep one, which was true only because this flag could delete it.
   assert_absent "$docs/METHOD.md" "where the project keeps an inventory" \
     "METHOD.md §7 still hedges that a project may not keep an inventory"
-  assert_contains "$docs/METHOD.md" "architecture doc — and in the repo's \`repos.yml\` row." \
+  assert_contains "$docs/METHOD.md" \
+    "architecture doc — and in the repo's \`repos.yml\` row, whose \`readme:\` field records" \
     "METHOD.md §7's declined-README fallback no longer names the inventory row"
   assert_contains "$docs/runbooks/check-in.md" 'and in its `repos.yml` row (`METHOD.md` §7).' \
     "check-in README sweep no longer names the inventory row plainly"


### PR DESCRIPTION
`METHOD.md` §7 lets a declined README addition **stand for every remaining repo registered in
place**, so the same proposal is not put to the same owners once per repo. Three shipped files tell
an agent to record that answer *"in the repo's `repos.yml` row"* — and no field there held it, so
the answer survived only in the session that produced it.

`runbooks/check-in.md`'s README sweep then branches on that fact: a declined repo is not a gap to
close. Months later it could not tell a refusal from an addition nobody had proposed, or from a
`Role in <project>` section somebody deleted. It either re-proposed into a repo whose owners had
already said no, or filed a real gap as settled and stopped checking.

## What this adds

Every `registries/repos.yml` row now carries a `readme:` value, defined in the registry's own
header:

| value | meaning |
|---|---|
| `stamped` | the method created this repo, so the whole README is its own |
| `augmented` | their README, plus a `Role in <project>` section they accepted |
| `written` | their repo had none; the method wrote the file from the template |
| `role-stated` | their README already says the repo's place — nothing was proposed |
| `declined` | proposed and refused; nothing written, nothing owed |
| `not-proposed` | not yet put to its owners — the one value that means something is open |

The last three all mean the method wrote nothing, and they are three values rather than one because
they tell a later reader to do three different things: leave it, leave it, or ask.

A **standing** decline is recorded as `declined` on each remaining row at the moment it is given —
that is what "record that those repos document themselves" now means. There is no separate value
for it: the outcome per repo is identical either way, and the rows are the record.

A **missing** value means *not recorded* and defaults to nothing. Reading it as `stamped` would hide
a repo nobody asked; reading it as `not-proposed` would re-open a question the owners already
answered. Inventories written before this release keep working and say so.

The field is a **record, never an instruction** — the repo's own README is authoritative and this
line is a copy that can drift, so the repo wins when they disagree and the line gets fixed.

## Also here

- **A README that already states the repo's place is a complete outcome.** §7 said to "add only the
  missing piece", which reads as *add it* when the piece is not missing. That case is now stated in
  all four files that describe the augment branch, and recorded as `role-stated` so a later sweep
  does not read it as a repo nobody asked.
- **The check-in sweep reads the field** instead of re-deriving each repo's history, with a branch
  per value including rows written before the field existed.
- **A test bug.** The per-artifact bullet count in `tests/init-inplace-repo-rules.sh` used a range
  whose end anchor is not in `METHOD.md`, so `sed` ran to end of file and was correct only because
  §7's bullets happen to be the last of their kind in the document. Any future `- **` bullet below
  §7 would have failed the suite with a bogus *"says five but lists six"*. Verified: with the
  anchored range an added bullet is ignored; with the old one it produces exactly that message.

## Verification

- **13/13** at `8cf5312`, working tree clean.
- Three fixtures built by `git archive` of the committed ref, deliberately varied — multi/Apache/team,
  mono/Proprietary/solo, and multi/BSD-3 with the deprecated `--registries=no`. Each project's own
  `scripts/check.sh` and `scripts/links.sh` clean; prose read in the **generated** project, with the
  substituted `Role in <project>` form confirmed.
- **19 assertions bite-checked one at a time**, each by reverting only that one thing, judged on
  exit status rather than output text, and each restore proved byte-identical against a pristine
  copy of the committed ref. Includes reinstating the superseded sentence *alongside* the new one,
  which is how a rule ends up stated two ways with every positive assertion still passing.

Adoption-facing files (the adoption prompt's per-repo substep, and the recon map's
`Docs (as found)` column) are not on this line and follow separately on `retcon` after a forward
merge.
