### PR TITLE
Ignore per-machine agent config by pattern in generated repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ any project built with it.
   maintainer test enforces it.
 
 ### Fixed
+- **A generated repo's ignore file named one per-machine agent file instead of matching the family.**
+  Every repo `init.sh` creates ignored `.claude/settings.local.json` exactly, so an editor's lock or
+  autosave sibling (`#settings.local.json#`, `settings.local.json~`) — per-machine files, all of
+  them — was left untracked and swept in by a `git add -A`. Throughstone's own repository moved off
+  the by-name rule for this reason and the generated one did not follow. Now matched by pattern.
+  Shared project config (`.claude/settings.json`) is still committed, so this narrows what leaks
+  without narrowing what a team can share.
 - **`init.sh`'s closing backup tip was wrong for a mono-repo project.** It told every project to
   "create empty repos on your host, add their URLs to `registries/repos.yml`, and push each local
   repo's `main` branch" — which is what `runbooks/collaboration.md` §9 expressly tells a mono

--- a/init.sh
+++ b/init.sh
@@ -780,8 +780,12 @@ write_gitignore() {
 .DS_Store
 *.swp
 
-# Per-machine agent config (not shared)
-.claude/settings.local.json
+# Per-machine agent config (not shared). Patterns rather than one filename: an editor's lock and
+# autosave siblings (#settings.local.json#, settings.local.json~) are per-machine too, and a
+# `git add -A` would otherwise commit them. Shared project config (.claude/settings.json) still commits.
+.claude/*.local.json
+.claude/#*#
+.claude/*~
 
 # Personal local Throughstone profile (not shared)
 /.throughstone/local-user.md


### PR DESCRIPTION
Every repo `init.sh` creates ignored `.claude/settings.local.json` by exact name.
An editor's lock or autosave sibling — `#settings.local.json#`, `settings.local.json~` —
is per-machine too, and being unignored was swept in by a `git add -A`. Throughstone's
own repository moved off the by-name rule for exactly this reason; the ignore file it
writes for users never followed.

Matched by pattern now — **not** the wholesale `.claude/` this repo uses for itself: a
generated project's `.claude/settings.json` is shared team config and has to stay
committable, which a whole-tree ignore would prevent.

## Verification

- All 11 `tests/` scripts pass.
- Measured on a generated repo: `settings.local.json`, `#settings.local.json#` and
  `settings.local.json~` all report ignored; `settings.json` and `launch.json` stay
  committable; `git add -A` stages only those two.

Split out of the closed #173 — the release-notes half of that PR is held until 1.8 is
ready to tag; this fix is independent of release timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
