### PR TITLE
Stop telling adoption the license helper would catch a bad invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,19 @@ error/corruption and re-run paths, not normal operation.
   exactly as before once given, `--license` is unaffected, and no generated project is rewritten.
 
 ### Fixed
+- **Adoption told the agent the license helper would stop it, and for one repo it would not.**
+  `RETCON-PROMPT.md` said, at the point of action, "do not run the helper without that flag; it
+  will refuse, and correctly" — while sixty lines on, in the rules that govern the same substep, it
+  said the accurate thing: the helper refuses a repo that states its own terms, and the ones it
+  would not refuse are exactly the repos that would silently gain a `LICENSE`. An adopted repo with
+  no `LICENSE`, `COPYING`, `NOTICE`, or licensing in its manifest — the `none stated` case the
+  recon map has a column value for — is indistinguishable from a repo the method just created, so
+  the plain invocation applies the project's license and a `LICENSING.md` asserting it over code
+  the method did not write. That is the write the whole section exists to prevent, and the sentence
+  nearest the work said it could not happen. The claim is gone; the prohibition now lives once,
+  with the other **Never** rules, names `--notice-only` as the one allowed invocation so it cannot
+  be read as forbidding the notice, and says outright that the flag is the rule and the refusal
+  only a backstop behind it.
 - **`init.sh` would destroy an existing repository it was run inside.** Extract the download into
   your own repo and run it — the mistake adoption invites, since `--mode=existing` is aimed at the
   one population that has a repository — and the fresh-template guard saw the template's own

--- a/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
+++ b/Code/{{PROJECT}}-docs/RETCON-PROMPT.md
@@ -380,10 +380,9 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   addition was accepted, that section is BSD-3-Clause scaffold material, so run
   `scripts/apply-project-license.sh --notice-only <repo-path>` — it writes `LICENSE-THROUGHSTONE`
   and a `LICENSING.md` scoped to that material, disclaiming the rest of the repo, and never a
-  project `LICENSE`. Do **not** run the helper without that flag; it will refuse, and correctly.
-  Run it **now**, before the commit below, so those two files go in with the README change; run
-  afterwards they are written into their working tree at the point you have already stopped, and
-  the addition reaches their trunk with nothing saying where it came from.
+  project `LICENSE`. Run it **now**, before the commit below, so those two files go in with the
+  README change; run afterwards they are written into their working tree at the point you have
+  already stopped, and the addition reaches their trunk with nothing saying where it came from.
   If the user declined the README addition, nothing Throughstone-authored is in the repo and
   nothing is owed — placing a notice for absent material would only confuse a later reader.
   **On a yes, commit it on a branch and stop.** The yes was about the text, not about how that
@@ -438,10 +437,14 @@ asset is recorded. Reading one asset at a time keeps even a 20-repo system legib
   **Never license an adopted repo.** Every repo here is registered in place, so its licensing is
   its owner's and the method only records it — the same rule that leaves its README augmented and
   its CI alone (`METHOD.md` §7: a repo the method did not create keeps what it already has).
-  Concretely: do **not** run
-  `scripts/apply-project-license.sh` against any of these repos — it will refuse one that states
-  its own terms, and the ones it would not refuse are exactly the repos that would silently gain a
-  `LICENSE` and a `LICENSING.md` claiming it over code you did not write. Recording it **is** the
+  Concretely: never run `scripts/apply-project-license.sh` against one of these repos without
+  `--notice-only`. That flag is the one allowed invocation — the notice for material the method
+  left behind (above), which writes no project `LICENSE` and makes no claim about the rest of the
+  repo. The plain invocation refuses a repo that states its own terms, but a repo that states
+  nothing is indistinguishable from one the method just created, so the ones it would not refuse
+  are exactly the repos that would silently gain a `LICENSE` and a `LICENSING.md` claiming it over
+  code you did not write. The flag is the rule; the refusal is only a backstop behind it.
+  Recording it **is** the
   work here, in two places with two jobs: the recon map's **Stack Per Repo** row already captured
   it at `inv-3` as part of the frozen point-in-time snapshot, and this row's `license:` field is
   the **living** copy that stays current as the repo changes. Copy it across as found — same

--- a/tests/init-retcon-mode.sh
+++ b/tests/init-retcon-mode.sh
@@ -158,7 +158,12 @@ run_existing_case() {
   # column is the record that makes "record it" an actual place rather than a sentiment.
   assert_file_contains "$docs/RETCON-PROMPT.md" "Never license an adopted repo"
   assert_file_contains "$docs/RETCON-PROMPT.md" \
-    "\`scripts/apply-project-license.sh\` against any of these repos"
+    "\`scripts/apply-project-license.sh\` against one of these repos without"
+  # The prohibition must not rest on the helper refusing. It refuses a repo that states its own
+  # terms, and a repo that states nothing looks exactly like one the method just created — which
+  # is the repo that would silently take the project's license. Say which is the rule.
+  assert_file_contains "$docs/RETCON-PROMPT.md" \
+    "The flag is the rule; the refusal is only a backstop behind it."
   assert_file_contains "$docs/templates/reports/recon-map-report-template.md" \
     "Licensing (as found)"
   # Whether a repo explains its place in the system is a fact about the repo, recorded once during
@@ -233,7 +238,7 @@ run_existing_case() {
   # landing paragraph so the resolver reads in the order it is meant to execute; an agent working
   # top-to-bottom that hits the commit first has already stopped by the time it reaches the notice.
   assert_file_contains "$docs/RETCON-PROMPT.md" \
-    "Run it **now**, before the commit below, so those two files go in with the README change; run"
+    "Run it **now**, before the commit below, so those two files go in with the"
   local notice_line landing_line
   notice_line="$(grep -n -F -- "**Place the Throughstone notice only if something Throughstone-authored landed.**" \
     "$docs/RETCON-PROMPT.md" | head -1 | cut -d: -f1)"


### PR DESCRIPTION
`RETCON-PROMPT.md` said two different things about the same helper, and the wrong one sat at the
point of action.

In the per-repo substep, where the agent is working:

> Do **not** run the helper without that flag; it will refuse, and correctly.

Fifty lines on, in the rules governing that same substep:

> it will refuse one that states its own terms, and the ones it would not refuse are exactly the
> repos that would silently gain a `LICENSE` and a `LICENSING.md` claiming it over code you did not
> write

The second one is right. An adopted repo with no `LICENSE`, `COPYING`, `NOTICE`, or licensing in
its manifest — the `none stated` case the recon map has a column value for — is indistinguishable
from a repo the method just created. Pointed at one, the plain invocation writes the project's
`LICENSE` and a `LICENSING.md` asserting that license over code the method did not write.
Reproduced against an MIT hub: `project license: <adopted-repo>/LICENSE`.

The helper's own header says as much — the guard *"is a backstop against a misdirected invocation,
not the control"*. So the sentence closest to the work told an agent the guard would stop the one
write this section exists to prevent.

## The fix

The claim is removed rather than corrected in both places. The prohibition now lives once, with the
other **Never** rules, and does three things the old pair did not:

- names `--notice-only` as the one allowed invocation, so it cannot be read as forbidding the
  notice the paragraph above it just told the agent to place (the old block said only *"do not run
  `scripts/apply-project-license.sh` against any of these repos"*, with no mention of the flag —
  the upstream clause was the only thing carving it out)
- says why a `none stated` repo is the dangerous one
- says which half is load-bearing: **the flag is the rule; the refusal is only a backstop behind it**

`METHOD.md` §7 on both lines was already conditional and is untouched.

## Coverage

The retcon suite asserted the removed wording, so it now asserts the rule that replaced it, plus
the sentence naming the flag as the rule — that being the half a later edit could drop with nothing
failing. 15/15 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
