### PR TITLE
Cover the whole 1.8 release in its notes, and fix what the audit found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ any project built with it.
   maintainer test enforces it.
 
 ### Fixed
+- **A generated repo's ignore file named one per-machine agent file instead of matching the family.**
+  Every repo `init.sh` creates ignored `.claude/settings.local.json` exactly, so an editor's lock or
+  autosave sibling (`#settings.local.json#`, `settings.local.json~`) — per-machine files, all of
+  them — was left untracked and swept in by a `git add -A`. Throughstone's own repository moved off
+  the by-name rule for this reason and the generated one did not follow. Now matched by pattern.
+  Shared project config (`.claude/settings.json`) is still committed, so this narrows what leaks
+  without narrowing what a team can share.
 - **`init.sh`'s closing backup tip was wrong for a mono-repo project.** It told every project to
   "create empty repos on your host, add their URLs to `registries/repos.yml`, and push each local
   repo's `main` branch" — which is what `runbooks/collaboration.md` §9 expressly tells a mono

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ any project built with it.
   families.
 
 ### Changed
+- **The website's process section is three steps, not four, and says the method covers the whole
+  lifecycle.** The four-step flow led with *Initialize* — running the setup wizard — which put a
+  tooling step where a reader is trying to understand the method, and pushed *Check-ins* off the
+  end. It now reads **Design first → Build in STEPs → Check-ins**, with initialization described
+  where you actually install. A new *Beyond the build* note under the flow says outright that the
+  architecture sessions and runbooks plan for deployment, monitoring, releases and incidents, which
+  the site previously only implied. Site copy only — no method or scaffold change.
 - **The README and website now tell you to clone the latest *release*, not `main`.**
   `git clone --branch v1.7.1 …` gives you the 1.7 release; `main` is where Throughstone itself is
   built and can carry unfinished work. The "Use this template" path is flagged as unable to be

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -77,15 +77,33 @@ not fail the check.
 
 ### 1.8 migration
 
-**Upgrading from 1.7? Nothing is rewritten and nothing is required of you** unless you are about to
-split a repository. The release adds a runbook for that, and repeals one rule. Fast path:
+**Upgrading from 1.7? Nothing you own is rewritten.** The headline is a runbook for splitting a
+repository, and one rule repealed — but the release also carries a check-in fix worth pulling even
+if you never split, so the fast path covers more than the split. Fast path:
 
-1. Pull the process docs as one review-required group (the new `runbooks/splitting-repos.md`,
-   `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §9, `prompts/README.md`, and
-   the header comment in `registries/repos.yml`).
-2. If you were planning to split a repo **only** in order to add a second contributor — stop.
+1. **Pull the split's process docs as one review-required group** (the new
+   `runbooks/splitting-repos.md`, `runbooks/README.md`, `METHOD.md` §7,
+   `runbooks/collaboration.md` §9, `prompts/README.md`, and the header comment in
+   `registries/repos.yml`). Skip this group entirely if you are not splitting anything — nothing
+   else in the release reads it.
+2. **Pull `runbooks/check-in.md` whether or not you split.** Its deferred-coverage sweep asked you
+   to enumerate docs "carrying `Coverage: deferred`", and the docs write that field as
+   `**Coverage:** deferred — …`, so a run that took the literal at face value found nothing to
+   sweep. It now says to read the field and to treat any value other than `full` as deferred. If
+   your check-ins have never surfaced a deferred-coverage doc, this is why.
+3. **Pull `inputs/README.md`** if you lift documents into `architecture/`. It now names all three
+   header fields a lifted doc needs — `Version`, `Status` **and** `Version Log` — because
+   `scripts/check.sh` requires all three of a numbered doc however it got there, and it used to
+   name only the first two.
+4. If you were planning to split a repo **only** in order to add a second contributor — stop.
    That rule is gone, and nothing replaces it.
-3. Nothing else. A project that never splits reads none of this, and no file of yours changes.
+5. **Everything else is templates, and templates are future-only** (§2). The session templates,
+   `templates/architecture-doc-template.md` and `templates/step-index-seed.md` all changed; none
+   of it rewrites a doc you already generated. Worth knowing anyway, because session templates are
+   read live: a session's go-ahead now fires on being *invoked* rather than on being *read*, and
+   the two sessions that named their work list something else (`13-glossary.md`,
+   `14-cross-cutting-review.md`) now use `## Decisions to make (in order)` like the other fifteen.
+   Take these when you next pull templates; nothing breaks if you don't.
 
 **The rule that went away.** The method used to say a mono-repo-for-now project had to split before
 taking on a second contributor. It gave two reasons and neither holds. The STEP-number push race

--- a/init.sh
+++ b/init.sh
@@ -780,8 +780,12 @@ write_gitignore() {
 .DS_Store
 *.swp
 
-# Per-machine agent config (not shared)
-.claude/settings.local.json
+# Per-machine agent config (not shared). Patterns rather than one filename: an editor's lock and
+# autosave siblings (#settings.local.json#, settings.local.json~) are per-machine too, and a
+# `git add -A` would otherwise commit them. Shared project config (.claude/settings.json) still commits.
+.claude/*.local.json
+.claude/#*#
+.claude/*~
 
 # Personal local Throughstone profile (not shared)
 /.throughstone/local-user.md


### PR DESCRIPTION
An audit of what has actually landed in the unreleased block since `v1.7.1` —
35 net-changed files mapped against the recorded entries. Three gaps, one commit each.

## 1. The upgrade guide covered only the split

`UPDATING-THROUGHSTONE.md`'s 1.8 section was written when the split runbook was the
whole release. It opened *"nothing is required of you unless you are about to split a
repository"* and its fast path ended *"Nothing else … no file of yours changes."*
Nine more entries have landed since.

One of them a project needs **whether or not it ever splits**: the check-in's
deferred-coverage sweep asked for docs *"carrying `Coverage: deferred`"*, while the docs
write the field as `**Coverage:** deferred — …`, so a run taking that literal at face
value found nothing to sweep. `runbooks/check-in.md` is a review-required process doc
under §2's File Buckets, and the fast path sent nobody to it. `inputs/README.md` is the
same shape — it now names all three header fields a lifted doc needs rather than two,
because `check.sh` requires all three.

Template changes stay future-only per §2, so *"nothing you own is rewritten"* still holds
and the section says that instead. But session templates are read live rather than
generated once, so the go-ahead and work-list-heading changes are named rather than left
to be found.

## 2. The website reframe was unrecorded

The block already describes one website change — the clone-a-release switch — so the site
is in scope for these notes. The reframe that took the process flow from four steps to
three and added the full-SDLC note was not recorded, leaving the site half covered.
Entered under Changed and marked site copy only.

## 3. A generated repo's ignore file named one file where the risk is a family

Not a documentation gap — a real one the audit surfaced. Every repo `init.sh` creates
ignored `.claude/settings.local.json` by exact name, so an editor's lock or autosave
sibling (`#settings.local.json#`, `settings.local.json~`) — per-machine files, all of
them — was swept in by a `git add -A`. This repository moved off the by-name rule for
exactly that reason; the ignore file it writes for users never followed.

Fixed by pattern, **not** by copying this repo's wholesale `.claude/`: a generated
project's `.claude/settings.json` is shared team config and has to stay committable.

## Verification

- All 11 `tests/` scripts pass.
- A generated project is `check.sh` **0 fail(s), 0 warning(s)** and `links.sh` clean.
- The ignore change measured on a generated repo: `settings.local.json`,
  `#settings.local.json#` and `settings.local.json~` all report ignored; `settings.json`
  and `launch.json` stay committable; `git add -A` stages only those two.

## Note

Commit 3 is independent of the first two — say so and I'll split it into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
