### PR TITLE
Add a runbook for splitting a repository, and repeal the split-before-a-teammate rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,20 +26,24 @@ any project built with it.
   sides keep the full history, and `git blame`, `git log --follow` and every commit SHA your
   project has recorded keep working in the new repo on day one. It covers both cases behind one
   routing block: splitting a code repo in two, and converting a mono-repo-for-now workspace to
-  multi-repo. It asks three questions before you start and the rest at the step that needs them,
-  each with a default, so answering "use your judgement" still produces a correct split. The one
-  real cost is stated plainly in the file: every new repo inherits every blob the origin ever
-  committed, including deleted ones, and an appendix covers purging first when that matters.
+  multi-repo. It asks three questions before you start and the rest at the step that needs them;
+  every one but the mapping itself has a default, so answering "use your judgement" still produces
+  a correct split. The one real cost is stated plainly in the file: every new repo inherits every
+  blob the origin ever committed, including deleted ones, and an appendix covers purging first when
+  that matters.
   Split-out repos can now record where they came from, in a `provenance:` block on their
   `registries/repos.yml` row.
 
   Shipping with it: **the rule telling you to split before adding a second contributor is gone.**
   It gave two reasons and neither survived. The STEP-number push-race works exactly the same in a
   mono repo with a shared remote — what a team needs is shared remotes, not several of them — and
-  the overlap warning's mono fallback was already written, one section above the clause that said
-  it wasn't. How many repos you have follows your architecture, not your headcount. The
-  solo-to-team section of `runbooks/collaboration.md` now has a mono path of its own, including
-  the warning not to run `scripts/setup-workspace.sh` in a mono clone.
+  the overlap warning's mono fallback was already written, in the very section that clause cited.
+  How many repos you have follows your architecture, not your headcount. The solo-to-team section
+  of `runbooks/collaboration.md` now has a mono path of its own, including the warning not to run
+  `scripts/setup-workspace.sh` in a mono clone; `METHOD.md` §7 and `prompts/README.md` moved with
+  it, the first gaining the mono→multi special case (that STEP is branchless, and its number is
+  reserved on trunk) and the second generalizing its thin-STEP note from the check-in alone to two
+  families.
 
 ### Changed
 - **The README and website now tell you to clone the latest *release*, not `main`.**
@@ -63,6 +67,15 @@ any project built with it.
   maintainer test enforces it.
 
 ### Fixed
+- **`init.sh`'s closing backup tip was wrong for a mono-repo project.** It told every project to
+  "create empty repos on your host, add their URLs to `registries/repos.yml`, and push each local
+  repo's `main` branch" — which is what `runbooks/collaboration.md` §9 expressly tells a mono
+  project *not* to do, since those rows describe folders inside the one repo rather than repos to
+  clone. The tip is now layout-conditional: mono is told to create one repo, push the root repo's
+  trunk, and leave the registry rows alone. The mono + team kickoff note stopped citing the
+  repealed split-before-a-teammate rule in the same change — the observation under it still holds
+  and is still printed, but it now points at the fallback `collaboration.md` §4 prescribes rather
+  than telling you to split.
 - **`11-interface-contracts.md` punctuation drift.** Its go-ahead paragraph had ASCII hyphens where
   every sibling file had em dashes — identical wording otherwise. Now byte-identical to the rest.
 - **Lifting a document into `architecture/` could fail the check that guards it.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ any project built with it.
 > copy carries an unfinished version of it. **No tagged release was affected**; the latest release
 > remains v1.7.1.
 
+### Added
+- **A runbook for splitting a repository** — `runbooks/splitting-repos.md`. The method used to say
+  splitting was "standard git," which is not something you can act on: the recipe you find
+  elsewhere makes the extracted repo *new*, with its history rewritten by `git filter-repo`, a
+  tool that never ships with git and needs Python on every install route. The runbook writes down
+  a different mechanic — clone the whole repo and delete forward — so nothing is rewritten, both
+  sides keep the full history, and `git blame`, `git log --follow` and every commit SHA your
+  project has recorded keep working in the new repo on day one. It covers both cases behind one
+  routing block: splitting a code repo in two, and converting a mono-repo-for-now workspace to
+  multi-repo. It asks three questions before you start and the rest at the step that needs them,
+  each with a default, so answering "use your judgement" still produces a correct split. The one
+  real cost is stated plainly in the file: every new repo inherits every blob the origin ever
+  committed, including deleted ones, and an appendix covers purging first when that matters.
+  Split-out repos can now record where they came from, in a `provenance:` block on their
+  `registries/repos.yml` row.
+
+  Shipping with it: **the rule telling you to split before adding a second contributor is gone.**
+  It gave two reasons and neither survived. The STEP-number push-race works exactly the same in a
+  mono repo with a shared remote — what a team needs is shared remotes, not several of them — and
+  the overlap warning's mono fallback was already written, one section above the clause that said
+  it wasn't. How many repos you have follows your architecture, not your headcount. The
+  solo-to-team section of `runbooks/collaboration.md` now has a mono path of its own, including
+  the warning not to run `scripts/setup-workspace.sh` in a mono clone.
+
 ### Changed
 - **The README and website now tell you to clone the latest *release*, not `main`.**
   `git clone --branch v1.7.1 …` gives you the 1.7 release; `main` is where Throughstone itself is

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -556,9 +556,10 @@ project, push the `In progress` flip so others can see that the architecture STE
 
 **Mono→multi split special case:** converting a mono-repo-for-now workspace to multi-repo is
 **branchless** — there is no `step-NNNN` branch, because the repos that branch would live in are
-the ones being created. Its STEP number is reserved on `prompts/`'s trunk and committed there
-before the split starts (`runbooks/splitting-repos.md`, Part 2). Splitting a code repo later is
-ordinary branch-per-STEP work like anything else.
+the ones being created. Its STEP number is reserved in `prompts/STEP-index.md` and committed on
+the mono repo's trunk — the workspace root, the project's only repo at that point — before the
+split starts (`runbooks/splitting-repos.md`, Part 2). Splitting a code repo later is ordinary
+branch-per-STEP work like anything else.
 
 ## 8. Naming conventions
 

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -525,13 +525,15 @@ itself is that one repo** (the lone exception to "the root is not a repo" above)
 `prompts/` and `Code/{{PROJECT}}-docs/` as folders inside it rather than sibling repos. In
 this mode the root pointers (`CLAUDE.md` / `AGENTS.md`) are just ordinary committed files, not
 per-machine artifacts, and the hygiene rule relaxes to match. It's a convenience for getting
-moving solo; the multi-repo layout is the target. **Team collaboration assumes multi-repo.**
-What a team actually needs is **shared remotes** (so the push-reject that referees STEP-number
-reservation can fire — `runbooks/collaboration.md` §2); on top of that, the overlap warning
-(§4 there) is repo-granular, so it's meaningless when every STEP touches the one mono-repo. So
-split before you go team. Splitting later is standard git (extract `prompts/`
-and the docs hub into their own repos); afterward, fill in the `remote:` fields in
-`registries/repos.yml` and have others run `scripts/setup-workspace.sh`.
+moving solo; the multi-repo layout is the target — but move to it when the architecture asks
+for it. **How many repos a project has follows its architecture, not its headcount.** A
+mono-repo project that gains a second contributor needs **shared remotes** — so the push-reject
+that referees STEP-number reservation can fire (`runbooks/collaboration.md` §2, whose solo→team
+section carries the mono path) — not a split.
+
+**Splitting is its own procedure:** `runbooks/splitting-repos.md`, covering both leaving mono
+and dividing a code repo in two later on — deliberately not "standard git", because the published
+recipe rewrites history with a tool the method can't require.
 
 **Working with others:** every STEP is worked on its own branch (`step-NNNN-short-name`, same
 name in every repo it touches) — **solo too**, so the workflow doesn't change the day a second
@@ -551,6 +553,12 @@ kickoff closes, flip the `STEP-1` row to `In progress`. Use the branch name
 `step-0001-architecture` for STEP-1 work wherever branch-per-STEP applies (docs hub and
 `prompts/` in multi-repo projects; the root repo in mono-repo-for-now). In a team/shared-remote
 project, push the `In progress` flip so others can see that the architecture STEP is active.
+
+**Mono→multi split special case:** converting a mono-repo-for-now workspace to multi-repo is
+**branchless** — there is no `step-NNNN` branch, because the repos that branch would live in are
+the ones being created. Its STEP number is reserved on `prompts/`'s trunk and committed there
+before the split starts (`runbooks/splitting-repos.md`, Part 2). Splitting a code repo later is
+ordinary branch-per-STEP work like anything else.
 
 ## 8. Naming conventions
 

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -90,8 +90,8 @@ split a repository. The release adds a runbook for that, and repeals one rule. F
 **The rule that went away.** The method used to say a mono-repo-for-now project had to split before
 taking on a second contributor. It gave two reasons and neither holds. The STEP-number push race
 works exactly the same in a mono repo with a shared remote — what a team needs is *shared* remotes,
-not *several* repos — and the overlap warning's mono fallback was already written, one section above
-the clause that said it wasn't. **How many repos you have follows your architecture, not your
+not *several* repos — and the overlap warning's mono fallback was already written, in the very
+section that clause cited. **How many repos you have follows your architecture, not your
 headcount.** If you already split for the old reason you have lost nothing and there is nothing to
 undo; if you were about to, you no longer need to.
 

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -75,6 +75,50 @@ During an update, treat those old `overview.md` sections as legacy project-state
 `scripts/check.sh` warns when it sees these legacy sections. The warning is advisory and does
 not fail the check.
 
+### 1.8 migration
+
+**Upgrading from 1.7? Nothing is rewritten and nothing is required of you** unless you are about to
+split a repository. The release adds a runbook for that, and repeals one rule. Fast path:
+
+1. Pull the process docs as one review-required group (the new `runbooks/splitting-repos.md`,
+   `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §9, `prompts/README.md`, and
+   the header comment in `registries/repos.yml`).
+2. If you were planning to split a repo **only** in order to add a second contributor — stop.
+   That rule is gone, and nothing replaces it.
+3. Nothing else. A project that never splits reads none of this, and no file of yours changes.
+
+**The rule that went away.** The method used to say a mono-repo-for-now project had to split before
+taking on a second contributor. It gave two reasons and neither holds. The STEP-number push race
+works exactly the same in a mono repo with a shared remote — what a team needs is *shared* remotes,
+not *several* repos — and the overlap warning's mono fallback was already written, one section above
+the clause that said it wasn't. **How many repos you have follows your architecture, not your
+headcount.** If you already split for the old reason you have lost nothing and there is nothing to
+undo; if you were about to, you no longer need to.
+
+**Splitting, when you do want it.** `runbooks/splitting-repos.md` covers both cases behind one
+routing block: splitting a code repo in two, and converting a mono-repo-for-now workspace to
+multi-repo. It is a STEP, like the check-in, with a thin PLAN that points at the runbook rather than
+authored substep prompts. The mechanic clones the whole repo and deletes forward, so **nothing is
+rewritten**: both sides keep the full history as the same objects with the same SHAs, and
+`git blame`, `git log --follow`, `git bisect`, `git merge-base` and every commit SHA you have
+recorded anywhere keep resolving in the new repo on day one. The cost is stated plainly in the file
+— every new repo inherits every blob the origin ever committed, including deleted ones — and an
+appendix covers purging history first when that matters.
+
+- *Process docs* (`runbooks/splitting-repos.md`, `runbooks/README.md`, `METHOD.md` §7,
+  `runbooks/collaboration.md` §9, `prompts/README.md`, `registries/repos.yml`'s header): a new
+  runbook plus the edits that route to it — `METHOD.md` §7 gains the mono→multi special case (that
+  STEP is branchless, and its number is reserved on trunk), `collaboration.md` §9 gains a mono path
+  through solo→team including the warning not to run `scripts/setup-workspace.sh` in a mono clone,
+  and `prompts/README.md`'s thin-STEP note now names two families rather than the check-in alone.
+  Apply them as a coherent group; they reference each other. No `status.sh` / `check.sh` change, and
+  no new check — nothing detects registry drift after a split, which is accepted rather than
+  overlooked.
+- *Project state* (your existing `registries/repos.yml` rows and your repos): never auto-updated.
+  `provenance:` is a new optional block recording that a repo was split out of another one — where
+  it came from, and where the two histories part company. It is written **at** a split and only
+  then, so existing rows do not gain it and a project that split before 1.8 does not backfill.
+
 ### 1.7 migration
 
 **Upgrading from 1.6? Start here.** This release rewrites no project files. Only two defaults

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -100,8 +100,9 @@ routing block: splitting a code repo in two, and converting a mono-repo-for-now 
 multi-repo. It is a STEP, like the check-in, with a thin PLAN that points at the runbook rather than
 authored substep prompts. The mechanic clones the whole repo and deletes forward, so **nothing is
 rewritten**: both sides keep the full history as the same objects with the same SHAs, and
-`git blame`, `git log --follow`, `git bisect`, `git merge-base` and every commit SHA you have
-recorded anywhere keep resolving in the new repo on day one. The cost is stated plainly in the file
+`git blame`, `git log --follow`, `git bisect` and every commit SHA you have recorded anywhere keep
+resolving in the new repo on day one, and `git merge-base` resolves across the split once one repo
+fetches the other. The cost is stated plainly in the file
 — every new repo inherits every blob the origin ever committed, including deleted ones — and an
 appendix covers purging history first when that matters.
 

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -14,11 +14,17 @@
 # keep `location` and `remote` distinct: a clone URL goes in `remote`, never folded into `location`.
 #
 # Mono-repo-for-now: the entries below are folders inside the single repo, not separate repos
-# yet — this inventory describes the post-split (multi-repo) target.
+# yet — this inventory describes the post-split (multi-repo) target. When you do split them
+# apart, follow `runbooks/splitting-repos.md`, and delete this note once the repos are real.
 #
 # Teams: give each repo a `remote:` field (any cloneable git URL). scripts/setup-workspace.sh clones from
 # it, and the STEP-number reservation in runbooks/collaboration.md relies on a shared remote
 # for prompts/ + this docs hub. Solo with no remotes, it's optional.
+#
+# `provenance:` records that a repo was **split out** of another one — where it came from, and
+# where the two histories part company. Only a split-out repo carries it, and it is written at
+# the split (`runbooks/splitting-repos.md`); nothing maintains it afterwards. The shape is in
+# the commented example below.
 
 repos:
   - name: "{{PROJECT}}-docs"
@@ -38,3 +44,8 @@ repos:
   #   type: service
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
   #   description: "..."
+  #   provenance:                                          # only on a repo that was split out
+  #     from: "{{PROJECT}}-web"                            # the repo this used to be part of
+  #     split_on: "2026-01-31"
+  #     split_commit: "a1b2c3d"                            # last shared commit — resolves in BOTH repos
+  #     archive_remote: "git@example.com:TEAM/{{PROJECT}}.git"   # only when a mono repo was retired

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -24,7 +24,9 @@
 # `provenance:` records that a repo was **split out** of another one — where it came from, and
 # where the two histories part company. Only a split-out repo carries it, and it is written at
 # the split (`runbooks/splitting-repos.md`); nothing maintains it afterwards. The shape is in
-# the commented example below.
+# the commented example below. `from:` is a historical name and may have no row of its own —
+# after a mono-repo-for-now split it never does, because the repo it names was retired; that is
+# what `archive_remote:` is for.
 
 repos:
   - name: "{{PROJECT}}-docs"

--- a/Code/{{PROJECT}}-docs/runbooks/README.md
+++ b/Code/{{PROJECT}}-docs/runbooks/README.md
@@ -12,8 +12,9 @@ The method (`../METHOD.md`) draws a line that matters for how you *invoke* each 
 - **STEP-shaped** — runs as a tracked STEP with substeps that record status in the
   `prompts/STEP-index.md`/PLAN. Its PLAN is thin and points at the runbook; you don't author substep
   prompts for it (the same special case as the architecture STEP — see `prompts/README.md`).
-  The **check-in** is one; the **incident** follow-up (Parts 2–4) becomes one; security
-  reviews become one when the check-in gate or project cadence says a separate review is due.
+  The **check-in** is one; the **incident** follow-up (Parts 2–4) becomes one; a **repository
+  split** is one; security reviews become one when the check-in gate or project cadence says a
+  separate review is due.
 - **Operational procedure** — *not* a STEP. You run it in the moment by telling the agent the
   trigger phrase below, and it follows the file. The **release**, **dependency** vetting/audit,
   **secrets rotation**, **an explicitly requested early S0 security baseline**, and the **incident** Part-1
@@ -39,3 +40,4 @@ first-contribution STEP guidance, so it lives at [`../ONBOARDING.md`](../ONBOARD
 | [`dependency-supply-chain.md`](dependency-supply-chain.md) | Vet a dependency **before** adding it (Part 1); audit installed deps on a cadence (Parts 2–3). | Operational; before `install`/`add` — *"vet this dependency"*; audit rides the check-in or a new advisory. | Security & Threat Model architecture doc (`architecture/*-security-threat-model.md`); `registries/risks.yml` for accepted deferrals |
 | [`secrets-rotation.md`](secrets-rotation.md) | Rotate secrets with no downtime on a cadence (Part 1); revoke-first emergency response to a suspected leak (Part 2). | Operational; on a cadence — *"rotate the secrets"*; on exposure — *"we may have leaked a secret."* | Security & Threat Model architecture doc (`architecture/*-security-threat-model.md`) |
 | [`collaboration.md`](collaboration.md) | How more than one contributor — human or agent — works without colliding: STEP/ADR numbering, branch-per-STEP, shared-file edits. | Reference; read it when a second contributor joins (solo, mostly a no-op). | `METHOD.md` §6, §8; `AGENTS.md` (team conventions) |
+| [`splitting-repos.md`](splitting-repos.md) | Split one code repo into two, or convert a mono-repo-for-now workspace into multi-repo — clone-and-forward-delete, so both sides keep full un-rewritten history. | A **STEP**, when the architecture calls for a new repo boundary or you're leaving mono — *"run the split."* | `METHOD.md` §7 (repos & the workspace shell); `registries/repos.yml` (the row and its `provenance:`); `collaboration.md` §9 |

--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -266,10 +266,7 @@ The *structural* habits above you already practice solo — branch-per-STEP (§1
 the STEP number in the index (§2, a plain local edit with no remote). What **switches on** when
 the second contributor arrives is the *coordination*: the push/renumber race (§2), the overlap
 warning (§4), the shared-file your-row-only discipline (§5), and the `Proposed → Accepted` ADR
-flow (§6). The transition is mostly mechanical (and assumes the **multi-repo** layout — if
-you're still mono-repo-for-now per `METHOD.md` §7, split first: a team needs shared remotes
-for the reservation push-race to work, and the overlap warning (§4) is meaningless in a single
-repo):
+flow (§6). The transition is mostly mechanical:
 
 1. **Stand up the shared remotes — and push your existing history to them first.** A solo
    dev has been committing locally with no remote, so the order matters: (a) create the remote
@@ -278,6 +275,17 @@ repo):
    gone; (b) add the `remote:` fields in `registries/repos.yml`; (c) have each new contributor
    run `scripts/setup-workspace.sh` to clone them. Number reservation (§2) relies on this
    shared `prompts/` remote.
+
+   **Mono-repo-for-now** (`METHOD.md` §7) has one repo, the workspace root, so this is one
+   remote rather than several: create it, push the root repo's existing history to it, and have
+   each new contributor clone that single repo. Don't add `remote:` fields to
+   `registries/repos.yml` and **don't run `scripts/setup-workspace.sh`** — those rows describe
+   folders inside your one repo rather than repos to clone, and the script is for multi-repo
+   workspaces: run in a mono clone it overwrites the committed root `CLAUDE.md`, `AGENTS.md`
+   and `doctor.sh` with per-machine pointers asserting the root is not a repo. Everything else
+   is the same, including number reservation, which needs a shared remote and not a particular
+   number of them. Whether to split is a separate question, answered by the architecture rather
+   than by the size of the team — see `splitting-repos.md`.
 2. **Have each contributor create their local profile** (`.throughstone/local-user.md`) during
    onboarding. This records their own Experience level and Communication style; do not copy
    the original solo maintainer's preferences into project docs.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -52,8 +52,8 @@ gets handled.
 There is no fixed number of them, because the shape of a split follows the shape of your repos.
 The usual breakpoints:
 
-- *Part 1, typically three:* **N.1** extract and stand the new repo up (steps 3–5) · **N.2** prune
-  and repoint (steps 6–8) · **N.3** verify (step 9).
+- *Part 1, typically three:* **N.1** pre-flight, extract and stand the new repo up (steps 1–5) ·
+  **N.2** prune and repoint (steps 6–8) · **N.3** verify (step 9).
 - *Part 2, typically four:* **N.1** pre-flight and backup (steps 1–3) · **N.2** build the new repos
   beside (steps 5–7) · **N.3** assemble and verify the workspace (steps 8–10) · **N.4** swap and
   retire (steps 11–12). Steps 4 and 13 are the STEP's own bookkeeping rather than work inside it,

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -17,9 +17,15 @@
 > **Stop and get a go-ahead before continuing at each of these**, even where a default already
 > answers the question. A split is rare and mostly hard to undo, so the extra exchanges are the
 > cheapest part of it: before the first destructive command, with the mapping written out; at
-> every file-list confirmation point, showing the list itself and never a summary; before
+> every file-list confirmation point, showing the list itself and never a summary; when you
+> reconcile two ignore files into one, showing both and what you merged them into; before
 > anything leaves your machine — creating a remote, pushing a trunk; and before anything on disk
-> stops being easy to undo — pruning the origin, swapping the workspace, retiring the old remote.
+> stops being easy to undo — pruning the origin, clearing what it left behind, swapping the
+> workspace, retiring the old remote.
+>
+> Each one is marked **Stop** where it fires — in the mechanic, which runs in three pieces per
+> repo, and at the steps below. Getting a go-ahead means ending your turn and waiting for a
+> reply, not recording afterwards that you passed the point.
 >
 > **A split is a STEP**, like the check-in. Its PLAN is thin and points here; you don't author
 > substep prompts for it — this runbook *is* the substeps (the same special case as the check-in,
@@ -224,7 +230,9 @@ special here, which is why it gets no steps of its own below.
 > carries it.
 
 1. **Confirm the mapping and the boundary** (questions 1 and 2). Write down the origin repo, the
-   path being extracted, and the new repo's name.
+   path being extracted, and the new repo's name. **Stop here, before step 3 builds anything** —
+   show that written-out mapping and your answer to question 2. Deciding not to split is one of
+   the answers, and this is the step where it gets made.
 2. **Pre-flight: the branches that won't survive.** Run `git branch -a`. A clone carries every
    commit and every tag, but only the default branch arrives as a real branch — the rest exist
    only as remote-tracking refs and die with `git remote remove origin`, silently. The origin repo
@@ -250,14 +258,18 @@ special here, which is why it gets no steps of its own below.
 5. **Give it a remote.** Create it **private** — widening is a separate decision, made deliberately
    later, and this repo now carries the origin's whole history. **Push trunk before you record the
    remote anywhere** (step 8 writes the registry row): that is the order `collaboration.md` §9
-   already uses, and it is what stops the next person cloning an empty repo.
+   already uses, and it is what stops the next person cloning an empty repo. **Stop before this
+   step runs** — creating the remote and pushing trunk are the first two things that leave your
+   machine.
 6. **Prune the origin.** `git rm -r -q -- <extracted-path>` and commit. Then **`ls -a
    <extracted-path>`** — do not look for dirtiness. `git rm` removes only tracked files, and what
    stays behind is everything the repo was told to *ignore*: build output, vendored files,
    snapshots, `.env`. Ignored files never show as dirty; they do not show at all. Clear what is
    left by hand. Two reasons this is not just tidiness: stale build output where the source used to
    be can keep the origin's tests passing against code the repo no longer contains, and step 7's
-   `git grep` searches tracked files only, so it will not see it either.
+   `git grep` searches tracked files only, so it will not see it either. **Stop on the
+   `ls -a` output, before deleting any of it** — the `git rm` above is recoverable from history
+   and this is not: no remote, no mirror and no clone holds these files.
 7. **Repoint everything that knew the old path.** `git grep -n -F "<old path>"` in the origin, in
    the extracted repo, **and in the docs hub** — including each `.gitignore`, where a rule anchored
    at the old path is now dead. Every hit is either a repoint or a mention of history you keep on
@@ -320,6 +332,9 @@ repos of their own. This happens at most once per project.
      durable home is `archive_remote:` in the registry at step 7; until then a scratch note is fine.
    - **Decide what happens to the old remote** at the end (step 12): leave it, retire it, or delete
      it. *Default: retire it.*
+   - **Stop here, before step 5 builds anything.** Show the mapping written out — every unit and
+     the repo it becomes, every root file from step 1 and its disposition, and both lists above in
+     full rather than counted. Everything after this is derived from that answer.
 3. **Backup mirror.** `git clone --mirror --no-local . ../<project>-presplit.git`, and confirm it
    is readable (`git -C ../<project>-presplit.git log --oneline -1`). Every new repo will carry the
    full history anyway, so this is a spare copy rather than the home of the project's past — skip
@@ -355,6 +370,8 @@ repos of their own. This happens at most once per project.
    the `origin` URL you wrote down at step 2 as `archive_remote:`. **Delete the mono-repo-for-now
    note** above the rows; it stops being true the moment this step runs. **Push the hub last**,
    after its registry commit, or none of these rows reaches a teammate.
+   **Stop before the first create and push** — this is where the whole mono history leaves your
+   machine, once per repo, and where private-or-not stops being a local decision.
 8. **Root pointers.** Run `scripts/setup-workspace.sh` from the new hub, in the build directory.
    The build directory is assembled purely from clones, so it has no root `CLAUDE.md`, `AGENTS.md`
    or `doctor.sh` until this runs — and nothing would ever flag their absence.
@@ -375,10 +392,11 @@ repos of their own. This happens at most once per project.
       `Code/<project>-docs/` inside it, run `scripts/setup-workspace.sh` there, and confirm every
       registered repo actually arrives.
     - The pre-split commit resolves in every new repo.
-11. **Swap.** **Rename** the old workspace aside — do not delete it — and move the build directory
-    into its place. Abort is still just deleting the build directory. Delete the old workspace only
-    after you have worked in the new one for a while: it is the only copy of anything step 2's
-    lists missed, and no mirror holds untracked or ignored files.
+11. **Swap.** **Stop before the rename** — show which directory becomes which. Then **rename** the
+    old workspace aside — do not delete it — and move the build directory into its place. Abort is
+    still just deleting the build directory. Delete the old workspace only after you have worked in
+    the new one for a while: it is the only copy of anything step 2's lists missed, and no mirror
+    holds untracked or ignored files.
 12. **Retire the old remote**, per step 2's decision. *Default:* delete its contents in one tip
     commit, leaving a `README.md` that says the history is still there and how to reach it, then set
     the host's permissions to read-only. **Never delete refs**, and author that commit on a fresh
@@ -387,7 +405,8 @@ repos of their own. This happens at most once per project.
     one sentence for anyone else holding a clone: *start a fresh empty folder, clone the docs hub
     into `Code/<project>-docs/` inside it, and run `scripts/setup-workspace.sh` there — do not
     reuse your old project folder.* Re-onboarding in place leaves the new repos nested inside the
-    retired one, and every check passes.
+    retired one, and every check passes. **Stop before you push that commit** — show the README and
+    the tree it leaves behind.
 13. **Write the STEP's PLAN** and archive it into the new `prompts/` repo at
     `prompts/<phase>/step-NNNN/`, then mark the STEP done in `prompts/STEP-index.md`. Written now
     rather than at step 4, it never has to pass through a forward delete. *Skip this if you skipped

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -425,5 +425,8 @@ path change — but only one repo can inherit it, and the workspace root stops b
 moment you move `.git`, so this only makes sense as part of Part 2. **Do it last**, after every
 other unit has been cloned at step 5, not here before Part 2 starts: the move drops those units
 from HEAD, so their forward delete keeps nothing and the guard fires on a path you typed
-correctly. And be clear what it buys — one copy of the object graph, not the blob. Every other
-unit is still a clone and still carries it.
+correctly. Then **move the inheriting folder into the build directory** with the rest — step 11
+moves that directory into place and would otherwise strand this repo in the workspace you renamed
+aside. Its untracked and ignored files travel with it, so step 9 has nothing to carry for it. And
+be clear what it buys — one copy of the object graph, not the blob. Every other unit is still a
+clone and still carries it.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -467,10 +467,10 @@ repos of their own. This happens at most once per project.
     reuse your old project folder.* Re-onboarding in place leaves the new repos nested inside the
     retired one, and every check passes. **Stop before you push that commit** — show the README and
     the tree it leaves behind.
-13. **Write the STEP's PLAN** and archive it into the new `prompts/` repo at
-    `prompts/<phase>/step-NNNN/`, then mark the STEP done in `prompts/STEP-index.md`. Written now
-    rather than at step 4, it never has to pass through a forward delete. *Skip this if you skipped
-    step 4.*
+13. **Write the STEP's PLAN** and archive it into the new `prompts/` repo — at `<phase>/step-NNNN/`
+    and `STEP-index.md` from that repo's root, since the un-nest at step 5 moved `prompts/`'s
+    contents up to it. Then mark the STEP done. Written now rather than at step 4, it never has to
+    pass through a forward delete. *Skip this if you skipped step 4.*
 
 ## Appendix — purging history first
 

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -1,7 +1,8 @@
 # Runbook — Splitting a Repository
 
 > **How to run:** Two cases behind one procedure. Answer the three questions in **Before you
-> start**, then go to your part — you don't pick the case, it falls out of the first answer.
+> start**, then go to your part — you run one of them, never both, and you don't pick which: it
+> falls out of the first answer.
 > Tell your agent *"run the split"* and it follows this file.
 > - **Part 1 — Splitting a code repo in two.** The ordinary one: a repo grew two things that
 >   should ship separately. Any number of times.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -367,9 +367,11 @@ repos of their own. This happens at most once per project.
    side effect of the split. Push trunk, then record `remote:` in
    `registries/repos.yml`. Every row in that file is now a split-out repo, so each also gets a
    `provenance:` block — naming the mono repo, today's date, the last commit they all share, and
-   the `origin` URL you wrote down at step 2 as `archive_remote:`. **Delete the mono-repo-for-now
-   note** above the rows; it stops being true the moment this step runs. **Push the hub last**,
-   after its registry commit, or none of these rows reaches a teammate.
+   the `origin` URL you wrote down at step 2 as `archive_remote:`. **That commit has to exist on
+   the archive too** — if the mono trunk you cloned at step 5 was ahead of its remote, push it
+   there before you record these, because step 12 makes that host read-only. **Delete the
+   mono-repo-for-now note** above the rows; it stops being true the moment this step runs.
+   **Push the hub last**, after its registry commit, or none of these rows reaches a teammate.
    **Stop before the first create and push** — this is where the whole mono history leaves your
    machine, once per repo, and where private-or-not stops being a local decision.
 8. **Root pointers.** Run `scripts/setup-workspace.sh` from the new hub, in the build directory.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -338,8 +338,12 @@ The workspace root stops being a repository. `prompts/`, the docs hub and each c
 repos of their own. This happens at most once per project.
 
 > **You build the new workspace beside the old one and swap at the end.** Everything up to step 11
-> happens in `../<project>-split/`; the live workspace is never touched, so abort is deleting that
-> directory. Do not start by deleting or rewriting anything you have.
+> happens in `../<project>-split/`, and until step 4 the live workspace is untouched, so abort is
+> deleting that directory. Do not start by deleting or rewriting anything you have. From step 4 on,
+> two things live outside the build directory and abort has to undo them by hand: the STEP
+> reservation committed and pushed on the live trunk, which becomes a row to mark **Abandoned**,
+> and the remotes step 7 creates and pushes, which have to be deleted. Left standing, a teammate
+> cloning the hub from them gets a complete, green workspace for a split nobody did.
 
 1. **Confirm the mapping** (question 1), and decide **where each root file goes**. Derive the list;
    don't work from memory:
@@ -450,9 +454,9 @@ repos of their own. This happens at most once per project.
     - The pre-split commit resolves in every new repo.
 11. **Swap.** **Stop before the rename** — show which directory becomes which. Then **rename** the
     old workspace aside — do not delete it — and move the build directory into its place. Abort is
-    still just deleting the build directory. Delete the old workspace only after you have worked in
-    the new one for a while: it is the only copy of anything step 2's lists missed, and no mirror
-    holds untracked or ignored files.
+    still deleting the build directory, plus the step-4 and step-7 cleanup above. Delete the old
+    workspace only after you have worked in the new one for a while: it is the only copy of
+    anything step 2's lists missed, and no mirror holds untracked or ignored files.
 12. **Retire the old remote**, per step 2's decision. *Default:* delete its contents in one tip
     commit, leaving a `README.md` that says the history is still there and how to reach it, then set
     the host's permissions to read-only. **Never delete refs**, and author that commit on a fresh

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -454,10 +454,12 @@ git -C ../purge-work.git filter-repo --analyze             # path + rename repor
 git -C ../purge-work.git for-each-ref --format='%(objectname) %(refname)' > ../refs-before.txt
 ```
 
-The `--analyze` reports are how you build the path list. **Neither tool follows renames.** History
-truncates at every historical path you fail to name, silently — one reported case lost 119 of 144
-commits of `--follow` history on a plain directory filter. If the file ever moved, every one of its
-old paths has to be on the list.
+The `--analyze` reports are how you build the path list. **Neither tool follows renames.** If the
+file ever moved, every one of its old paths has to be on the list, and a path you miss fails
+silently in whichever direction you are filtering. Keeping a set of paths truncates history at the
+ones you did not name — one reported case lost 119 of 144 commits of `--follow` history on a plain
+directory filter. Removing a set leaves the blob in history under the old name, and the tool
+reports success: on a purge, that is the credential you came here to delete.
 
 **The tools.**
 - **`git filter-repo`** is the one that handles a scattered set of paths, and the one you cannot

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -10,6 +10,13 @@
 >
 > Either way, when you're done: push every repo you touched, and tell your teammates.
 >
+> **Stop and get a go-ahead before continuing at each of these**, even where a default already
+> answers the question. A split is rare and mostly hard to undo, so the extra exchanges are the
+> cheapest part of it: before the first destructive command, with the mapping written out; at
+> every file-list confirmation point, showing the list itself and never a summary; before
+> anything leaves your machine — creating a remote, pushing a trunk; and before anything on disk
+> stops being easy to undo — pruning the origin, swapping the workspace, retiring the old remote.
+>
 > **A split is a STEP**, like the check-in. Its PLAN is thin and points here; you don't author
 > substep prompts for it — this runbook *is* the substeps (the same special case as the check-in,
 > see `prompts/README.md`). *Substeps*, below, names the usual breakpoints.
@@ -109,7 +116,7 @@ test -z "$(git ls-files -- <keep>)" || { echo "un-nest incomplete — reconcile 
 git commit -m "Move <scope> to the repo root"
 find . -mindepth 1 -type d -empty -not -path './.git/*' -delete
 
-git ls-files                                  # LOOK AT THIS. It is the repo you just made.
+git ls-files                                  # STOP. Show this — it is the repo you just made.
 ```
 
 **`.gitignore` is exempt from the delete, and that exemption is load-bearing.** Without
@@ -152,7 +159,8 @@ what step 7's repointing grep is for instead.
 
 **Why the confirmation points print a file list.** The forward delete and the un-nest are the two
 steps that can succeed while producing the wrong repo, and their exit status will not tell you.
-The list is what shows it. Do not skip past it, and do not replace it with a summary.
+The list is what shows it. Do not skip past it, do not replace it with a summary, and do not
+carry on until the person running the split has seen it and said go.
 
 **Reading a path across the un-nest.** The move is a rename, so plain `git log -- <path>` stops at
 the un-nest commit; use `git log --follow -- <path>`. `git blame` crosses it without help.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -143,9 +143,11 @@ git commit -m "Split: this repo now holds <scope>"
 ```
 
 **Stop if the kept directory has its own `.gitignore`** — reconcile it here, before the move, and
-show both files and the one you merged them into before you stage it (see below). Nothing further
-down reads that file, so a rule dropped here reaches the finished repo unremarked. No nested
-ignore file, no stop: carry straight on.
+show both files and the one you merged them into before you stage it (see below). Both files in
+full every time, including at the second and third repo where the root one looks unchanged from
+the last: *"same as before"* is the reviewer taking it on trust. Nothing further down reads that
+file, so a rule dropped here reaches the finished repo unremarked. No nested ignore file, no stop:
+carry straight on.
 
 ```bash
 cd <new-repo>
@@ -160,7 +162,8 @@ git ls-files
 ```
 
 **Stop.** Show that list — it is the repo you just made, and nothing else will tell you whether it
-is the right one. Then start the next repo.
+is the right one. Paste it whole however long it runs: a list with entries elided, or collapsed
+into brace expansion, is a summary. Then start the next repo.
 
 **`.gitignore` is exempt from the delete, and that exemption is load-bearing.** Without
 `':!.gitignore'` the new repo inherits no ignore file, and nothing left inside it can regenerate

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -471,8 +471,11 @@ git -C ../purge-work.git for-each-ref --format='%(objectname) %(refname)' > ../r
 diff ../refs-before.txt ../refs-after.txt
 ```
 
-Two refs that now point at the same object collapsed. Decide what each one should be before you
-push anything.
+Every SHA changes, so every line of that diff differs — read it for refs that *disappeared*, not
+for refs that moved. The collapse above needs a per-branch check instead: `git rev-list --count
+<trunk>..<branch>`, before and after. A branch that had commits of its own and now returns zero has
+been folded into another line of history, under a SHA that is not any other ref's tip, so the diff
+will not show it. Decide what each one should be before you push anything.
 
 **What a purge costs you**, so nobody is surprised: every SHA changes, so every commit reference
 recorded anywhere — `reviewed_commit:` in `registries/security-reviews.yml`, SHAs in reports and

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -49,8 +49,8 @@ So this runbook does something else, and it is deliberately **not** the recipe y
 elsewhere: it clones the whole repo and **deletes forward**. Nothing is rewritten. Both sides keep
 the full history; the shared commits are the same objects with the same SHAs in both repos, so
 `git blame`, `git log --follow` and `git bisect` work in the new repo on day one, `git merge-base`
-resolves across the split, and anything recorded against a commit — a `reviewed_commit:` in
-`registries/security-reviews.yml`, a SHA in a report — keeps resolving.
+resolves across the split once one repo fetches the other, and anything recorded against a commit —
+a `reviewed_commit:` in `registries/security-reviews.yml`, a SHA in a report — keeps resolving.
 
 The cost, stated plainly: **every new repo inherits every blob the origin ever committed**,
 including files deleted long ago. If a secret was ever committed, the split copies it into a

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -402,6 +402,7 @@ repos of their own. This happens at most once per project.
    the mechanic into its place in the new workspace:
 
    ```bash
+   # Where each unit lands. Substitute <new-repo> absolute — a relative one breaks blocks 2 and 3.
    git clone --no-local . ../<project>-split/prompts        # <keep> = prompts
    git clone --no-local . ../<project>-split/Code/<name>    # <keep> = Code/<name>
    ```

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -476,6 +476,13 @@ other unit has been cloned at step 5, not here before Part 2 starts: the move dr
 from HEAD, so their forward delete keeps nothing and the guard fires on a path you typed
 correctly. Then **move the inheriting folder into the build directory** with the rest — step 11
 moves that directory into place and would otherwise strand this repo in the workspace you renamed
-aside. Its untracked and ignored files travel with it, so step 9 has nothing to carry for it. And
+aside. Its ignored files travel with it untouched, so step 9 has nothing to carry for it. And
 be clear what it buys — one copy of the object graph, not the blob. Every other unit is still a
 clone and still carries it.
+
+**This replaces the clone and the forward delete, not the rest of the mechanic.** `origin` still
+points at the mono repo, so `git remote set-url` it to this repo's own remote before step 7 —
+otherwise "push trunk" pushes this tree over the mono repo's, and nothing errors. The root
+`.gitignore` is not here to be exempted: copy it in and reconcile it with the folder's own, as
+step 5 does. And `git add -A` commits every untracked file in the folder, where a clone would
+have left them untracked — so end with `git ls-files` and stop on it, like every other repo.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -248,7 +248,8 @@ special here, which is why it gets no steps of its own below.
    survives, so nothing is lost there; the risk is in-flight work on the *extracted* files, which
    lands in a repo where those files no longer exist. Merge or close everything but trunk before
    starting, or accept the loss knowingly. **Commit or stash your working tree too** — the clone
-   takes committed state, so an uncommitted edit never reaches the new repo.
+   takes committed state, so an uncommitted edit never reaches the new repo. Edits to tracked files,
+   that is: anything untracked under the extracted path is what step 6 moves across by hand.
 3. **Extract.** Run the mechanic above with `<keep>` set to the path being extracted. When it
    prints `git ls-files`, read it: it should look like the repo you asked for, at the root, with
    nothing left nested.
@@ -343,9 +344,10 @@ repos of their own. This happens at most once per project.
      with `git remote remove origin`, silently. Here the root repo is being *replaced*, so a stray
      branch is stranded with nowhere to land. Merge or close everything but trunk first, or accept
      the loss knowingly. **Commit your working tree too** — the clones at step 5 take committed
-     state, so an uncommitted edit reaches no new repo and nothing flags it. Stashing is not an
-     alternative here: a stash lives in the repo you are about to replace, so pop it and commit
-     before step 5.
+     state, so an uncommitted edit reaches no new repo and nothing flags it. That means edits to
+     tracked files; the untracked ones are already on the list above and cross by hand at step 9,
+     so there is nothing to sweep in here. Stashing is not an alternative either: a stash lives in
+     the repo you are about to replace, so pop it and commit before step 5.
    - **Write the mono repo's `origin` URL down now.** After the swap it exists nowhere on disk. Its
      durable home is `archive_remote:` in the registry at step 7; until then a scratch note is fine.
    - **Decide what happens to the old remote** at the end (step 12): leave it, retire it, or delete

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -128,12 +128,13 @@ exemption worked: `git check-ignore -v .env` should exit 0.
 **If the kept directory has its own `.gitignore`, reconcile before the move.** Two files exist at
 that moment: the origin's, which the exemption above left at the root, and the kept directory's,
 still nested — and the move will stop on the collision. Read both, reconcile them into one file at
-the repo root, and `git rm` the nested one. *Default: the union of the two.* Re-anchor any rule
-written against the old path (`/Code/<name>/dist/` becomes `/dist/`); it matches nothing after the
-move. In Part 2 this fires for every code folder, and never for `prompts/` or the docs hub, which
-have no ignore file of their own. In Part 1 it usually does not fire at all, because the extracted
-directory is a subdirectory of a code repo — the dead path-anchored rules it would have caught are
-what step 7's repointing grep is for instead.
+the repo root, `git rm` the nested one, and `git add` the reconciled one — nothing further down
+stages that edit for you. *Default: the union of the two.* Re-anchor any rule written against the
+old path (`/Code/<name>/dist/` becomes `/dist/`); it matches nothing after the move. In Part 2 this
+fires for every code folder, and never for `prompts/` or the docs hub, which have no ignore file of
+their own. In Part 1 it usually does not fire at all, because the extracted directory is a
+subdirectory of a code repo — the dead path-anchored rules it would have caught are what step 7's
+repointing grep is for instead.
 
 **The two checks do different jobs, and both are needed.**
 

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -104,19 +104,39 @@ repo's keep-set — the path or paths from question 1 that this repo is meant to
 what you would call that out loud (`billing`, `the docs hub`); it appears only in the two commit
 messages, which every repo the split produces then carries permanently.
 
+**It runs in three pieces, and the breaks between them are stops, not formatting.** Run a piece,
+show what it printed, wait for a go-ahead, then run the next. They are between the blocks rather
+than inside them because a stop written as a comment on a line you are about to execute is not a
+stop — it runs, and the block reads as finished. Each piece re-enters the repo on its first line:
+a stop can outlast the shell you started in, and these commands are destructive in the wrong
+directory.
+
 ```bash
 git clone --no-local <origin> <new-repo>      # --no-local is required for a local source
 cd <new-repo>
 git remote remove origin                      # the new repo must not point at the old one
 
 for p in <keep>; do echo "$p: $(git ls-files -- "$p" | wc -l | tr -d ' ') file(s)"; done
+```
 
+**Stop.** Show the mapping — this repo, its keep-set, and that count, one line per path. Every
+path has to be non-zero: a zero is a path that is mistyped or wrong-cased, and the delete below
+removes everything the keep-set did not match. Nothing has been deleted yet.
+
+```bash
+cd <new-repo>
 git rm -r -q -- . ':!<keep>' ':!.gitignore'   # forward-delete the complement; nothing is rewritten
 test -n "$(git ls-files -- <keep>)" || { echo "<keep> matched nothing — check the path"; exit 1; }
 git commit -m "Split: this repo now holds <scope>"
+```
 
-# Reconcile the kept directory's own .gitignore HERE, before the move — see below.
+**Stop if the kept directory has its own `.gitignore`** — reconcile it here, before the move, and
+show both files and the one you merged them into before you stage it (see below). Nothing further
+down reads that file, so a rule dropped here reaches the finished repo unremarked. No nested
+ignore file, no stop: carry straight on.
 
+```bash
+cd <new-repo>
 # The un-nest below applies only when <keep> is a SINGLE directory. With a scattered keep-set
 # (two or more paths) skip the next three lines: those paths stay where they are.
 ( set -e; shopt -s dotglob nullglob; for e in <keep>/*; do git mv "$e" .; done )
@@ -124,8 +144,11 @@ test -z "$(git ls-files -- <keep>)" || { echo "un-nest incomplete — reconcile 
 git commit -m "Move <scope> to the repo root"
 find . -mindepth 1 -type d -empty -not -path './.git/*' -delete
 
-git ls-files                                  # STOP. Show this — it is the repo you just made.
+git ls-files
 ```
+
+**Stop.** Show that list — it is the repo you just made, and nothing else will tell you whether it
+is the right one. Then start the next repo.
 
 **`.gitignore` is exempt from the delete, and that exemption is load-bearing.** Without
 `':!.gitignore'` the new repo inherits no ignore file, and nothing left inside it can regenerate

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -271,14 +271,17 @@ special here, which is why it gets no steps of its own below.
    step runs** — creating the remote and pushing trunk are the first two things that leave your
    machine.
 6. **Prune the origin.** `git rm -r -q -- <extracted-path>` and commit. Then **`ls -a
-   <extracted-path>`** — do not look for dirtiness. `git rm` removes only tracked files, and what
-   stays behind is everything the repo was told to *ignore*: build output, vendored files,
-   snapshots, `.env`. Ignored files never show as dirty; they do not show at all. Clear what is
-   left by hand — but first move anything that belongs to the **extracted** repo, its `.env` and
-   `.secrets/`, over to it: the clone took committed state, so what is sitting here is the only
-   copy. Two reasons clearing the rest is not just tidiness: stale build output where the source
-   used to be can keep the origin's tests passing against code the repo no longer contains, and
-   step 7's `git grep` searches tracked files only, so it will not see it either. **Stop on the
+   <extracted-path>`** — do not look for dirtiness. `git rm` removes only tracked files. What stays
+   behind is everything the repo never tracked: what it was told to *ignore* — build output,
+   vendored files, snapshots, `.env` — which `git status` does not print at all, plus any untracked
+   work you had in flight. Clear what is left by hand — but first move anything that belongs to the
+   **extracted** repo over to it: `.env` and `.secrets/` are the usual ones, in-flight work is the
+   one people lose, and the clone took committed state, so what is sitting here is the only copy.
+   It goes where the un-nest would have put it — `<extracted-path>/.env` becomes `.env` at the new
+   repo's root, or stays under `<extracted-path>/` when the keep-set was scattered and nothing was
+   un-nested. Two reasons clearing the rest is not just tidiness: stale build output where the
+   source used to be can keep the origin's tests passing against code the repo no longer contains,
+   and step 7's `git grep` searches tracked files only, so it will not see it either. **Stop on the
    `ls -a` output, before deleting any of it** — the `git rm` above is recoverable from history
    and this is not: no remote, no mirror and no clone holds these files.
 7. **Repoint everything that knew the old path.** `git grep -n -F "<old path>"` in the origin, in

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -113,9 +113,11 @@ messages, which every repo the split produces then carries permanently.
 **It runs in three pieces, and the breaks between them are stops, not formatting.** Run a piece,
 show what it printed, wait for a go-ahead, then run the next. They are between the blocks rather
 than inside them because a stop written as a comment on a line you are about to execute is not a
-stop — it runs, and the block reads as finished. Each piece re-enters the repo on its first line:
-a stop can outlast the shell you started in, and these commands are destructive in the wrong
-directory.
+stop — it runs, and the block reads as finished. A stop can outlast the shell you started in, and
+these commands are destructive in the wrong directory, so **run block 1 from the origin repo** —
+it resolves `<origin>` and `<new-repo>` against wherever you are standing — while blocks 2 and 3
+re-enter the new repo themselves on their first line. Block 3 leaves you inside the repo you just
+finished, which is not where the next repo's block 1 starts.
 
 ```bash
 git clone --no-local <origin> <new-repo>      # --no-local is required for a local source
@@ -126,8 +128,9 @@ for p in <keep>; do echo "$p: $(git ls-files -- "$p" | wc -l | tr -d ' ') file(s
 ```
 
 **Stop.** Show the mapping — this repo, its keep-set, and that count, one line per path. Every
-path has to be non-zero: a zero is a path that is mistyped or wrong-cased, and the delete below
-removes everything the keep-set did not match. Nothing has been deleted yet.
+path has to be non-zero: a zero is a path that is mistyped or wrong-cased, or a clone taken from
+somewhere other than the origin, and the delete below removes everything the keep-set did not
+match. Nothing has been deleted yet.
 
 ```bash
 cd <new-repo>

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -286,20 +286,24 @@ special here, which is why it gets no steps of its own below.
    already uses, and it is what stops the next person cloning an empty repo. **Stop before this
    step runs** — creating the remote and pushing trunk are the first two things that leave your
    machine.
-6. **Prune the origin.** `git rm -r -q -- <extracted-path>` and commit. Then **`ls -a
-   <extracted-path>`** — do not look for dirtiness. `git rm` removes only tracked files. What stays
-   behind is everything the repo never tracked: what it was told to *ignore* — build output,
-   vendored files, snapshots, `.env` — which `git status` does not print at all, plus any untracked
-   work you had in flight. Clear what is left by hand — but first move anything that belongs to the
-   **extracted** repo over to it: `.env` and `.secrets/` are the usual ones, in-flight work is the
-   one people lose, and the clone took committed state, so what is sitting here is the only copy.
-   It goes where the un-nest would have put it — `<extracted-path>/.env` becomes `.env` at the new
-   repo's root, or stays under `<extracted-path>/` when the keep-set was scattered and nothing was
-   un-nested. Two reasons clearing the rest is not just tidiness: stale build output where the
-   source used to be can keep the origin's tests passing against code the repo no longer contains,
-   and step 7's `git grep` searches tracked files only, so it will not see it either. **Stop on the
-   `ls -a` output, before deleting any of it** — the `git rm` above is recoverable from history
-   and this is not: no remote, no mirror and no clone holds these files.
+6. **Prune the origin.** `git rm -r -q -- <extracted-path>` and commit — naming *every* path in the
+   keep-set, not just the first, and `git ls-files -- <extracted-path>` has to come back empty
+   afterwards. That is the origin's only post-condition, and it is what a scattered keep-set needs:
+   pruning one of two paths leaves the other tracked and live in both repos, and every check below
+   still passes. Then **`ls -a <extracted-path>`** — do not look for dirtiness. `git rm` removes
+   only tracked files. What stays behind is everything the repo never tracked: what it was told to
+   *ignore* — build output, vendored files, snapshots, `.env` — which `git status` does not print
+   at all, plus any untracked work you had in flight. Clear what is left by hand — but first move
+   anything that belongs to the **extracted** repo over to it: `.env` and `.secrets/` are the usual
+   ones, in-flight work is the one people lose, and the clone took committed state, so what is
+   sitting here is the only copy. It goes where the un-nest would have put it —
+   `<extracted-path>/.env` becomes `.env` at the new repo's root, or stays under
+   `<extracted-path>/` when the keep-set was scattered and nothing was un-nested. Two reasons
+   clearing the rest is not just tidiness: stale build output where the source used to be can keep
+   the origin's tests passing against code the repo no longer contains, and step 7's `git grep`
+   searches tracked files only, so it will not see it either. **Stop on the `ls -a` output, before
+   deleting any of it** — the `git rm` above is recoverable from history and this is not: no
+   remote, no mirror and no clone holds these files.
 7. **Repoint everything that knew the old path.** `git grep -n -F "<old path>"` in the origin, in
    the extracted repo, **and in the docs hub** — including each `.gitignore`, where a rule anchored
    at the old path is now dead. Every hit is either a repoint or a mention of history you keep on

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -481,11 +481,14 @@ path change — but only one repo can inherit it, and the workspace root stops b
 moment you move `.git`, so this only makes sense as part of Part 2. **Do it last**, after every
 other unit has been cloned at step 5, not here before Part 2 starts: the move drops those units
 from HEAD, so their forward delete keeps nothing and the guard fires on a path you typed
-correctly. Then **move the inheriting folder into the build directory** with the rest — step 11
-moves that directory into place and would otherwise strand this repo in the workspace you renamed
-aside. Its ignored files travel with it untouched, so step 9 has nothing to carry for it. And
-be clear what it buys — one copy of the object graph, not the blob. Every other unit is still a
-clone and still carries it.
+correctly. **Push the mono trunk to its remote before you move `.git`** — step 7 records a commit
+that has to exist on the archive, and after the move nothing on disk can put it there: the
+workspace root is no longer a repo, and the inheriting repo's `origin` gets repointed below. Then
+**move the inheriting folder into the build directory** with the rest — step 11 moves that
+directory into place and would otherwise strand this repo in the workspace you renamed aside. Its
+ignored files travel with it untouched, so step 9 has nothing to carry for it. And be clear what
+it buys — one copy of the object graph, not the blob. Every other unit is still a clone and still
+carries it.
 
 **This replaces the clone and the forward delete, not the rest of the mechanic.** `origin` still
 points at the mono repo, so `git remote set-url` it to this repo's own remote before step 7 —

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -242,10 +242,12 @@ special here, which is why it gets no steps of its own below.
 
 > **Where abort gets expensive.** Up to step 6, abort is cheap: delete the new directory, and
 > delete the extracted repo's remote if you already created it. Nothing else has been touched, and
-> neither the origin nor the hub has been pushed. From step 6 on the origin has been pruned
-> locally, so abort means deleting your local copies and re-cloning them from their remotes.
-> **Save anything untracked or ignored first** — `.env`, `.secrets/`, in-flight work. Nothing
-> carries it.
+> neither the origin nor the hub has been pushed. From step 6 on the origin has been pruned, so
+> abort is `git reset --hard <the tip you wrote down at step 1>` in the origin — force-pushed if
+> step 9 has already pushed it — plus deleting the extracted repo and its remote. Do not reach for
+> a re-clone: step 9 makes you push the prune, so re-cloning hands the split state back, and on a
+> project with no remotes there is nothing to re-clone from. **Save anything untracked or ignored
+> first** — `.env`, `.secrets/`, in-flight work. Nothing carries it.
 
 1. **Confirm the mapping and the boundary** (questions 1 and 2). Write down the origin repo, the
    path being extracted, the new repo's name, and the origin's tip (`git rev-parse --short HEAD`,

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -288,7 +288,10 @@ special here, which is why it gets no steps of its own below.
 7. **Repoint everything that knew the old path.** `git grep -n -F "<old path>"` in the origin, in
    the extracted repo, **and in the docs hub** — including each `.gitignore`, where a rule anchored
    at the old path is now dead. Every hit is either a repoint or a mention of history you keep on
-   purpose. **This step is not optional and is the easiest one to skip:** the hub's link checker
+   purpose. Note what the grep does not find: an `import` or package reference to what left carries
+   no path, so it never appears. Whether the two sides still call into each other is step 4's
+   boundary decision, and step 9's build-and-test is what fails if it was not made.
+   **This step is not optional and is the easiest one to skip:** the hub's link checker
    resolves link targets into the code repos, so a *correct* split makes hub links dangle —
    `scripts/links.sh` fails on a finished split and passes on an unfinished one. Step 7 is what
    makes step 9 satisfiable.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -102,6 +102,8 @@ git commit -m "Split: this repo now holds <scope>"
 
 # Reconcile the kept directory's own .gitignore HERE, before the move — see below.
 
+# The un-nest below applies only when <keep> is a SINGLE directory. With a scattered keep-set
+# (two or more paths) skip the next three lines: those paths stay where they are.
 ( set -e; shopt -s dotglob nullglob; for e in <keep>/*; do git mv "$e" .; done )
 test -z "$(git ls-files -- <keep>)" || { echo "un-nest incomplete — reconcile and re-run"; exit 1; }
 git commit -m "Move <scope> to the repo root"

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -114,10 +114,13 @@ messages, which every repo the split produces then carries permanently.
 show what it printed, wait for a go-ahead, then run the next. They are between the blocks rather
 than inside them because a stop written as a comment on a line you are about to execute is not a
 stop — it runs, and the block reads as finished. A stop can outlast the shell you started in, and
-these commands are destructive in the wrong directory, so **run block 1 from the origin repo** —
-it resolves `<origin>` and `<new-repo>` against wherever you are standing — while blocks 2 and 3
-re-enter the new repo themselves on their first line. Block 3 leaves you inside the repo you just
-finished, which is not where the next repo's block 1 starts.
+these commands are destructive in the wrong directory, so **run block 1 from the workspace root**
+— it resolves `<origin>` and `<new-repo>` against wherever you are standing, and both are written
+relative to that root. **Substitute `<new-repo>` as an absolute path**, so that blocks 2 and 3
+re-enter the new repo themselves on their first line: a relative one resolves only from where
+block 1 ran, and if your shell is anywhere else that `cd` fails and the forward delete below runs
+against whatever repo you are standing in. Block 3 leaves you inside the repo you just finished,
+which is not where the next repo's block 1 starts.
 
 ```bash
 git clone --no-local <origin> <new-repo>      # --no-local is required for a local source

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -8,6 +8,10 @@
 > - **Part 2 — Converting mono-repo-for-now to multi-repo.** At most once per project, and only
 >   if you started mono (`METHOD.md` §7). The workspace root stops being a repo.
 >
+> **Do the whole split on one machine, in one go.** It turns on local state no repo carries — the
+> build directory, the files you carry across by hand, the mapping you wrote down — so a
+> half-finished one does not hand off.
+>
 > Either way, when you're done: push every repo you touched, and tell your teammates.
 >
 > **Stop and get a go-ahead before continuing at each of these**, even where a default already

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -325,8 +325,9 @@ repos of their own. This happens at most once per project.
     - `scripts/check.sh` at **0 fail(s), 0 warning(s)** — warnings do not fail the run, so "green"
       is not the criterion.
     - `scripts/links.sh` clean.
-    - A **real teammate clone**: a fresh empty directory, clone the docs hub into it, run
-      `scripts/setup-workspace.sh` there, and confirm every registered repo actually arrives.
+    - A **real teammate clone**: a fresh empty directory, clone the docs hub into
+      `Code/<project>-docs/` inside it, run `scripts/setup-workspace.sh` there, and confirm every
+      registered repo actually arrives.
     - The pre-split commit resolves in every new repo.
 11. **Swap.** **Rename** the old workspace aside — do not delete it — and move the build directory
     into its place. Abort is still just deleting the build directory. Delete the old workspace only
@@ -338,9 +339,9 @@ repos of their own. This happens at most once per project.
     clone of the host, not in your live workspace. Do this **after the swap is verified, never
     before** — a complete pushed copy stays on the host through the whole destructive window. That README needs
     one sentence for anyone else holding a clone: *start a fresh empty folder, clone the docs hub
-    into it, and run `scripts/setup-workspace.sh` there — do not reuse your old project folder.*
-    Re-onboarding in place leaves the new repos nested inside the retired one, and every check
-    passes.
+    into `Code/<project>-docs/` inside it, and run `scripts/setup-workspace.sh` there — do not
+    reuse your old project folder.* Re-onboarding in place leaves the new repos nested inside the
+    retired one, and every check passes.
 13. **Write the STEP's PLAN** and archive it into the new `prompts/` repo at
     `prompts/<phase>/step-NNNN/`, then mark the STEP done in `prompts/STEP-index.md`. Written now
     rather than at step 4, it never has to pass through a forward delete. *Skip this if you skipped

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -256,9 +256,11 @@ special here, which is why it gets no steps of its own below.
    starting, or accept the loss knowingly. **Commit or stash your working tree too** — the clone
    takes committed state, so an uncommitted edit never reaches the new repo. Edits to tracked files,
    that is: anything untracked under the extracted path is what step 6 moves across by hand.
-3. **Extract.** Run the mechanic above with `<keep>` set to the path being extracted. When it
-   prints `git ls-files`, read it: it should look like the repo you asked for, at the root, with
-   nothing left nested.
+3. **Extract.** Run the mechanic above with `<keep>` set to the path being extracted and
+   `<new-repo>` set to `Code/<new-name>/`, a sibling of the origin: step 8 writes that path into
+   the registry row's `location:`, and it is where `scripts/setup-workspace.sh` puts the repo on
+   everyone else's machine. When it prints `git ls-files`, read it: it should look like the repo
+   you asked for, at the root, with nothing left nested.
 4. **Make it a repo, not a folder.**
    - `scripts/apply-project-license.sh <new-repo-path>` from the docs hub.
    - A `README.md` stamped from `templates/repo-readme-template.md`, with its role one-liner and

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -382,10 +382,12 @@ repos of their own. This happens at most once per project.
    repo's forward delete removed it: no clone carries it. If it is empty, create it anyway — it is
    where the project's next PLAN gets written, and nothing else recreates it.
 10. **Verify the build directory before you swap.**
-    - Each new repo: `git status` showing nothing but the untracked files you carried at step 9,
-      local trunk matching its remote, `git check-ignore -v .env` exiting 0, and nothing left
-      under the path it was moved out of. Anything else in `git status` — build output, a
-      vendored directory — means that repo's ignore file did not survive step 5's reconcile.
+    - Each new repo: `git status` showing nothing but that repo's entries from step 2's
+      `git ls-files --others --exclude-standard` list, re-anchored to its new root; local trunk
+      matching its remote; `git check-ignore -v .env` exiting 0; and nothing left under the path
+      it was moved out of. Anything from step 2's *ignored* list showing up as untracked — a
+      `node_modules/`, a `dist/` — means that repo's ignore file did not survive step 5's
+      reconcile.
     - Each code repo **builds and tests**.
     - `scripts/check.sh` at **0 fail(s), 0 warning(s)** — warnings do not fail the run, so "green"
       is not the criterion.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -168,6 +168,11 @@ carry on until the person running the split has seen it and said go.
 **Reading a path across the un-nest.** The move is a rename, so plain `git log -- <path>` stops at
 the un-nest commit; use `git log --follow -- <path>`. `git blame` crosses it without help.
 
+**The origin's tags come across too.** The clone carries every tag, and in a new repo they point
+at trees that are not this repo — `git describe` will report `v1.0-3-g…` against a release of the
+thing you split away from. `git push` does not send them, so they stay local until someone asks
+for them. Keep, retag or delete is your call: nothing in the method reads tags.
+
 **The origin side needs none of this.** Its paths are already correct, so it gets no clone, no
 exemption and no un-nest — just a forward `git rm` of what left (Part 1 step 6). In Part 2 there
 is no surviving origin; every unit gets the mechanic above.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -521,6 +521,12 @@ recorded anywhere — `reviewed_commit:` in `registries/security-reviews.yml`, S
 ADRs, links in issues — stops resolving, and everyone re-clones. That is the trade for not carrying
 the blob.
 
+**Then hand back.** The purged mirror is what the split reads, not a side artifact: Part 1 clones
+the origin you are standing in and Part 2 step 5 clones `.`, so a split run beside a purge copies
+the blob into every new repo instead. Copy your untracked and ignored files aside first — a fresh
+clone has none, and Part 2 step 2's two lists come back empty once you re-clone. Then force-push
+the mirror over the origin host, re-clone your workspace from it, and start the split there.
+
 **If the motive is purely size**, there is a cheaper answer that rewrites nothing: let one new repo
 inherit the origin's identity outright rather than cloning it. Move the `.git` directory into the
 folder that is becoming a repo, then inside it `git rm -r --cached .`, `git add -A`, and commit. It

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -265,9 +265,11 @@ special here, which is why it gets no steps of its own below.
    <extracted-path>`** — do not look for dirtiness. `git rm` removes only tracked files, and what
    stays behind is everything the repo was told to *ignore*: build output, vendored files,
    snapshots, `.env`. Ignored files never show as dirty; they do not show at all. Clear what is
-   left by hand. Two reasons this is not just tidiness: stale build output where the source used to
-   be can keep the origin's tests passing against code the repo no longer contains, and step 7's
-   `git grep` searches tracked files only, so it will not see it either. **Stop on the
+   left by hand — but first move anything that belongs to the **extracted** repo, its `.env` and
+   `.secrets/`, over to it: the clone took committed state, so what is sitting here is the only
+   copy. Two reasons clearing the rest is not just tidiness: stale build output where the source
+   used to be can keep the origin's tests passing against code the repo no longer contains, and
+   step 7's `git grep` searches tracked files only, so it will not see it either. **Stop on the
    `ls -a` output, before deleting any of it** — the `git rm` above is recoverable from history
    and this is not: no remote, no mirror and no clone holds these files.
 7. **Repoint everything that knew the old path.** `git grep -n -F "<old path>"` in the origin, in

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -522,6 +522,11 @@ for refs that moved. The collapse above needs a per-branch check instead: `git r
 been folded into another line of history, under a SHA that is not any other ref's tip, so the diff
 will not show it. Decide what each one should be before you push anything.
 
+**And confirm the purge itself.** Neither of those checks looks at the blob, and the failure this
+section opens with — a path you did not name, the tool reporting success — is invisible to both:
+`git -C ../purge-work.git log --oneline --branches -- <path>` has to print nothing for every path
+on your list, and the blob must no longer resolve.
+
 **What a purge costs you**, so nobody is surprised: every SHA changes, so every commit reference
 recorded anywhere — `reviewed_commit:` in `registries/security-reviews.yml`, SHAs in reports and
 ADRs, links in issues — stops resolving, and everyone re-clones. That is the trade for not carrying

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -293,8 +293,10 @@ special here, which is why it gets no steps of its own below.
    before the prune — it resolves in both). Your-row-only, per `collaboration.md` §5.
 9. **Verify.**
    - Both repos **build and test**.
-   - `git status` is clean in each, and each local trunk matches its remote — that is the check
-     that what you can see is what everyone else receives.
+   - `git status` shows nothing new in either repo — in the origin, only what was already
+     untracked before you started; in the extracted repo, only what step 6 moved across — and each
+     local trunk matches its remote: that is the check that what you can see is what everyone else
+     receives.
    - The step-7 grep now returns only the historical mentions you decided to keep.
    - `git log --follow` and `git blame` resolve across the un-nest in the extracted repo, and the
      pre-split commit exists in both.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -317,8 +317,10 @@ repos of their own. This happens at most once per project.
    repo's forward delete removed it: no clone carries it. If it is empty, create it anyway — it is
    where the project's next PLAN gets written, and nothing else recreates it.
 10. **Verify the build directory before you swap.**
-    - Each new repo: `git status` clean, local trunk matching its remote, `git check-ignore -v .env`
-      exiting 0, and nothing left under the path it was moved out of.
+    - Each new repo: `git status` showing nothing but the untracked files you carried at step 9,
+      local trunk matching its remote, `git check-ignore -v .env` exiting 0, and nothing left
+      under the path it was moved out of. Anything else in `git status` — build output, a
+      vendored directory — means that repo's ignore file did not survive step 5's reconcile.
     - Each code repo **builds and tests**.
     - `scripts/check.sh` at **0 fail(s), 0 warning(s)** — warnings do not fail the run, so "green"
       is not the criterion.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -20,8 +20,8 @@
 > every file-list confirmation point, showing the list itself and never a summary; when you
 > reconcile two ignore files into one, showing both and what you merged them into; before
 > anything leaves your machine — creating a remote, pushing a trunk; and before anything on disk
-> stops being easy to undo — pruning the origin, clearing what it left behind, swapping the
-> workspace, retiring the old remote.
+> stops being easy to undo — clearing what the prune left behind, swapping the workspace, retiring
+> the old remote.
 >
 > Each one is marked **Stop** where it fires — in the mechanic, which runs in three pieces per
 > repo, and at the steps below. Getting a go-ahead means ending your turn and waiting for a

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -419,6 +419,10 @@ repos of their own. This happens at most once per project.
    name.** Its `.gitkeep` is tracked, so the folder is on neither of step 2's lists, and every new
    repo's forward delete removed it: no clone carries it. If it is empty, create it anyway — it is
    where the project's next PLAN gets written, and nothing else recreates it.
+   Every unit keeps its workspace-relative path across the split, so this is a plain copy from the
+   old workspace into the build directory: `Code/<name>/.env` is `Code/<name>/.env` on both sides.
+   The re-anchoring step 10 asks for is a different thing — it is how the same file reads from
+   *inside* the new repo, where that path is just `.env`.
 10. **Verify the build directory before you swap.**
     - Each new repo: `git status` showing nothing but that repo's entries from step 2's
       `git ls-files --others --exclude-standard` list, re-anchored to its new root; local trunk

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -134,6 +134,9 @@ match. Nothing has been deleted yet.
 
 ```bash
 cd <new-repo>
+# With a scattered keep-set, <keep> substitutes here as one ':!<path>' per keep path. ':!a b' is a
+# single pathspec that matches nothing, so the delete removes everything and the guard blames a
+# path the count in block 1 just certified.
 git rm -r -q -- . ':!<keep>' ':!.gitignore'   # forward-delete the complement; nothing is rewritten
 test -n "$(git ls-files -- <keep>)" || { echo "<keep> matched nothing — check the path"; exit 1; }
 git commit -m "Split: this repo now holds <scope>"

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -109,6 +109,8 @@ git clone --no-local <origin> <new-repo>      # --no-local is required for a loc
 cd <new-repo>
 git remote remove origin                      # the new repo must not point at the old one
 
+for p in <keep>; do echo "$p: $(git ls-files -- "$p" | wc -l | tr -d ' ') file(s)"; done
+
 git rm -r -q -- . ':!<keep>' ':!.gitignore'   # forward-delete the complement; nothing is rewritten
 test -n "$(git ls-files -- <keep>)" || { echo "<keep> matched nothing — check the path"; exit 1; }
 git commit -m "Split: this repo now holds <scope>"
@@ -150,11 +152,12 @@ repointing grep is for instead.
   zero times, and the check after it passes vacuously, because "the old path is empty" is also
   true when it never held anything. The only signal is `nothing to commit, working tree clean`,
   which reads like success. The guard fires at the one moment the mistake is still free.
-- **With more than one keep path, run the guard once per path** — `git ls-files -- <path>`
-  non-empty for *each*, not for the set. A set-wide check passes on the one path that matched
-  while the mistyped one is deleted with no signal. And note what a scattered keep-set does not
-  get: the un-nest applies only when the kept set is a single directory, so a scattered split has
-  no post-condition either. The per-path guard is the only mechanical check it has.
+- **With more than one keep path, the per-path count in the first block is the check** —
+  `git ls-files -- <path>` non-empty for *each*, not for the set. A set-wide check passes on the
+  one path that matched while the mistyped one is deleted with no signal. And note what a
+  scattered keep-set does not get: the un-nest applies only when the kept set is a single
+  directory, so a scattered split has no post-condition either. The per-path guard is the only
+  mechanical check it has.
 - **The post-condition, after the move**, catches a half-finished un-nest. Do not try to replace
   it with a check on the loop's exit status. The `set -e` is inside the subshell, so a failed
   `git mv` exits the subshell and the next line runs anyway — `git commit` then succeeds, commits

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -205,7 +205,7 @@ special here, which is why it gets no steps of its own below.
    later, and this repo now carries the origin's whole history. **Push trunk before you record the
    remote anywhere** (step 8 writes the registry row): that is the order `collaboration.md` §9
    already uses, and it is what stops the next person cloning an empty repo.
-6. **Prune the origin.** `git rm -r -q -- <extracted-path>` and commit. Then **`ls
+6. **Prune the origin.** `git rm -r -q -- <extracted-path>` and commit. Then **`ls -a
    <extracted-path>`** — do not look for dirtiness. `git rm` removes only tracked files, and what
    stays behind is everything the repo was told to *ignore*: build output, vendored files,
    snapshots, `.env`. Ignored files never show as dirty; they do not show at all. Clear what is

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -328,8 +328,10 @@ repos of their own. This happens at most once per project.
    - **Branch state.** `git branch -a`. Only trunk survives a clone as a real branch; the rest die
      with `git remote remove origin`, silently. Here the root repo is being *replaced*, so a stray
      branch is stranded with nowhere to land. Merge or close everything but trunk first, or accept
-     the loss knowingly. **Commit or stash your working tree too** — the clones at step 5 take
-     committed state, so an uncommitted edit reaches no new repo and nothing flags it.
+     the loss knowingly. **Commit your working tree too** — the clones at step 5 take committed
+     state, so an uncommitted edit reaches no new repo and nothing flags it. Stashing is not an
+     alternative here: a stash lives in the repo you are about to replace, so pop it and commit
+     before step 5.
    - **Write the mono repo's `origin` URL down now.** After the swap it exists nowhere on disk. Its
      durable home is `archive_remote:` in the registry at step 7; until then a scratch note is fine.
    - **Decide what happens to the old remote** at the end (step 12): leave it, retire it, or delete

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -248,10 +248,11 @@ special here, which is why it gets no steps of its own below.
 > carries it.
 
 1. **Confirm the mapping and the boundary** (questions 1 and 2). Write down the origin repo, the
-   path being extracted, the new repo's name, and the origin's tip right now
-   (`git rev-parse --short HEAD`): that is the last commit the two repos will share, and it is
-   easiest to record here, because by the time step 8 wants it the prune and the repoint have
-   moved the origin two commits past it. **Stop here, before step 3 builds anything** —
+   path being extracted, the new repo's name, and the origin's tip (`git rev-parse --short HEAD`,
+   run in the origin): that is the last commit the two repos will share. **Re-read it once step 2
+   has committed your working tree** — that commit moves the tip, and step 3 clones what step 2
+   leaves. Record it here rather than at step 8, by which time the prune and the repoint have
+   moved the origin past it. **Stop here, before step 3 builds anything** —
    show that written-out mapping and your answer to question 2. Deciding not to split is one of
    the answers, and this is the step where it gets made.
 2. **Pre-flight: the branches that won't survive.** Run `git branch -a`. A clone carries every

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -521,5 +521,6 @@ carries it.
 points at the mono repo, so `git remote set-url` it to this repo's own remote before step 7 —
 otherwise "push trunk" pushes this tree over the mono repo's, and nothing errors. The root
 `.gitignore` is not here to be exempted: copy it in and reconcile it with the folder's own, as
-step 5 does. And `git add -A` commits every untracked file in the folder, where a clone would
+step 5 does — before the `git add -A` above, or that commit takes in everything those rules would
+have kept out. And `git add -A` commits every untracked file in the folder, where a clone would
 have left them untracked — so end with `git ls-files` and stop on it, like every other repo.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -245,7 +245,10 @@ special here, which is why it gets no steps of its own below.
 > carries it.
 
 1. **Confirm the mapping and the boundary** (questions 1 and 2). Write down the origin repo, the
-   path being extracted, and the new repo's name. **Stop here, before step 3 builds anything** —
+   path being extracted, the new repo's name, and the origin's tip right now
+   (`git rev-parse --short HEAD`): that is the last commit the two repos will share, and it is
+   easiest to record here, because by the time step 8 wants it the prune and the repoint have
+   moved the origin two commits past it. **Stop here, before step 3 builds anything** —
    show that written-out mapping and your answer to question 2. Deciding not to split is one of
    the answers, and this is the step where it gets made.
 2. **Pre-flight: the branches that won't survive.** Run `git branch -a`. A clone carries every
@@ -306,8 +309,8 @@ special here, which is why it gets no steps of its own below.
    `scripts/links.sh` fails on a finished split and passes on an unfinished one. Step 7 is what
    makes step 9 satisfiable.
 8. **Register it.** Add the new repo's row to `registries/repos.yml` with its `provenance:` block:
-   the repo it came from, today's date, and the last commit the two repos share (the origin's tip
-   before the prune — it resolves in both). Your-row-only, per `collaboration.md` §5.
+   the repo it came from, today's date, and the last commit the two repos share — the tip you
+   wrote down at step 1, which resolves in both. Your-row-only, per `collaboration.md` §5.
 9. **Verify.**
    - Both repos **build and test**.
    - `git status` shows nothing new in either repo — in the origin, only what was already
@@ -399,7 +402,9 @@ repos of their own. This happens at most once per project.
    history, and widening any of them is a separate decision to make deliberately later, not a
    side effect of the split. Push trunk, then record `remote:` in
    `registries/repos.yml`. Every row in that file is now a split-out repo, so each also gets a
-   `provenance:` block — naming the mono repo, today's date, the last commit they all share, and
+   `provenance:` block — naming the mono repo, today's date, the last commit they all share (the
+   mono tip the clones were taken from at step 5; that workspace is on disk until step 11, so read
+   it there), and
    the `origin` URL you wrote down at step 2 as `archive_remote:`. **That commit has to exist on
    the archive too** — if the mono trunk you cloned at step 5 was ahead of its remote, push it
    there before you record these, because step 12 makes that host read-only. **Delete the

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -171,6 +171,12 @@ one — the only thing that writes a `.gitignore` is `init.sh`, which the new re
 either way. The measured result is a repo that tracks `.env`. After the un-nest, confirm the
 exemption worked: `git check-ignore -v .env` should exit 0.
 
+**`.gitmodules` is not exempt, and a submodule inside the keep-set needs it.** That file lives at
+the origin's root, so the forward delete takes it while the keep-set's gitlink survives: the file
+list above shows the submodule path looking exactly right, and it is `git status` at the verify
+step that reports it as deleted, with nothing to say why. If any kept path contains a submodule,
+re-create the entries that repo needs before you push it.
+
 **If the kept directory has its own `.gitignore`, reconcile before the move.** Two files exist at
 that moment: the origin's, which the exemption above left at the root, and the kept directory's,
 still nested — and the move will stop on the collision. Read both, reconcile them into one file at

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -296,7 +296,9 @@ special here, which is why it gets no steps of its own below.
 7. **Repoint everything that knew the old path.** `git grep -n -F "<old path>"` in the origin, in
    the extracted repo, **and in the docs hub** — including each `.gitignore`, where a rule anchored
    at the old path is now dead. Every hit is either a repoint or a mention of history you keep on
-   purpose. Note what the grep does not find: an `import` or package reference to what left carries
+   purpose. Stage the files you repointed, not `git add -A` — this commit goes to a shared remote,
+   and the origin's working tree still holds whatever was untracked there before you started. Note
+   what the grep does not find: an `import` or package reference to what left carries
    no path, so it never appears. Whether the two sides still call into each other is step 4's
    boundary decision, and step 9's build-and-test is what fails if it was not made.
    **This step is not optional and is the easiest one to skip:** the hub's link checker

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -244,8 +244,10 @@ special here, which is why it gets no steps of its own below.
 > delete the extracted repo's remote if you already created it. Nothing else has been touched, and
 > neither the origin nor the hub has been pushed. From step 6 on the origin has been pruned, so
 > abort is `git reset --hard <the tip you wrote down at step 1>` in the origin — force-pushed if
-> step 9 has already pushed it — plus deleting the extracted repo and its remote. Do not reach for
-> a re-clone: step 9 makes you push the prune, so re-cloning hands the split state back, and on a
+> step 9 has already pushed it — plus deleting the extracted repo and its remote, and reverting the
+> hub's step-7 repoint and step-8 registry row, pushed if step 9 pushed them: left standing, that
+> row sends everyone else's `setup-workspace.sh` at a remote you just deleted. Do not reach for a
+> re-clone: step 9 makes you push the prune, so re-cloning hands the split state back, and on a
 > project with no remotes there is nothing to re-clone from. **Save anything untracked or ignored
 > first** — `.env`, `.secrets/`, in-flight work. Nothing carries it.
 

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -96,7 +96,9 @@ and it has to happen first.
 ## The mechanic
 
 Both parts build every new repo the same way, in bash, one repo at a time. `<keep>` is that
-repo's keep-set — the path or paths from question 1 that this repo is meant to be.
+repo's keep-set — the path or paths from question 1 that this repo is meant to be. `<scope>` is
+what you would call that out loud (`billing`, `the docs hub`); it appears only in the two commit
+messages, which every repo the split produces then carries permanently.
 
 ```bash
 git clone --no-local <origin> <new-repo>      # --no-local is required for a local source

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -402,4 +402,8 @@ inherit the origin's identity outright rather than cloning it. Move the `.git` d
 folder that is becoming a repo, then inside it `git rm -r --cached .`, `git add -A`, and commit. It
 comes out with the complete un-rewritten history and `--follow` and `blame` resolving through the
 path change — but only one repo can inherit it, and the workspace root stops being a repo the
-moment you move `.git`, so this only makes sense as part of Part 2.
+moment you move `.git`, so this only makes sense as part of Part 2. **Do it last**, after every
+other unit has been cloned at step 5, not here before Part 2 starts: the move drops those units
+from HEAD, so their forward delete keeps nothing and the guard fires on a path you typed
+correctly. And be clear what it buys — one copy of the object graph, not the blob. Every other
+unit is still a clone and still carries it.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -184,7 +184,8 @@ special here, which is why it gets no steps of its own below.
    only as remote-tracking refs and die with `git remote remove origin`, silently. The origin repo
    survives, so nothing is lost there; the risk is in-flight work on the *extracted* files, which
    lands in a repo where those files no longer exist. Merge or close everything but trunk before
-   starting, or accept the loss knowingly.
+   starting, or accept the loss knowingly. **Commit or stash your working tree too** — the clone
+   takes committed state, so an uncommitted edit never reaches the new repo.
 3. **Extract.** Run the mechanic above with `<keep>` set to the path being extracted. When it
    prints `git ls-files`, read it: it should look like the repo you asked for, at the root, with
    nothing left nested.
@@ -267,7 +268,8 @@ repos of their own. This happens at most once per project.
    - **Branch state.** `git branch -a`. Only trunk survives a clone as a real branch; the rest die
      with `git remote remove origin`, silently. Here the root repo is being *replaced*, so a stray
      branch is stranded with nowhere to land. Merge or close everything but trunk first, or accept
-     the loss knowingly.
+     the loss knowingly. **Commit or stash your working tree too** — the clones at step 5 take
+     committed state, so an uncommitted edit reaches no new repo and nothing flags it.
    - **Write the mono repo's `origin` URL down now.** After the swap it exists nowhere on disk. Its
      durable home is `archive_remote:` in the registry at step 7; until then a scratch note is fine.
    - **Decide what happens to the old remote** at the end (step 12): leave it, retire it, or delete

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -1,0 +1,398 @@
+# Runbook — Splitting a Repository
+
+> **How to run:** Two cases behind one procedure. Answer the three questions in **Before you
+> start**, then go to your part — you don't pick the case, it falls out of the first answer.
+> Tell your agent *"run the split"* and it follows this file.
+> - **Part 1 — Splitting a code repo in two.** The ordinary one: a repo grew two things that
+>   should ship separately. Any number of times.
+> - **Part 2 — Converting mono-repo-for-now to multi-repo.** At most once per project, and only
+>   if you started mono (`METHOD.md` §7). The workspace root stops being a repo.
+>
+> Either way, when you're done: push every repo you touched, and tell your teammates.
+>
+> **A split is a STEP**, like the check-in. Its PLAN is thin and points here; you don't author
+> substep prompts for it — this runbook *is* the substeps (the same special case as the check-in,
+> see `prompts/README.md`). *Substeps*, below, names the usual breakpoints.
+>
+> **Two special cases.** **Part 2 is branchless** — there is no `step-NNNN` branch, because the
+> repos that branch would live in are the ones being created. Its STEP number is reserved
+> *on trunk* at step 4 (`METHOD.md` §7). And **tracking a split as a STEP is the method's
+> convention, not an obligation**: a project that would rather not track this one skips Part 2's
+> steps 4 and 13 together and loses nothing else. Part 1 needs no equivalent — `prompts/` is
+> untouched there, so the ordinary recipe in `prompts/README.md` applies unchanged.
+
+## Why this runbook exists
+"Splitting later is standard git" is not an answer you can act on. The published standard
+procedure — GitHub's, Atlassian's — makes the extracted repo **new**, with its history rewritten
+by `git filter-repo`: a tool that never ships with git, needs Python on every install route, and
+behaves differently version to version, so the method cannot require you to have it. A rewrite
+also truncates history at every historical path you forget to name, silently.
+
+So this runbook does something else, and it is deliberately **not** the recipe you will find
+elsewhere: it clones the whole repo and **deletes forward**. Nothing is rewritten. Both sides keep
+the full history; the shared commits are the same objects with the same SHAs in both repos, so
+`git blame`, `git log --follow` and `git bisect` work in the new repo on day one, `git merge-base`
+resolves across the split, and anything recorded against a commit — a `reviewed_commit:` in
+`registries/security-reviews.yml`, a SHA in a report — keeps resolving.
+
+The cost, stated plainly: **every new repo inherits every blob the origin ever committed**,
+including files deleted long ago. If a secret was ever committed, the split copies it into a
+second repo. The third question below is where that gets decided, and the appendix is where it
+gets handled.
+
+## Substeps
+
+There is no fixed number of them, because the shape of a split follows the shape of your repos.
+The usual breakpoints:
+
+- *Part 1, typically three:* **N.1** extract and stand the new repo up (steps 3–5) · **N.2** prune
+  and repoint (steps 6–8) · **N.3** verify (step 9).
+- *Part 2, typically four:* **N.1** pre-flight and backup (steps 1–3) · **N.2** build the new repos
+  beside (steps 5–7) · **N.3** assemble and verify the workspace (steps 8–10) · **N.4** swap and
+  retire (steps 11–12). Steps 4 and 13 are the STEP's own bookkeeping rather than work inside it,
+  which is also why they are the pair a project skips together.
+
+A split that extracts several repos at once, or that stops at a boundary these don't anticipate,
+names its own. The point of naming them is that the index should show where a half-finished split
+stopped, not that every split has the same joints.
+
+## Before you start — three questions
+
+**1. What is the split — which folders end up in which repo?** There is no default; this is the
+whole input, and everything else is derived from it. Before answering, **list the units** so
+nothing invisible gets left behind:
+
+```bash
+git ls-files | cut -d/ -f1-2 | sort -u      # or: ls Code/, plus prompts/ and the docs hub
+```
+
+Every entry has to land in some repo's **keep-set** or be dropped on purpose. Work from this list,
+not from `registries/repos.yml` — a folder that was never registered (a vendored SDK, an in-tree
+tools directory, a repo somebody scaffolded and forgot to add) is invisible to every check in this
+runbook and disappears at the split without a word.
+
+If the answer is *"the workspace root stops being a repo"*, you are in **Part 2**. Otherwise
+**Part 1**.
+
+**2. Should you split at all?** *(Part 1 only — for Part 2 the layout decision was made at
+`init.sh` time.) Default: proceed.* One exchange, and the two questions worth asking are: would
+the two halves be **chatty** with each other, and would an ordinary change require **deploying
+both together**? Either one means the boundary is in the wrong place. Splitting a repo is
+expensive and hard to undo; deciding not to is a real answer.
+
+**3. Does this history have a secrets or size problem?** *Default: no.* If no, skip the appendix
+entirely — it is not mentioned again. Say yes if a credential was ever committed and you would
+rather it did not propagate into a second repo, or if the history carries large binaries you do
+not want to copy. Then go to the **appendix** *before* doing anything else: purging is a rewrite,
+and it has to happen first.
+
+## The mechanic
+
+Both parts build every new repo the same way, in bash, one repo at a time. `<keep>` is that
+repo's keep-set — the path or paths from question 1 that this repo is meant to be.
+
+```bash
+git clone --no-local <origin> <new-repo>      # --no-local is required for a local source
+cd <new-repo>
+git remote remove origin                      # the new repo must not point at the old one
+
+git rm -r -q -- . ':!<keep>' ':!.gitignore'   # forward-delete the complement; nothing is rewritten
+test -n "$(git ls-files -- <keep>)" || { echo "<keep> matched nothing — check the path"; exit 1; }
+git commit -m "Split: this repo now holds <scope>"
+
+# Reconcile the kept directory's own .gitignore HERE, before the move — see below.
+
+( set -e; shopt -s dotglob nullglob; for e in <keep>/*; do git mv "$e" .; done )
+test -z "$(git ls-files -- <keep>)" || { echo "un-nest incomplete — reconcile and re-run"; exit 1; }
+git commit -m "Move <scope> to the repo root"
+find . -mindepth 1 -type d -empty -not -path './.git/*' -delete
+
+git ls-files                                  # LOOK AT THIS. It is the repo you just made.
+```
+
+**`.gitignore` is exempt from the delete, and that exemption is load-bearing.** Without
+`':!.gitignore'` the new repo inherits no ignore file, and nothing left inside it can regenerate
+one — the only thing that writes a `.gitignore` is `init.sh`, which the new repo doesn't have
+either way. The measured result is a repo that tracks `.env`. After the un-nest, confirm the
+exemption worked: `git check-ignore -v .env` should exit 0.
+
+**If the kept directory has its own `.gitignore`, reconcile before the move.** Two files exist at
+that moment: the origin's, which the exemption above left at the root, and the kept directory's,
+still nested — and the move will stop on the collision. Read both, reconcile them into one file at
+the repo root, and `git rm` the nested one. *Default: the union of the two.* Re-anchor any rule
+written against the old path (`/Code/<name>/dist/` becomes `/dist/`); it matches nothing after the
+move. In Part 2 this fires for every code folder, and never for `prompts/` or the docs hub, which
+have no ignore file of their own. In Part 1 it usually does not fire at all, because the extracted
+directory is a subdirectory of a code repo — the dead path-anchored rules it would have caught are
+what step 7's repointing grep is for instead.
+
+**The two checks do different jobs, and both are needed.**
+
+- **The guard, before the move**, catches a keep-set that matched nothing. If the path is
+  mistyped — or just the wrong case, since macOS treats `code/` and `Code/` as the same folder
+  and git's pathspecs do not — the forward delete removes *everything*, the move loop iterates
+  zero times, and the check after it passes vacuously, because "the old path is empty" is also
+  true when it never held anything. The only signal is `nothing to commit, working tree clean`,
+  which reads like success. The guard fires at the one moment the mistake is still free.
+- **With more than one keep path, run the guard once per path** — `git ls-files -- <path>`
+  non-empty for *each*, not for the set. A set-wide check passes on the one path that matched
+  while the mistyped one is deleted with no signal. And note what a scattered keep-set does not
+  get: the un-nest applies only when the kept set is a single directory, so a scattered split has
+  no post-condition either. The per-path guard is the only mechanical check it has.
+- **The post-condition, after the move**, catches a half-finished un-nest. Do not try to replace
+  it with a check on the loop's exit status. The `set -e` is inside the subshell, so a failed
+  `git mv` exits the subshell and the next line runs anyway — `git commit` then succeeds, commits
+  whatever prefix of entries the loop managed to move, and leaves `git status` clean. And the
+  obvious fix is worse: writing `( set -e; … ) || exit 1` **disables** errexit inside the
+  subshell, because a compound command on the left of `||` is exempt from it, so the loop runs
+  past the failure and moves *more* files, not fewer. `git ls-files -- <keep>` reads the index, so
+  it is true whatever went wrong.
+
+**Why the confirmation points print a file list.** The forward delete and the un-nest are the two
+steps that can succeed while producing the wrong repo, and their exit status will not tell you.
+The list is what shows it. Do not skip past it, and do not replace it with a summary.
+
+**Reading a path across the un-nest.** The move is a rename, so plain `git log -- <path>` stops at
+the un-nest commit; use `git log --follow -- <path>`. `git blame` crosses it without help.
+
+**The origin side needs none of this.** Its paths are already correct, so it gets no clone, no
+exemption and no un-nest — just a forward `git rm` of what left (Part 1 step 6). In Part 2 there
+is no surviving origin; every unit gets the mechanic above.
+
+## Part 1 — Splitting a code repo in two
+
+The **origin repo** survives and keeps its identity, its remote and its history. The **extracted
+repo** is new. The docs hub and `prompts/` do not move.
+
+*Tracking this as a STEP?* Reserve the number, branch, and archive the PLAN exactly as
+`prompts/README.md` says — `prompts/` is untouched by this split, so none of that timing is
+special here, which is why it gets no steps of its own below.
+
+> **Where abort gets expensive.** Up to step 6, abort is cheap: delete the new directory, and
+> delete the extracted repo's remote if you already created it. Nothing else has been touched, and
+> neither the origin nor the hub has been pushed. From step 6 on the origin has been pruned
+> locally, so abort means deleting your local copies and re-cloning them from their remotes.
+> **Save anything untracked or ignored first** — `.env`, `.secrets/`, in-flight work. Nothing
+> carries it.
+
+1. **Confirm the mapping and the boundary** (questions 1 and 2). Write down the origin repo, the
+   path being extracted, and the new repo's name.
+2. **Pre-flight: the branches that won't survive.** Run `git branch -a`. A clone carries every
+   commit and every tag, but only the default branch arrives as a real branch — the rest exist
+   only as remote-tracking refs and die with `git remote remove origin`, silently. The origin repo
+   survives, so nothing is lost there; the risk is in-flight work on the *extracted* files, which
+   lands in a repo where those files no longer exist. Merge or close everything but trunk before
+   starting, or accept the loss knowingly.
+3. **Extract.** Run the mechanic above with `<keep>` set to the path being extracted. When it
+   prints `git ls-files`, read it: it should look like the repo you asked for, at the root, with
+   nothing left nested.
+4. **Make it a repo, not a folder.**
+   - `scripts/apply-project-license.sh <new-repo-path>` from the docs hub.
+   - A `README.md` stamped from `templates/repo-readme-template.md`, with its role one-liner and
+     Overview actually filled in.
+   - `templates/env-example.txt` copied in as `.env.example` if it needs one.
+   - **Its build and test entry point.** The forward delete removed the origin's `Makefile`, CI
+     config and test harness, so right now this repo has no way to build itself. Decide what it
+     runs. If the extracted code also calls into code that stayed behind, decide that here too —
+     the options are duplicate it, put it in a third shared repo, have one side own it and expose
+     it as a service, or don't split at this boundary after all. There is no threshold that picks
+     for you; the one thing every source agrees on is not to share domain logic.
+   - **Commit all of it.** The stamping writes new, untracked files and the next step pushes.
+5. **Give it a remote.** Create it **private** — widening is a separate decision, made deliberately
+   later, and this repo now carries the origin's whole history. **Push trunk before you record the
+   remote anywhere** (step 8 writes the registry row): that is the order `collaboration.md` §9
+   already uses, and it is what stops the next person cloning an empty repo.
+6. **Prune the origin.** `git rm -r -q -- <extracted-path>` and commit. Then **`ls
+   <extracted-path>`** — do not look for dirtiness. `git rm` removes only tracked files, and what
+   stays behind is everything the repo was told to *ignore*: build output, vendored files,
+   snapshots, `.env`. Ignored files never show as dirty; they do not show at all. Clear what is
+   left by hand. Two reasons this is not just tidiness: stale build output where the source used to
+   be can keep the origin's tests passing against code the repo no longer contains, and step 7's
+   `git grep` searches tracked files only, so it will not see it either.
+7. **Repoint everything that knew the old path.** `git grep -n -F "<old path>"` in the origin, in
+   the extracted repo, **and in the docs hub** — including each `.gitignore`, where a rule anchored
+   at the old path is now dead. Every hit is either a repoint or a mention of history you keep on
+   purpose. **This step is not optional and is the easiest one to skip:** the hub's link checker
+   resolves link targets into the code repos, so a *correct* split makes hub links dangle —
+   `scripts/links.sh` fails on a finished split and passes on an unfinished one. Step 7 is what
+   makes step 9 satisfiable.
+8. **Register it.** Add the new repo's row to `registries/repos.yml` with its `provenance:` block:
+   the repo it came from, today's date, and the last commit the two repos share (the origin's tip
+   before the prune — it resolves in both). Your-row-only, per `collaboration.md` §5.
+9. **Verify.**
+   - Both repos **build and test**.
+   - `git status` is clean in each, and each local trunk matches its remote — that is the check
+     that what you can see is what everyone else receives.
+   - The step-7 grep now returns only the historical mentions you decided to keep.
+   - `git log --follow` and `git blame` resolve across the un-nest in the extracted repo, and the
+     pre-split commit exists in both.
+   - `scripts/links.sh` is clean.
+
+## Part 2 — Converting mono-repo-for-now to multi-repo
+
+The workspace root stops being a repository. `prompts/`, the docs hub and each code folder become
+repos of their own. This happens at most once per project.
+
+> **You build the new workspace beside the old one and swap at the end.** Everything up to step 11
+> happens in `../<project>-split/`; the live workspace is never touched, so abort is deleting that
+> directory. Do not start by deleting or rewriting anything you have.
+
+1. **Confirm the mapping** (question 1), and decide **where each root file goes**. Derive the list;
+   don't work from memory:
+
+   ```bash
+   git ls-files -- . ':!Code/' ':!prompts/'    # everything tracked that no keep-set claims
+   ```
+
+   Nine entries on a stock mono root. *Default disposition:* the licence files are stamped into
+   each new repo by `scripts/apply-project-license.sh` (step 6); `CLAUDE.md`, `AGENTS.md` and
+   `doctor.sh` change kind at this split — they stop being committed files and become per-machine
+   pointers regenerated by `scripts/setup-workspace.sh` (step 8); and `init.sh` has done its job
+   and is dropped. Anything your project added to the root is yours to place.
+2. **Pre-flight.**
+   - **What git won't carry.** The swap replaces the workspace, so anything untracked or ignored
+     has to be carried across on purpose. Derive both lists; never hand-write them:
+
+     ```bash
+     git status --porcelain --ignored
+     git ls-files --others --exclude-standard
+     ```
+
+     *Default: carry everything listed.* This is where each code folder's own `.env` and
+     `.secrets/` show up, which is exactly what a from-memory list misses. Note that a directory
+     whose entire contents are ignored appears as a **single entry** and is not descended into —
+     carry the whole directory.
+   - **Branch state.** `git branch -a`. Only trunk survives a clone as a real branch; the rest die
+     with `git remote remove origin`, silently. Here the root repo is being *replaced*, so a stray
+     branch is stranded with nowhere to land. Merge or close everything but trunk first, or accept
+     the loss knowingly.
+   - **Write the mono repo's `origin` URL down now.** After the swap it exists nowhere on disk. Its
+     durable home is `archive_remote:` in the registry at step 7; until then a scratch note is fine.
+   - **Decide what happens to the old remote** at the end (step 12): leave it, retire it, or delete
+     it. *Default: retire it.*
+3. **Backup mirror.** `git clone --mirror --no-local . ../<project>-presplit.git`, and confirm it
+   is readable (`git -C ../<project>-presplit.git log --oneline -1`). Every new repo will carry the
+   full history anyway, so this is a spare copy rather than the home of the project's past — skip
+   it if you'd rather not, though it costs nothing. It captures **tracked content only**; it is
+   not a backup of step 2's lists.
+4. **Reserve the STEP number** in `prompts/STEP-index.md` and **commit the reservation on trunk**
+   — this STEP is the documented exception to branch-per-STEP (`METHOD.md` §7). Uncommitted, the
+   clones in step 5 never see it and the reservation dies with the old workspace; committed, the
+   row rides across inside the `prompts/` keep-set. **The PLAN itself is written at step 13**,
+   after the swap — written now, every new repo's forward delete would remove it. *Skipping the
+   STEP framing? Skip this step and step 13 together.*
+5. **Build the new repos beside.** For each unit — `prompts/`, the docs hub, each code folder — run
+   the mechanic into its place in the new workspace:
+
+   ```bash
+   git clone --no-local . ../<project>-split/prompts        # <keep> = prompts
+   git clone --no-local . ../<project>-split/Code/<name>    # <keep> = Code/<name>
+   ```
+
+   Reconcile the ignore file, un-nest, and read the file list each time. The reconcile fires for
+   every code folder: the file the clone left at the root is the *workspace* root's, which carries
+   none of that code repo's build ignores, and the folder's own is still nested.
+6. **Stamp each new repo, and commit it.** Run `scripts/apply-project-license.sh` once per repo
+   from the new hub, then **commit the result in that repo**. The script writes new, untracked
+   files, step 7 pushes, and nothing else in this procedure commits them — skip this and a repo
+   reaches its host with no `LICENSE`, no `LICENSE-THROUGHSTONE` and no `LICENSING.md` while your
+   own copy on disk still shows all three.
+7. **Remotes.** Create each **private** — every one of them now carries the whole mono repo's
+   history, and widening any of them is a separate decision to make deliberately later, not a
+   side effect of the split. Push trunk, then record `remote:` in
+   `registries/repos.yml`. Every row in that file is now a split-out repo, so each also gets a
+   `provenance:` block — naming the mono repo, today's date, the last commit they all share, and
+   the `origin` URL you wrote down at step 2 as `archive_remote:`. **Delete the mono-repo-for-now
+   note** above the rows; it stops being true the moment this step runs. **Push the hub last**,
+   after its registry commit, or none of these rows reaches a teammate.
+8. **Root pointers.** Run `scripts/setup-workspace.sh` from the new hub, in the build directory.
+   The build directory is assembled purely from clones, so it has no root `CLAUDE.md`, `AGENTS.md`
+   or `doctor.sh` until this runs — and nothing would ever flag their absence.
+9. **Carry the local state** chosen at step 2 — **plus `Upcoming Prompts/` and its contents, by
+   name.** Its `.gitkeep` is tracked, so the folder is on neither of step 2's lists, and every new
+   repo's forward delete removed it: no clone carries it. If it is empty, create it anyway — it is
+   where the project's next PLAN gets written, and nothing else recreates it.
+10. **Verify the build directory before you swap.**
+    - Each new repo: `git status` clean, local trunk matching its remote, `git check-ignore -v .env`
+      exiting 0, and nothing left under the path it was moved out of.
+    - Each code repo **builds and tests**.
+    - `scripts/check.sh` at **0 fail(s), 0 warning(s)** — warnings do not fail the run, so "green"
+      is not the criterion.
+    - `scripts/links.sh` clean.
+    - A **real teammate clone**: a fresh empty directory, clone the docs hub into it, run
+      `scripts/setup-workspace.sh` there, and confirm every registered repo actually arrives.
+    - The pre-split commit resolves in every new repo.
+11. **Swap.** **Rename** the old workspace aside — do not delete it — and move the build directory
+    into its place. Abort is still just deleting the build directory. Delete the old workspace only
+    after you have worked in the new one for a while: it is the only copy of anything step 2's
+    lists missed, and no mirror holds untracked or ignored files.
+12. **Retire the old remote**, per step 2's decision. *Default:* delete its contents in one tip
+    commit, leaving a `README.md` that says the history is still there and how to reach it, then set
+    the host's permissions to read-only. **Never delete refs**, and author that commit on a fresh
+    clone of the host, not in your live workspace. Do this **after the swap is verified, never
+    before** — a complete pushed copy stays on the host through the whole destructive window. That README needs
+    one sentence for anyone else holding a clone: *start a fresh empty folder, clone the docs hub
+    into it, and run `scripts/setup-workspace.sh` there — do not reuse your old project folder.*
+    Re-onboarding in place leaves the new repos nested inside the retired one, and every check
+    passes.
+13. **Write the STEP's PLAN** and archive it into the new `prompts/` repo at
+    `prompts/<phase>/step-NNNN/`, then mark the STEP done in `prompts/STEP-index.md`. Written now
+    rather than at step 4, it never has to pass through a forward delete. *Skip this if you skipped
+    step 4.*
+
+## Appendix — purging history first
+
+You are here because a credential or a large binary is in the history and you do not want it copied
+into a second repo. This is the **purge** procedure, not an escape hatch from the default: it
+rewrites history, so it happens *before* either part, on a mirror, once.
+
+**Rotate the credential first.** A rewrite does not reach the clones your teammates already have,
+or the copies on the host until it garbage-collects, or anything a CI log captured. Rotation is the
+control; the rewrite is cleanup.
+
+**Reconnaissance, before you rewrite anything.**
+
+```bash
+git clone --mirror --no-local <origin> ../purge-work.git   # work on a copy, never your only one
+git -C ../purge-work.git filter-repo --analyze             # path + rename reports (needs the tool below)
+git -C ../purge-work.git for-each-ref --format='%(objectname) %(refname)' > ../refs-before.txt
+```
+
+The `--analyze` reports are how you build the path list. **Neither tool follows renames.** History
+truncates at every historical path you fail to name, silently — one reported case lost 119 of 144
+commits of `--follow` history on a plain directory filter. If the file ever moved, every one of its
+old paths has to be on the list.
+
+**The tools.**
+- **`git filter-repo`** is the one that handles a scattered set of paths, and the one you cannot
+  assume anybody has: it never ships with git, every install route wants Python, and released
+  versions differ enough in behavior that "it worked on my machine" is not evidence. Repeated runs
+  are not reproducible — matching commit IDs across two runs happen by luck, not by design, as its
+  own FAQ says.
+- **`git subtree split`** ships with git and *is* deterministic: the same history splits to the
+  same commit IDs every time. It is also single-prefix, single-branch, and exports no tags — and
+  it **silently accepts only the last `-P`**. `-P src/api -P src/billing` exits 0, warns about
+  nothing, and gives you only the billing files.
+
+**Afterwards, diff the ref graph.** A branch whose commits all touched purged paths is not deleted
+— it is remapped onto some other commit's SHA, and the tool reports no problems.
+
+```bash
+git -C ../purge-work.git for-each-ref --format='%(objectname) %(refname)' > ../refs-after.txt
+diff ../refs-before.txt ../refs-after.txt
+```
+
+Two refs that now point at the same object collapsed. Decide what each one should be before you
+push anything.
+
+**What a purge costs you**, so nobody is surprised: every SHA changes, so every commit reference
+recorded anywhere — `reviewed_commit:` in `registries/security-reviews.yml`, SHAs in reports and
+ADRs, links in issues — stops resolving, and everyone re-clones. That is the trade for not carrying
+the blob.
+
+**If the motive is purely size**, there is a cheaper answer that rewrites nothing: let one new repo
+inherit the origin's identity outright rather than cloning it. Move the `.git` directory into the
+folder that is becoming a repo, then inside it `git rm -r --cached .`, `git add -A`, and commit. It
+comes out with the complete un-rewritten history and `--follow` and `blame` resolving through the
+path change — but only one repo can inherit it, and the workspace root stops being a repo the
+moment you move `.git`, so this only makes sense as part of Part 2.

--- a/init.sh
+++ b/init.sh
@@ -389,10 +389,10 @@ if [ "$COLLAB" = "2" ]; then
     echo "  Heads-up: team collaboration relies on shared Git remotes so everyone clones"
     echo "  from the same place. You can still skip that now and add remotes later."
     if [ "$LAYOUT" = "2" ]; then
-      echo "  NOTE: you picked mono-repo + team. That works for STEP-number reservation (one"
-      echo "  shared repo with a remote), but the overlap warning is repo-granular and so is"
-      echo "  meaningless when every STEP touches the one repo. Plan to split into multi-repo"
-      echo "  before the team grows — see METHOD.md §7 (\"Mono-repo for now\")."
+      echo "  NOTE: you picked mono-repo + team. That works — what a team needs is shared"
+      echo "  remotes, not several repos. One thing to know: the overlap warning is"
+      echo "  repo-granular, so it is meaningless when every STEP touches the one repo."
+      echo "  Fall back to the PLAN's file/area notes — see runbooks/collaboration.md §4."
     fi
   fi
 fi
@@ -976,6 +976,16 @@ else
 fi
 
 # --- 7. Done ----------------------------------------------------------------
+# Mono keeps ONE shared remote for the single root repo; registries/repos.yml's rows are folders
+# inside it, not repos to clone (runbooks/collaboration.md §9).
+if [ "$LAYOUT" = "2" ]; then
+  REMOTE_TIP="If you did not set up remotes during init, create one empty repo on your host
+  and push the root repo's ${TRUNK_BRANCH} branch to it. Leave registries/repos.yml's rows
+  alone — they describe folders inside your one repo, not repos to clone."
+else
+  REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
+  their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."
+fi
 say "Done."
 cat <<EOF
 
@@ -998,8 +1008,7 @@ Recommended optional backup:
   and working from another computer, put the project on a Git host when you're ready.
 
   GitHub, Bitbucket, GitLab, and other Git hosts all work with the generated repos.
-  If you did not set up remotes during init, create empty repos on your host, add
-  their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch.
+  ${REMOTE_TIP}
 
   GitHub:
     https://github.com/

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -135,26 +135,27 @@ teammate will need later.
    relevant tests to create or update and either the exact test command(s) to run before marking
    the substep done or the final verification substep/command that will run them before the STEP
    closes.
-   *(For the architecture STEP-1, the substeps are the interview sessions in
-   `Code/{{PROJECT}}-docs/templates/architecture-sessions/` — you don't author those from
-   scratch. For a **Check-in STEP**, you don't author prompts either — its two substeps are
-   the doc-drift/conditional-coverage reconciliation and full test run defined in
-   `Code/{{PROJECT}}-docs/runbooks/check-in.md`; the PLAN just points there. An **Incident
-   STEP** is the same kind of thin STEP — its three substeps (RCA → find similar → fix) are
-   defined in `Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md`, opened by that runbook
-   when responding to a production incident; its durable postmortem report starts from
-   `Code/{{PROJECT}}-docs/templates/reports/incidents/incident-postmortem-report-template.md`
-   and is saved under `Code/{{PROJECT}}-docs/reports/incidents/`. A **late conditional-session
-   follow-up STEP** is also thin: its one substep points directly to the applicable
-   `templates/architecture-sessions/conditional-*.md` file and records its exact by-name
-   invocation plus the assigned output-doc number; don't duplicate the session into a new
-   prompt. Give its index row the title `Conditional session: <topic>` so the resolver runs
-   it before ordinary planned implementation work.)*
-5. **Update `prompts/STEP-index.md`**: set the STEP's status and list its substeps. Then
+   **Thin STEPs are the exception — you author no substep prompts for them.** A STEP is thin
+   when its substeps are already defined by a file the method ships: the PLAN points at that
+   file and names them, and their status is recorded in the index like any other substep. Two
+   families, rather than a list to keep up to date:
+   - **Runbook-driven.** `Code/{{PROJECT}}-docs/runbooks/README.md` marks which runbooks are
+     STEP-shaped — that list is the one to check. The runbook defines the substeps, including
+     how many: the check-in has exactly two, a repository split has as many as that split's
+     shape needs.
+   - **Session-driven**, where the substeps are architecture sessions in
+     `Code/{{PROJECT}}-docs/templates/architecture-sessions/`. The architecture STEP-1 is the
+     large case — its substeps are the interview sessions chosen at kickoff. A **late
+     conditional-session follow-up** is the small one: a single substep pointing at the
+     applicable `conditional-*.md` file, recording its exact by-name invocation and the assigned
+     output-doc number. Don't copy a session into a new prompt. Give that STEP's index row the
+     title `Conditional session: <topic>` so the resolver runs it before ordinary planned
+     implementation work.
+6. **Update `prompts/STEP-index.md`**: set the STEP's status and list its substeps. Then
    present the PLAN and substep list to the user and **stop for approval** before running any
    substep. Do not continue from planning into execution unless the user explicitly asks for a
    specific substep, e.g. `run substep N.1`.
-6. **On completion:** run the STEP's review — your team's standard **PR / code review** (the
+7. **On completion:** run the STEP's review — your team's standard **PR / code review** (the
    method doesn't redefine it), plus the doc-drift check — then **gather the STEP's files
    (PLAN + any substep prompts + review) from `Upcoming Prompts/` into a new `step-NNNN/` folder**
    in the phase folder in this repo and mark it **Done** in the index. (If this is the phase's


### PR DESCRIPTION
Adds `runbooks/splitting-repos.md` — a STEP-shaped runbook for splitting a repository — and
repeals the rule that told you to split before adding a second contributor.

## What the runbook does

The method used to say splitting was "standard git," which is not something you can act on. The
published recipe makes the extracted repo *new*, with its history rewritten by `git filter-repo`:
a tool that never ships with git, wants Python on every install route, and truncates history at
every historical path you forget to name. This runbook does something else — clone the whole repo
and delete forward. Nothing is rewritten, both sides keep the full history as the same objects
with the same SHAs, and `git blame`, `git log --follow`, `git bisect` and every commit SHA the
project has recorded keep resolving in the new repo on day one.

One procedure covers both cases: splitting a code repo in two (Part 1) and converting a
mono-repo-for-now workspace to multi-repo (Part 2). Three questions up front, the rest at the step
that needs them, each with a default. The cost is stated plainly — every new repo inherits every
blob the origin ever committed — and an appendix covers purging first when that matters.

Split-out repos now record where they came from, in a `provenance:` block on their
`registries/repos.yml` row.

## What it repeals

The rule requiring a split before a second contributor gave two reasons and neither survived. The
STEP-number push race works the same in a mono repo with a shared remote — a team needs shared
remotes, not several of them — and the overlap warning's mono fallback was already written one
section above the clause saying it wasn't. Repo count follows the architecture, not headcount.
`runbooks/collaboration.md`'s solo-to-team section gains a mono path, including the warning not to
run `scripts/setup-workspace.sh` in a mono clone.

## Upgrading

`UPDATING-THROUGHSTONE.md` gains a `### 1.8 migration` section, written here rather than
reconstructed at release time. For an existing project the release is close to inert: pull the
process docs as one review-required group, and stop if you were planning a split only to gain a
second contributor. `provenance:` is written at a split and only then, so no existing registry row
changes and nobody backfills. 1.8's contents are still open, so the section is sized to be appended
to by whatever lands next.

## How it was checked

Built and rewritten across three review rounds, each one executing the file against real
repositories rather than reading it. The last round walked both parts end to end on a seeded
four-unit workspace — several commits of history, a rename, two code folders with their own ignore
files, untracked and ignored local state — and finished with `check.sh` at 0 fail / 0 warning,
`links.sh` clean, both code repos building and testing, and a real teammate clone pulling every
registered repo down correctly. Part 1 then split a directory out of one of the resulting repos,
producing a twice-split repo whose `--follow` history still crosses both un-nests and the earlier
rename. A separate agent was handed the same fixture and the file alone and ran the whole of
Part 2 from it, independently.

Things the rounds found and this branch fixes, among others: the mechanic now runs in three
blocks with the stops between them, because a stop written as a comment on an executable line is
not a stop; the first block is anchored to the origin, because only the other two re-enter the
repo they act on; the forward delete says how a scattered keep-set substitutes, because the
literal substitution deletes the keep-set and blames the path; the appendix's purge path was run
for the first time, which is how its ref-graph check turned out to miss the collapse it warns
about.

All 11 scripts in `tests/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
