### PR TITLE
Keep one Added section in the unreleased changelog block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,15 @@ error/corruption and re-run paths, not normal operation.
     creates everything it licenses and has nothing to read first, so it still asks at setup, and
     `--license=NAME` still decides at install time in either mode.
 
+- **`--notice-only` mode for `scripts/apply-project-license.sh`** — places `LICENSE-THROUGHSTONE`
+  and a companion `LICENSING.md` in a repo the method did *not* create, for the one case such a
+  repo needs it: the method left Throughstone-authored material behind (the `Role in <project>`
+  README section, or a README written from the template for a repo that had none). That material
+  is BSD-3-Clause and needs its notice, but the notice alone in someone else's repo invites the
+  wrong conclusion — so the companion names only what it covers and explicitly disclaims the rest
+  of the repository. It writes no project `LICENSE` and makes no claim about the repo's own code,
+  which is why it is allowed on a target the full mode refuses. Nothing is owed, and nothing is
+  written, when the owners declined the addition.
 ### Changed
 - **`status.sh` no longer guesses when the kickoff marker is missing.** If `overview.md` exists but
   carries no recognized `PROJECT-STATUS` value (`not-started` / `retcon` / `kickoff-complete` — a lost
@@ -591,17 +600,6 @@ error/corruption and re-run paths, not normal operation.
     false for the registered-in-place row directly beneath it.
 
   A new maintainer test pins all four in the generated project.
-
-### Added
-- **`--notice-only` mode for `scripts/apply-project-license.sh`** — places `LICENSE-THROUGHSTONE`
-  and a companion `LICENSING.md` in a repo the method did *not* create, for the one case such a
-  repo needs it: the method left Throughstone-authored material behind (the `Role in <project>`
-  README section, or a README written from the template for a repo that had none). That material
-  is BSD-3-Clause and needs its notice, but the notice alone in someone else's repo invites the
-  wrong conclusion — so the companion names only what it covers and explicitly disclaims the rest
-  of the repository. It writes no project `LICENSE` and makes no claim about the repo's own code,
-  which is why it is allowed on a target the full mode refuses. Nothing is owed, and nothing is
-  written, when the owners declined the addition.
 
 ## [1.7.1] - 2026-08-10
 


### PR DESCRIPTION
Same fix as #160, on this line. The duplication here predates the `readme:` field work — it is present at `56fb9df`, before that field existed, and did not arrive through the forward merge.

`[Unreleased]` carried **two `### Added` headings** — one at the top and one after `### Fixed`. The trailing section's entry (`--notice-only` mode for `apply-project-license.sh`) moves into the leading one, which already sits in the Added → Changed → Fixed order the format uses.

**Nothing else changes.** No test reads `CHANGELOG.md`, so the check that matters is a sorted-line comparison against the previous file — it differs only by the removed heading and its blank line.