### PR TITLE
Record what each repo is licensed under in the repo inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ any project built with it.
   field is a record, never an instruction: the repo's README is authoritative and this line is a
   copy that can drift. A missing value means *not recorded* and defaults to nothing, so inventories
   written before this release keep working and say so.
+- **The repo inventory records what each repo is licensed under.** `METHOD.md` §7 told an agent to
+  read a registered-in-place repo's licensing and record it "in the repo inventory entry that
+  describes it", and no field there held it — so the one place that already indexes every repo
+  could not show the licensing picture across them, which no single `LICENSE` file can and which
+  starts mattering as soon as a project's repos don't share one license. `registries/repos.yml`
+  rows now carry a `license:` field, and §7 names it. For a repo the method creates it is the
+  bootstrap posture, which `init.sh` substitutes into the seed rows **and into the worked example
+  beside them**, so the pattern an agent copies matches the project it is copying it into; for a
+  repo registered in place it is what that repo already says, recorded as found — an identifier
+  and the file it came from, or `none stated`. It is a record, never an instruction: the repo's own
+  license file stays authoritative, a missing value means "not recorded" so existing inventories
+  are unaffected, and repos carrying different licenses is a normal inventory rather than an
+  inconsistency to reconcile.
 - **A README that already states the repo's place is a complete outcome too.** §7 said to "add only
   the missing piece", which reads as "add it" when the piece is not missing. Where a
   registered-in-place repo's README already says what the repo is within the system, nothing is

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -523,12 +523,13 @@ project is actually missing. Per artifact that means:
   replace or break whatever already gates that repo's merges. Record what it runs instead.
 - **Licensing — recorded as found.** The repo already has a licensing status: a `LICENSE`, a
   `COPYING`, a `NOTICE`, vendored third-party terms, or a deliberate absence. Read what it uses
-  and record it — in the repo inventory entry that describes it, and wherever the architecture
-  docs cover it. A divergence from the `init.sh` selection is not an error to fix: that selection
-  governs the method's own artifacts and the repos it creates, and several in-place repos may
-  legitimately carry several different licenses. It is worth telling the owners about once, where
-  they can act on it, and that is the whole of it. So `scripts/apply-project-license.sh` is run
-  **only on a repo the method creates**; it refuses a target that already states its own licensing.
+  and record it — in its `registries/repos.yml` `license:` field (an identifier and the file it
+  came from, or `none stated`), and wherever the architecture docs cover it. A divergence from the
+  project's own selection is not an error to fix: that selection governs the method's artifacts and
+  the repos it creates, and several in-place repos may legitimately carry several different
+  licenses. It is worth telling the owners about once, where they can act on it, and that is the
+  whole of it. So `scripts/apply-project-license.sh` is run **only on a repo the method creates**;
+  it refuses a target that already states its own licensing.
 - **The Throughstone notice — only where something Throughstone-authored landed.** That is the one
   thing such a repo may still be owed: where the method leaves its own material behind — the
   `Role in <project>` section, or a README written from the template for a repo that had none —

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -276,6 +276,18 @@ and what to check.
   check-in — the repos the method created are `stamped`, and only you know what happened to the
   rest.
 
+- **`registries/repos.yml` rows also carry a `license:` field.** It records what each repo is
+  licensed under: the bootstrap posture for a repo the method created, and whatever the repo
+  already says — an identifier and the file it came from, or `none stated` — for one registered in
+  place. §7 already told you to record an in-place repo's licensing "in the repo inventory entry",
+  and no field there held it. It exists because a project whose repos don't share one license has
+  nowhere else to show that, and it is a record rather than an instruction: the repo's own license
+  file stays authoritative and this line is a copy that can drift. **One thing to check:** your
+  existing rows have no value, which reads as *not recorded* rather than "same as everything
+  else". Nothing rewrites them — `repos.yml` is project state. The two seed rows a fresh bootstrap
+  writes take the posture from `.throughstone/project-license`; backfill the rest by hand whenever
+  you want the licensing picture in one place.
+
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
   here to run this session…" and ends by releasing a reader who wasn't sent to run it. When you
   invoke a session normally, behavior is unchanged — you type `Run STEP-1.N` and get the first

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -56,37 +56,59 @@
 # and there is no separate value for it: the outcome per repo is identical either way, and these
 # rows are the record. A standing decline that lives only in the conversation is gone by the next
 # session, and the re-asking it was meant to stop starts again.
+#
+# `license:` (per row) records what a repo is licensed under, so the inventory can show the
+# licensing picture across every repo at once — something no single LICENSE file can, and the fact
+# that starts mattering as soon as the repos here do not share one license. It is a RECORD, never
+# an instruction: the repo's own license file is authoritative and this line is a copy that can
+# drift, so trust the repo when they disagree and fix the line. For a repo the method CREATES it is
+# the posture from `.throughstone/project-license` (the value init.sh writes below). For a repo
+# REGISTERED IN PLACE — one that existed before this project did — it is whatever that repo already
+# says, written down as found: an identifier and the file it came from (`GPL-2.0 (COPYING)`), or
+# `none stated` when the repo says nothing, which is a fact worth recording rather than a gap to
+# fill. Never set a license for such a repo; see METHOD.md §7 — a repo the method did not create
+# keeps what it already has, licensing included. A missing value means "not recorded", not
+# "same as everything else", and repos legitimately carrying different licenses is a normal
+# inventory rather than an inconsistency to reconcile.
 
 repos:
   - name: "{{PROJECT}}-docs"
     location: "Code/{{PROJECT}}-docs/"
     type: docs            # docs | service | library | app | infra | tests
     readme: stamped
+    license: "{{PROJECT_LICENSE}}"
     description: "Documentation hub: architecture, ADRs, standards, registries."
 
   - name: "prompts"
     location: "prompts/"
     type: docs
     readme: stamped
+    license: "{{PROJECT_LICENSE}}"
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
   # Service / app / library repos get added here as the architecture names them. A repo the method
   # CREATES is stamped from templates/repo-readme-template.md; a repo REGISTERED IN PLACE is listed
-  # here like any other but scaffolded in none of these ways — see METHOD.md §7. `readme:` is the
-  # field whose value differs by which kind it is, so one example of each:
+  # here like any other but scaffolded in none of these ways — see METHOD.md §7. `readme:` and
+  # `license:` are the two fields that differ by which kind it is: a repo the method creates carries
+  # the whole template README and takes the project posture, like the rows above; a repo registered
+  # in place records the README outcome its owners agreed to, and for licensing takes whatever that
+  # repo itself already says, copied as found — never the posture, and never a value you picked for
+  # it. One example of each:
   #
-  # Created by the method — a Code/* sibling, carrying the whole template README:
+  # Created by the method — a Code/* sibling, carrying the whole template README and the posture:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service
   #   readme: stamped
+  #   license: "{{PROJECT_LICENSE}}"                       # the posture, as on the rows above
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
   #   description: "..."
   #
-  # Registered in place — its real location, and the outcome of the one addition it was offered.
-  # Never a value you picked for it: `readme:` records the answer its owners actually gave.
+  # Registered in place — its real location, the outcome of the one addition it was offered, and
+  # its own licensing recorded as found:
   # - name: "legacy-billing"
   #   location: "/srv/src/legacy-billing/"
   #   type: service
-  #   readme: declined          # or augmented / written / role-stated / not-proposed
+  #   readme: declined            # or augmented / written / role-stated / not-proposed
+  #   license: "GPL-2.0 (COPYING)"                         # what THAT repo says; `none stated` if nothing
   #   description: "..."

--- a/init.sh
+++ b/init.sh
@@ -859,6 +859,14 @@ mkdir -p "$ROOT/.throughstone"
 # even when proprietary projects intentionally have no project LICENSE.
 printf '%s\n' "$PROJECT_LICENSE_ID" > "$DOCS/.throughstone/project-license"
 
+# The repo inventory records what each repo is licensed under, so fill the seed rows with the same
+# posture. These two repos are ones init.sh creates, so the posture IS their license. A repo
+# registered in place later records what that repo already says instead (registries/repos.yml).
+grep -rlF '{{PROJECT_LICENSE}}' . --exclude-dir=.git 2>/dev/null | while read -r f; do
+  PROJECT_LICENSE_ID="$PROJECT_LICENSE_ID" perl -pi -e \
+    's/\Q{{PROJECT_LICENSE}}\E/$ENV{PROJECT_LICENSE_ID}/g' "$f"
+done
+
 # description: fill {{PROJECT_DESCRIPTION}} EVERYWHERE it appears (AGENTS.md + every
 # architecture/planning-session "About" blurb) so no literal placeholder is left dangling.
 # The one-liner is just a seed — the kickoff can later expand any of these from overview.md.

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -132,6 +132,9 @@ run_interactive_case() {
   [ -f "$work/Code/$name-api/LICENSING.md" ]
   grep -Fq "does not replace or alter the project license" \
     "$work/Code/$name-api/LICENSING.md"
+  # The inventory rows record the same posture the helper applies.
+  assert_registry_license "$name" "$work" \
+    "$(cat "$work/Code/$name-docs/.throughstone/project-license")"
   "$work/Code/$name-docs/scripts/apply-project-license.sh" \
     "$work/Code/$name-api" >"$TMP_ROOT/$name-code-license-repeat.out"
 
@@ -218,6 +221,8 @@ run_private_case() {
   grep -Fq "Project-authored content in this repository is proprietary" \
     "$work/Code/$name-api/LICENSING.md"
   grep -Fq "does not grant permission" "$work/Code/$name-api/LICENSING.md"
+  # Proprietary is a posture, not an absence: the inventory records it like any other value.
+  assert_registry_license "$name" "$work" "Proprietary"
 
   assert_maintainer_tests_removed "$name" "$work"
   ! grep -Fq "Copyright holder" "$TMP_ROOT/$name.out"
@@ -418,6 +423,27 @@ run_missing_canonical_license_case() {
     "$TMP_ROOT/$name-helper.out"
   [ -z "$(find "$target" -mindepth 1 -print -quit)" ]
   assert_maintainer_tests_removed "$name" "$work"
+}
+
+# assert_registry_license NAME WORK EXPECTED — the repo inventory records what each repo it
+# created is licensed under, and no placeholder survives bootstrap. The value must match the
+# durable posture: two records that disagree are worse than one.
+assert_registry_license() {
+  local name="$1" work="$2" expected="$3" reg="$2/Code/$1-docs/registries/repos.yml"
+
+  # Whole-line match: the file also carries a commented example row, which is not a record.
+  [ "$(grep -Fxc "    license: \"$expected\"" "$reg")" -eq 2 ] || {
+    echo "FAIL: $name did not record license \"$expected\" on both seed rows of $reg" >&2
+    return 1
+  }
+  if grep -rq '{{PROJECT_LICENSE}}' "$work" --exclude-dir=.git; then
+    echo "FAIL: $name left an unresolved {{PROJECT_LICENSE}} placeholder" >&2
+    return 1
+  fi
+  grep -Fxq "$expected" "$work/Code/$name-docs/.throughstone/project-license" || {
+    echo "FAIL: $name registry license disagrees with the durable posture" >&2
+    return 1
+  }
 }
 
 # run_pre_existing_licensing_case — a repo that already states its own licensing must be refused


### PR DESCRIPTION
`METHOD.md` §7 tells an agent to read a **registered-in-place** repo's licensing and record it
*"in the repo inventory entry that describes it"*. No field there held it.

So the one place that already indexes every repo could not show the licensing picture across them
— which is the fact that starts mattering as soon as the repos don't share a single license, and a
repo that predates the project is exactly how that happens. The `readme:` field, added for the
answer beside it, went in on this line for the same reason; this one was written on `retcon` first,
for adoption, and never came back.

## What this adds

`registries/repos.yml` rows carry a `license:` field, and §7 names it:

| repo | value |
|---|---|
| created by the method | the posture from `.throughstone/project-license` |
| registered in place | what that repo already says — an identifier and the file it came from (`GPL-2.0 (COPYING)`), or `none stated` |

`init.sh` fills the two seed rows from the posture, and the worked example beside them, so the
pattern an agent copies matches the project it is copying it into.

It is a **record, never an instruction**: the repo's own license file stays authoritative and this
line is a copy that can drift, a missing value means *not recorded* rather than "same as everything
else", and repos carrying different licenses is a normal inventory rather than an inconsistency to
reconcile.

## Coverage

`tests/init-license-validation.sh` gains `assert_registry_license`, called from the open-source and
proprietary cases: both seed rows carry the posture, no `{{PROJECT_LICENSE}}` survives bootstrap,
and the rows agree with the durable posture — two records that disagree are worse than one.
Negative-tested by disabling the substitution, which fails the suite with a named row rather than
passing vacuously.

## On the other line

`retcon` already carries the field, the §7 sentence, the `init.sh` substitution, and the test. The
shared prose here is byte-identical to it deliberately, so `METHOD.md` and the test merge with zero
conflicts. Adoption keeps what is only its own — the `Unset` value for a project that defers the
license question until the codebase has been read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
