### PR TITLE
Record an adopted repo's README outcome where the method can read it back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ error/corruption and re-run paths, not normal operation.
   field is a record, never an instruction: the repo's README is authoritative and this line is a
   copy that can drift. A missing value means *not recorded* and defaults to nothing, so inventories
   written before this release keep working and say so.
+- **Adoption records each repo's README outcome, and the recon map says which record is which.**
+  The per-repo substep now writes the `readme:` value as each answer comes — including
+  `readme: declined` on every remaining row when a decline is standing, which on a fourteen-repo
+  adoption is the difference between one answer being kept and the same proposal arriving thirteen
+  more times. The recon map's **Docs (as found)** column and that field cover the same subject from
+  two sides, so both now say which is which: the column is the point-in-time **finding**, frozen
+  when the map is confirmed; the row is the living **outcome**. They are expected to diverge as
+  proposals are answered, and where they disagree about the repo today the repo wins, the row is
+  corrected, and the frozen map is left alone. The column's `role stated` value is now spelled
+  `role-stated`, matching the field value it becomes.
+
 - **A README that already states the repo's place is a complete outcome too.** §7 said to "add only
   the missing piece", which reads as "add it" when the piece is not missing. Where a
   registered-in-place repo's README already says what the repo is within the system, nothing is

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -345,7 +345,8 @@ Resolve each in turn — the **lowest-open `asset-N`** (Status ≠ `Done`); mark
 asset is recorded. Reading one asset at a time keeps even a 20-repo system legible.
 
 - **Per repo** — register it in `registries/repos.yml` (a row: real `location`, `type`,
-  `throughstone: managed`, and `license:` — see below) and **augment** its README (below).
+  `throughstone: managed`, `license:` and `readme:` — see below) and **augment** its README
+  (below).
   Record a short per-repo note (stack, entry points, role) in the repo's `architecture/` docs and
   its inventory row as they are written — never back into the frozen recon map. Register repos
   **in place** by their real location; never relocate the user's code.
@@ -361,10 +362,20 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   thing adoption is producing: the repo's place in the system. So add exactly that, as a short
   `## Role in {{PROJECT}}` section — the one-liner, two or three sentences on the slice of the
   system this repo owns, and links to its `architecture/` doc and the docs hub — and change
-  nothing else. **Show the user the exact text and where it will go, and wait for a yes** before
-  writing into a repo they own. **A no is a complete answer, not a gap:** the same information is
-  already in the recon map, the repo's `architecture/` doc, and its `repos.yml` row, so record
-  that the repo documents itself and move on.
+  nothing else. Where the README already says what the repo is within the system nothing is
+  missing, so propose nothing — the map recorded that as `role-stated` and the row records it the
+  same way. Otherwise **show the user the exact text and where it will go, and wait for a yes**
+  before writing into a repo they own. **A no is a complete answer, not a gap:** the same
+  information is already in the recon map, the repo's `architecture/` doc, and its `repos.yml`
+  row, so record that the repo documents itself and move on.
+
+  **Record how it went in that repo's row, as its `readme:` value** — `augmented` when the section
+  went in, `written` when you wrote the file for a repo that had none, `role-stated` when its
+  README already said the repo's place, `declined` when they said no, and `not-proposed` until you
+  have actually asked (the registry header defines each). Write it as the answer comes, not at the
+  end of the stage. The recon map's **Docs (as found)** column is frozen at what the scan saw; this
+  row is the living record of what was actually done, and it is what a check-in reads months later
+  to tell a repo that is settled from one still owed a question.
   **Place the Throughstone notice only if something Throughstone-authored landed.** If the README
   addition was accepted, that section is BSD-3-Clause scaffold material, so run
   `scripts/apply-project-license.sh --notice-only <repo-path>` — it writes `LICENSE-THROUGHSTONE`
@@ -397,8 +408,11 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   **And a no can stand for the rest.** This same proposal reaches the same people once per repo,
   which in a fourteen-repo system is fourteen times — so on a decline, ask whether it covers this
   repo or all of them, and where it is standing, stop proposing and record the remaining repos as
-  documenting themselves (`METHOD.md` §7). Ask that once. It runs one way: a yes is never carried
-  forward, because the next repo's text is its own proposal and they haven't seen it.
+  documenting themselves — which means writing `readme: declined` on every one of their rows now,
+  one edit per row. Held only in this session it is gone by the next, and the asking it was given
+  to stop starts again fourteen repos later (`METHOD.md` §7). Ask that once. It runs one way:
+  a yes is never carried forward, because the next repo's text is its own proposal and they
+  haven't seen it.
   Which repos need what is already known — the map's **Docs (as found)** column recorded it at
   `inv-3` and `inv-4` said the shape out loud — so this arrives expected rather than as a surprise
   fourteen times over.

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -406,10 +406,23 @@ All but the last are documentation only; nothing you already produced is rewritt
   the general form of both rules. **One thing to check:** if a repo's visibility was changed during
   an adoption, look at it now — a repo that was made public stays retrievable regardless of what it
   is set to today.
+- **`registries/repos.yml` rows carry a `readme:` field.** It records what the method did to that
+  repo's README — `stamped` for a repo the method created, `augmented` where a `Role in <project>`
+  section was added to an existing README, `written` where the method wrote a README for a repo
+  that had none, `role-stated` where the README already said what the repo is within the system,
+  `declined` where the owners said no, and `not-proposed` while the addition is still to be put to
+  them. The registry's own header defines each. It exists because a decline may stand for every
+  remaining repo, and the instruction to record that named nowhere to record it — so the periodic
+  check-in, which skips a declined repo, could not tell one from a repo nobody had asked. Adoption
+  writes the value as each answer comes, and the recon map's **Docs (as found)** column is the
+  point-in-time finding beside it, not a second copy of the answer. **One thing to check:** rows in
+  an inventory written before this reads as *not recorded* rather than defaulting to anything, and
+  nothing rewrites them; fill them in at your next check-in.
+
 - **The recon map records whether each repo explains itself, and a decline can be standing.**
   Adoption's one offer to a repo it did not create is the framing its README probably lacks, and
   which repos need it was rediscovered one at a time at the moment of writing into each. The map's
-  **Stack Per Repo** table gains a **Docs (as found)** column — `role stated` / `README, no role` /
+  **Stack Per Repo** table gains a **Docs (as found)** column — `role-stated` / `README, no role` /
   `none` — recorded during the scan like the licensing column beside it, and the recon-map
   checkpoint says the total out loud so the per-repo proposals arrive expected. That line is
   deliberately **not** a gate: no blanket yes is collected before any text exists, and each repo's

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -71,6 +71,12 @@
 # rows are the record. A standing decline that lives only in the conversation is gone by the next
 # session, and the re-asking it was meant to stop starts again.
 #
+# Where a project adopted an existing codebase, its recon map's **Docs (as found)** column recorded
+# the same subject at scan time — whether each repo's README said what it is within the system.
+# That column is the FINDING and is frozen; this field is the OUTCOME and is living, so the two are
+# expected to diverge as proposals are answered. When they disagree about the repo as it stands
+# today, the repo itself wins, this row is the copy to correct, and the map is left alone.
+#
 # `license:` (per row) records what a repo is licensed under, so the inventory can show the
 # licensing picture across every repo at once — something no single LICENSE file can, and the fact
 # that starts mattering as soon as the repos here do not share one license. It is a RECORD, never

--- a/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
+++ b/Code/{{PROJECT}}-docs/templates/reports/recon-map-report-template.md
@@ -69,13 +69,25 @@ did not create is the framing its README probably lacks — a `Role in <project>
 README exists, the file itself where none does (`METHOD.md` §7). Which of those a repo needs is a
 fact about the repo, so read it here rather than rediscovering it one repo at a time later: does a
 `README` exist at all, and if it does, does it say what this repo is *within the system* — not
-just what it does on its own. Record one of `role stated`, `README, no role`, or `none`. Like the
+just what it does on its own. Record one of `role-stated`, `README, no role`, or `none`. Like the
 licensing column this is a record, not a verdict: a repo whose README explains it perfectly needs
 nothing, and `none` on a small internal library is a fact, not a failing.
 
+**This column is the finding; `registries/repos.yml`'s `readme:` field is the outcome.** This map is
+point-in-time and frozen once confirmed — it says what was there when adoption arrived, and it is
+never edited afterwards. The inventory row is the living record, written per repo as each addition
+is proposed and answered, and it is what a check-in reads months later. So the two are *expected* to
+diverge: a repo recorded here as `README, no role` becomes `augmented` in its row when its owners
+accept the section, or `declined` when they don't. That is the work happening, not drift. Where they
+disagree about the repo as it stands today, **the repo itself is authoritative, the row is the copy
+to correct, and this map is left alone** — correcting a frozen record would destroy the only account
+of what was found. `role-stated` is the one value that carries straight through unchanged: nothing
+was missing, so nothing is proposed and the row records `role-stated` too. The other two describe
+what still has to be put to somebody, and their outcome is not known here.
+
 | Repo | Languages | Frameworks / runtimes | Build / package manager | Licensing (as found) | Docs (as found) | Notes |
 |------|-----------|-----------------------|-------------------------|----------------------|-----------------|-------|
-| {{repo}} | {{langs}} | {{frameworks, runtime versions}} | {{tool}} | {{identifier (file it came from) / none stated; + vendored terms}} | {{role stated / README, no role / none}} | {{monorepo? generated code? notable pins}} |
+| {{repo}} | {{langs}} | {{frameworks, runtime versions}} | {{tool}} | {{identifier (file it came from) / none stated; + vendored terms}} | {{role-stated / README, no role / none}} | {{monorepo? generated code? notable pins}} |
 
 ## Entry Points & Services
 

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -44,7 +44,17 @@ copy_template() {
 
 # assert_file_contains FILE NEEDLE — fixed-string presence with a readable failure.
 assert_file_contains() {
-  grep -Fq "$2" "$1" || { echo "FAIL: '$2' not found in $1" >&2; return 1; }
+  grep -Fq -- "$2" "$1" || { echo "FAIL: '$2' not found in $1" >&2; return 1; }
+}
+
+# The superseded spelling must not come back alongside the new one, which is how a value ends up
+# written two ways and every positive assertion still passes. The needle has to be as specific as
+# a present-assertion one, or it matches unrelated prose.
+assert_file_absent() {
+  if grep -Fq -- "$2" "$1"; then
+    echo "FAIL: '$2' still present in $1" >&2
+    return 1
+  fi
 }
 
 # run_existing_case NAME LAYOUT — adopt an existing codebase in the given layout and assert the
@@ -157,13 +167,38 @@ run_existing_case() {
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Docs (as found)"
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
-    "role stated / README, no role / none"
+    "role-stated / README, no role / none"
   assert_file_contains "$docs/RETCON-PROMPT.md" "Say what the docs column adds up to"
   # The line is an observation, never a gate. A blanket yes collected before any text exists would
   # be consent to writes nobody has seen — the opposite of what the per-repo proposal is for — so
   # both halves are pinned: say the shape, and do not turn it into an approval.
   assert_file_contains "$docs/RETCON-PROMPT.md" "**Do not turn it"
   assert_file_contains "$docs/RETCON-PROMPT.md" "do not collect a blanket yes"
+  # The README outcome has a durable home. Adoption is where this bites hardest: the same proposal
+  # goes to the same people once per repo, so a decline may cover all of them — and the instruction
+  # to record that named nowhere to record it, leaving the answer in the session that produced it.
+  # A check-in months later then could not tell a refusal from a repo nobody had asked.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "**Record how it went in that repo's row, as its \`readme:\` value**"
+  # The standing decline is one edit per row, made when it is given.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "documenting themselves — which means writing \`readme: declined\` on every one of their rows now,"
+  # A README that already says the repo's place needs no proposal, under the same name the map uses.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "missing, so propose nothing — the map recorded that as \`role-stated\` and the row records it the"
+  # Two records of one subject need a stated precedence, or they become two answers that disagree
+  # with nothing saying which wins. The map is the frozen finding; the row is the living outcome.
+  # Pinned on BOTH sides: a rule stated only where it is defined goes stale where it is read.
+  assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
+    "**This column is the finding; \`registries/repos.yml\`'s \`readme:\` field is the outcome.**"
+  assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
+    "to correct, and this map is left alone**"
+  assert_file_contains "$docs/registries/repos.yml" \
+    "# That column is the FINDING and is frozen; this field is the OUTCOME and is living, so the two are"
+  # The column value and the field value naming the same outcome are spelled identically, so moving
+  # between the two files does not read as a typo. The old spaced form must not come back.
+  assert_file_absent "$docs/templates/reports/recon-map-report-template.md" "\`role stated\`"
+
   # A decline carries to the remaining repos; a yes never does.
   assert_file_contains "$docs/RETCON-PROMPT.md" "**And a no can stand for the rest.**"
   assert_file_contains "$docs/RETCON-PROMPT.md" "a yes is never carried"


### PR DESCRIPTION
The `readme:` inventory field arrived on this line by forward merge. Two files that carry the same
rules exist only here, and neither used it.

## The gap this closes

Adoption is where a standing decline actually bites: the same proposal reaches the same people once
per repo, so on a fourteen-repo system one "no" may cover all of them. The per-repo substep told the
agent to *"record the remaining repos as documenting themselves"* and named nowhere to record it —
so the answer survived only in the session that produced it, and the next session started asking
again.

`RETCON-PROMPT.md` now writes the `readme:` value as each answer comes, and a standing decline is
one edit per remaining row rather than a fact held in conversation. It also states the case the
augment rule implied but never said: a README that already says what the repo is within the system
is missing nothing, so nothing is proposed.

## Two records of one fact

The recon map's **Docs (as found)** column and the `readme:` field cover the same subject from two
sides. Two records with nothing saying which wins is a defect this codebase has produced before, so
both sides now say it:

| | the map's column | the inventory row |
|---|---|---|
| what it is | the **finding** — what was there when adoption arrived | the **outcome** — what was actually done |
| lifetime | frozen when the map is confirmed | living, updated as each answer comes |

They are *expected* to diverge: a repo found as `README, no role` becomes `augmented` when its
owners accept, or `declined` when they don't. That is the work happening, not drift. Where they
disagree about the repo as it stands today, **the repo itself is authoritative, the row is the copy
to correct, and the frozen map is left alone** — correcting it would destroy the only account of
what was found.

This mirrors how `license:` and the map's Licensing column already relate, and the same substep
already says so for licensing in the same words.

## One rename

The column's `role stated` is now spelled **`role-stated`**, identical to the field value it becomes.
It is the one finding that carries straight through unchanged — nothing was missing, so nothing is
proposed — and two spellings of one outcome read as a typo rather than a reference. The other two
column values describe what still has to be put to somebody, and their outcome isn't known at scan
time.

## Verification

- **15/15** at `cf23419`, working tree clean.
- Two adoption fixtures from `git archive` of the committed ref, deliberately different —
  `--mode=existing` multi/solo and mono/team. Each project's own `scripts/check.sh` and
  `scripts/links.sh` clean, no placeholders left, prose read in the **generated** project.
- **8 assertions bite-checked one at a time**, each by reverting only that one thing, judged on exit
  status, each restore proved byte-identical against a pristine copy. Includes reinstating the
  spaced spelling *alongside* the hyphenated one.
- The suite caught a real mistake mid-work: rewrapping a paragraph split the pinned phrase
  `a yes is never carried` across two lines, which `grep -F` reads as OR rather than as a match.
  Rewrapped to keep it whole.

The test's `assert_file_contains` now passes `--` to `grep`, so a needle starting with a dash cannot
fail as an option bundle regardless of the file's contents, and the file gains an absent-assertion
helper.
