### PR TITLE
Say that Part 1 of a split needs a multi-repo workspace

### DIFF
--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -92,6 +92,14 @@ runbook and disappears at the split without a word.
 If the answer is *"the workspace root stops being a repo"*, you are in **Part 2**. Otherwise
 **Part 1**.
 
+**Part 1 assumes the workspace root is not a repo.** In mono-repo-for-now it is, so extracting a
+folder there leaves the new repo *nested inside* the origin — the root reports it as an untracked
+directory, and step 9's `git status` check fails on it. It also strands the repo you just made:
+`collaboration.md` §9 tells a mono project not to put `remote:` fields in `registries/repos.yml`
+and not to run `scripts/setup-workspace.sh`, so nothing on the mono onboarding path would ever
+clone it onto a teammate's machine. **Run Part 2 first**, then Part 1 as often as you like on the
+repos it leaves you.
+
 **2. Should you split at all?** *(Part 1 only — for Part 2 the layout decision was made at
 `init.sh` time.) Default: proceed.* One exchange, and the two questions worth asking are: would
 the two halves be **chatty** with each other, and would an ordinary change require **deploying


### PR DESCRIPTION
The split runbook routes on one question: if the workspace root stops being a repo you are in
Part 2, otherwise Part 1. A **mono-repo-for-now** project that wants one folder to ship separately
answers "no" to that and lands in Part 1 — which puts the extracted repo at `Code/<new-name>/`,
"a sibling of the origin". In mono the origin *is* the workspace root, so the new repo ends up
nested inside it.

Nothing in Part 1 scoped itself to multi-repo, so nothing said this was the wrong door.

## Two things break, both observable

- The root repo reports the new one as an untracked directory, so **step 9's check fails** — its
  "`git status` shows nothing new in either repo" condition — on a split that otherwise went fine.
- The repo is **stranded**. `collaboration.md` §9 tells a mono project not to put `remote:` fields
  in `registries/repos.yml` and not to run `scripts/setup-workspace.sh` — a teammate just clones
  the one repo — so nothing on that onboarding path would ever clone what you extracted.

Reproduced rather than reasoned about: cloning a folder to `Code/<name>/` inside a mono root leaves
the root reporting `?? Code/<name>/`, and `git -C Code rev-parse --show-toplevel` resolves to the
mono root.

## The fix

There is no correct way to do this in mono, so this says so **at the routing question**, where the
choice is actually made, rather than adding a mono variant of Part 1. Convert with Part 2 first;
Part 1 applies afterwards, as often as you like.

## Notes

- **No changelog entry.** The runbook is unreleased, so this corrects what it says about its own
  scope rather than changing anything a reader has seen.
- Eight added lines, one file, no behavior change to any script.

## Verification

- All 11 `tests/` scripts pass.
- A generated project is `check.sh` **0 fail(s), 0 warning(s)** and `links.sh` clean, in **both**
  the multi and mono layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
