### PR TITLE
Ignore the whole local agent-config tree, not two files by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 .DS_Store
 *.swp
 
-# Per-machine agent config — never shared (also stale/personal here).
-.claude/settings.local.json
-.claude/launch.json
+# Per-machine agent config — never shared (also stale/personal here). The whole tree is ignored,
+# not the two files by name: editor lock/autosave siblings (#settings.local.json#) and any future
+# per-machine config would otherwise land in a `git add -A`.
+.claude/
 
 # Personal local Throughstone profile (not shared)
 /.throughstone/local-user.md


### PR DESCRIPTION
`.gitignore` named `.claude/settings.local.json` and `.claude/launch.json` individually, so anything
*else* appearing in that directory was untracked rather than ignored. An editor lock file
(`#settings.local.json#`) was swept into a commit by `git add -A` during the backout work and had to
be amended out.

Ignores `.claude/` wholesale, matching how `.dev/` and `marketing/` are already handled. The existing
comment already said the tree is per-machine agent config that is never shared — this makes the rule
match the comment.

**Scope:** this is the template repo's own `.gitignore`. Generated projects get a separate baseline
written by `write_gitignore()` in `init.sh`, which this does not touch. No user-visible change, so no
CHANGELOG entry.

**Verified:** both files report ignored via `git check-ignore`; `.claude/` no longer appears in
`git status`; suite 11/11.
