### PR TITLE
Keep one Added section in the unreleased changelog block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ any project built with it.
   registered-in-place repo's README already says what the repo is within the system, nothing is
   proposed — recorded as `role-stated`, so a later sweep does not read it as a repo nobody asked.
 
+- **`--notice-only` mode for `scripts/apply-project-license.sh`** — places `LICENSE-THROUGHSTONE`
+  and a companion `LICENSING.md` in a repo the method did *not* create, for the one case such a
+  repo needs it: the method left Throughstone-authored material behind (the `Role in <project>`
+  README section, or a README written from the template for a repo that had none). That material
+  is BSD-3-Clause and needs its notice, but the notice alone in someone else's repo invites the
+  wrong conclusion — so the companion names only what it covers and explicitly disclaims the rest
+  of the repository. It writes no project `LICENSE` and makes no claim about the repo's own code,
+  which is why it is allowed on a target the full mode refuses. Nothing is owed, and nothing is
+  written, when the owners declined the addition.
 ### Changed
 - **A session template's go-ahead now fires on being *invoked*, not on being *read*.** Every
   `templates/architecture-sessions/*.md` closed with "Begin now — in this same reply", which treated
@@ -363,17 +372,6 @@ any project built with it.
     false for the registered-in-place row directly beneath it.
 
   A new maintainer test pins all four in the generated project.
-
-### Added
-- **`--notice-only` mode for `scripts/apply-project-license.sh`** — places `LICENSE-THROUGHSTONE`
-  and a companion `LICENSING.md` in a repo the method did *not* create, for the one case such a
-  repo needs it: the method left Throughstone-authored material behind (the `Role in <project>`
-  README section, or a README written from the template for a repo that had none). That material
-  is BSD-3-Clause and needs its notice, but the notice alone in someone else's repo invites the
-  wrong conclusion — so the companion names only what it covers and explicitly disclaims the rest
-  of the repository. It writes no project `LICENSE` and makes no claim about the repo's own code,
-  which is why it is allowed on a target the full mode refuses. Nothing is owed, and nothing is
-  written, when the owners declined the addition.
 
 ## [1.7.1] - 2026-08-10
 


### PR DESCRIPTION
`[Unreleased]` carried **two `### Added` headings** — one at the top and one after `### Fixed` — so release notes cut from this block would open and close with the same section name.

The trailing section's entry (`--notice-only` mode for `apply-project-license.sh`) moves into the leading one, which already sits in the Added → Changed → Fixed order the format uses. The duplicate heading goes.

**Nothing else changes.** No test reads `CHANGELOG.md`, so a green suite would prove nothing here — the check that does is a sorted-line comparison against the previous file, which differs only by the removed heading and its blank line. Entry count is 33 before and after.