### PR TITLE
Point new users at the latest release instead of main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ any project built with it.
 > remains v1.7.1.
 
 ### Changed
+- **The README and website now tell you to clone the latest *release*, not `main`.**
+  `git clone --branch v1.7.1 …` gives you the 1.7 release; `main` is where Throughstone itself is
+  built and can carry unfinished work. The "Use this template" path is flagged as unable to be
+  pinned to a release, since GitHub always copies the default branch.
 - **A session template's go-ahead now fires on being *invoked*, not on being *read*.** Every
   `templates/architecture-sessions/*.md` closed with "Begin now — in this same reply", which treated
   the act of opening the file as the user's go-ahead. But session files are read by more than the

--- a/README.md
+++ b/README.md
@@ -109,13 +109,21 @@ production software, get review from an experienced engineer.
 1. **Get the files into a folder named for your project.** The folder you download into
    **becomes your project's workspace root** — `init.sh` never renames it — so give it the
    name you want the project to have (e.g. `acme` or `MyCoolMobileApp`, not `Throughstone`). Two ways:
-   - **Clone this repo directly** into a project-named folder (e.g. `acme`):
+   - **Clone the latest release** into a project-named folder (e.g. `acme`):
      ```bash
-     git clone https://github.com/mherschberg/Throughstone.git acme
+     git clone --branch v1.7.1 https://github.com/mherschberg/Throughstone.git acme
      cd acme
      ```
+     `--branch` takes a tag here, so this gives you the **1.7 release** rather than whatever
+     `main` happens to hold. `main` is where Throughstone itself is built; it can carry
+     unfinished work. Drop the flag only if you specifically want that. Releases are listed
+     under [Releases](https://github.com/mherschberg/Throughstone/releases). Git will note a
+     *detached HEAD* — that is expected when cloning a tag, and harmless here, because step 2
+     removes the template's git history anyway.
    - **Or use GitHub "Use this template" ▸ Create a new repository.** Name the new repo for
-     your project, then clone it into a folder of that name (e.g. `acme`):
+     your project, then clone it into a folder of that name (e.g. `acme`). Note this path always
+     copies the **default branch** and cannot be pinned to a release — use the clone above if you
+     want a specific version:
      ```bash
      git clone <your-new-repo-url> acme
      cd acme

--- a/brand/site/index.html
+++ b/brand/site/index.html
@@ -402,8 +402,8 @@
       <p>Run the wizard once, then hand the project to your AI agent in plain English. It drafts your architecture and then guides you through the code creation.</p>
     </div>
     <div class="codeblock">
-<span class="c"># 1 · Clone this repo into a new folder named for your project</span><br>
-$ git <span class="p">clone</span> https://github.com/mherschberg/Throughstone.git my-project &amp;&amp; cd my-project<br>
+<span class="c"># 1 · Clone the latest release into a new folder named for your project</span><br>
+$ git <span class="p">clone</span> --branch v1.7.1 https://github.com/mherschberg/Throughstone.git my-project &amp;&amp; cd my-project<br>
 <span class="c">#     GitHub "Use this template" is mainly for mono-repo starts; see README.</span><br><br>
 <span class="c"># 2 · Run the one-time setup wizard (asks a few questions)</span><br>
 $ ./init.sh<br><br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -402,8 +402,8 @@
       <p>Run the wizard once, then hand the project to your AI agent in plain English. It drafts your architecture and then guides you through the code creation.</p>
     </div>
     <div class="codeblock">
-<span class="c"># 1 · Clone this repo into a new folder named for your project</span><br>
-$ git <span class="p">clone</span> https://github.com/mherschberg/Throughstone.git my-project &amp;&amp; cd my-project<br>
+<span class="c"># 1 · Clone the latest release into a new folder named for your project</span><br>
+$ git <span class="p">clone</span> --branch v1.7.1 https://github.com/mherschberg/Throughstone.git my-project &amp;&amp; cd my-project<br>
 <span class="c">#     GitHub "Use this template" is mainly for mono-repo starts; see README.</span><br><br>
 <span class="c"># 2 · Run the one-time setup wizard (asks a few questions)</span><br>
 $ ./init.sh<br><br>


### PR DESCRIPTION
The README's first instruction and the website's step 1 both told people to clone the repository,
which hands them whatever `main` holds at that moment. `main` is where Throughstone itself is built,
so it is the one place a new user should not be sent by default.

## Changes

- **`README.md`** — `git clone --branch v1.7.1 …`, with a note on why, a pointer to Releases, and a
  line explaining that git's *detached HEAD* notice is expected and harmless (step 2 removes the
  template's git history anyway).
- **`README.md`** — the "Use this template" option is flagged as unable to be pinned to a release,
  since GitHub always copies the default branch.
- **`brand/site/index.html`** → published to **`docs/index.html`** via `brand/publish-site.sh`, so
  the website's step 1 matches. (`tests/site-publish.sh` enforces that the two stay in sync — it
  caught an edit made directly to the published copy.)
- **`CHANGELOG.md`** — one entry, folded into the existing `### Changed` block.

## Verified

- `git clone --branch v1.7.1 …` run end to end: exit 0, lands on `cc9d18c`, `git describe` reports
  `v1.7.1`, `init.sh` present and executable.
- Full suite **11/11**.
- `[Unreleased]` has exactly one `### Changed` and one `### Fixed` heading.

## Note

This bumps to a hardcoded tag, so it goes stale unless every release updates it. That step is now
item 6 of the internal release checklist.
