### PR TITLE
Refuse to bootstrap anywhere but a fresh template checkout, and stop defaulting to an open-source license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ any project built with it.
   families.
 
 ### Changed
+- **The interactive setup no longer licenses your project open source by default.** `init.sh` asks
+  whether the project is open source or private/proprietary, and that question used to default to
+  open source, with the license question after it defaulting to MIT — so two bare Enters granted
+  everyone an irrevocable license to the project's code without the user ever naming one. The
+  project-type question now defaults to **private / proprietary**, which writes no project
+  `LICENSE` at all and leaves the decision to be made deliberately later. The open-source
+  sub-question keeps its MIT default: by the time it is asked, open source is an explicit choice.
+  Nothing changes for `--license=…` or `--non-interactive`, which have always required the posture
+  to be stated. Existing projects are unaffected — their posture is already recorded in
+  `.throughstone/project-license`.
 - **The README and website now tell you to clone the latest *release*, not `main`.**
   `git clone --branch v1.7.1 …` gives you the 1.7 release; `main` is where Throughstone itself is
   built and can carry unfinished work. The "Use this template" path is flagged as unable to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,21 @@ any project built with it.
   maintainer test enforces it.
 
 ### Fixed
+- **`init.sh` could destroy a repository it was run inside.** Unpacking the template into a
+  repository you already had — the natural thing to try when you want Throughstone in a project
+  that exists — and running `./init.sh` there deleted that repository's `.git` outright, every
+  commit with it, at exit code 0 and with no warning. Your working files survived; your repository
+  did not. The bootstrap is one-time and destructive by design — it removes the template's own git
+  history and every template-only file — so it now establishes that it is looking at a fresh
+  template checkout *before* it removes anything, and refuses with an explanation when it is not.
+  The marker in the root pointers cannot answer that on its own, because an unpacked template
+  brings those files along with it, so git is asked too — and only when there is a `.git` in the
+  folder to lose. A checkout counts as fresh when its committed history is the template's own and
+  it tracks nothing the template does not ship, or when it has no commits, no branches and nothing
+  staged. Every documented setup route still works untouched: a fresh unpacked download, a clone of
+  a release tag, a "Use this template" repo, and `git init` beside the template to attach an empty
+  origin. Covered by `tests/init-fresh-template-guard.sh`, which derives the template's root-entry
+  list from the template itself so the check cannot go stale.
 - **A generated repo's ignore file named one per-machine agent file instead of matching the family.**
   Every repo `init.sh` creates ignored `.claude/settings.local.json` exactly, so an editor's lock or
   autosave sibling (`#settings.local.json#`, `settings.local.json~`) — per-machine files, all of

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -87,6 +87,13 @@ split a repository. The release adds a runbook for that, and repeals one rule. F
    That rule is gone, and nothing replaces it.
 3. Nothing else. A project that never splits reads none of this, and no file of yours changes.
 
+**A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run
+anywhere but a fresh template checkout. Unpacking the template into a repository you already had and
+running it there used to delete that repository's `.git` and every commit in it, silently. `init.sh`
+runs once, when a project is created, and an existing project never runs it again — so no file of
+yours changes and there is no action here. It matters only the next time you bootstrap a **new**
+Throughstone project: do that from 1.8 or later.
+
 **The rule that went away.** The method used to say a mono-repo-for-now project had to split before
 taking on a second contributor. It gave two reasons and neither holds. The STEP-number push race
 works exactly the same in a mono repo with a shared remote — what a team needs is *shared* remotes,

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -94,6 +94,12 @@ runs once, when a project is created, and an existing project never runs it agai
 yours changes and there is no action here. It matters only the next time you bootstrap a **new**
 Throughstone project: do that from 1.8 or later.
 
+The same release changes one bootstrap default, and again there is nothing to do. `init.sh`'s
+interactive project-type question now defaults to private/proprietary rather than open source, so
+pressing Enter through setup no longer licenses a project MIT without anyone naming a license. Your
+project's posture was chosen when it was created and is recorded in `.throughstone/project-license`;
+it does not change. Worth knowing only if you bootstrap another project from muscle memory.
+
 **The rule that went away.** The method used to say a mono-repo-for-now project had to split before
 taking on a second contributor. It gave two reasons and neither holds. The STEP-number push race
 works exactly the same in a mono repo with a shared remote — what a team needs is *shared* remotes,

--- a/init.sh
+++ b/init.sh
@@ -253,6 +253,76 @@ preflight_git_commit
 command -v gh      >/dev/null 2>&1 || echo "Note: 'gh' not found — GitHub repo creation is unavailable, but manual remote URLs still work."
 command -v python3 >/dev/null 2>&1 || echo "Note: 'python3' not found — the later setup-workspace.sh will use its plain-shell fallback."
 
+# --- 0c. Fresh-template guard -----------------------------------------------
+# init.sh is one-time and destructive: section 2 removes .git and every template-only file. That
+# is right for a freshly downloaded template and catastrophic anywhere else — unpacking the
+# template into a repository that already exists and running it here deletes that repository's
+# history outright, with no warning and no way back.
+#
+# Four checks, because no one of them covers the rest. The sentinel below travels with the files,
+# so it cannot answer "whose repository is this?" — an extracted template brings AGENTS.md and
+# CLAUDE.md along with it. Git is asked separately, and only when there is a .git here to lose: a
+# checkout nested inside someone else's repository has nothing at $ROOT for section 2 to remove.
+#
+# Each check is paired with a case that must still proceed: a fresh unpacked template (no .git at
+# all), a clone of Throughstone or of a "Use this template" repo (history that is the template's
+# own), and `git init` beside an unpacked template to attach an empty origin (no commits, nothing
+# staged). tests/init-fresh-template-guard.sh holds both halves.
+
+# Every top-level entry Throughstone ships, pipe-delimited so entries with spaces stay intact.
+# tests/init-fresh-template-guard.sh regenerates this from the template and fails if it drifts.
+TEMPLATE_ROOT_ENTRIES='|.github|.gitignore|AGENTS.md|ARTIFACT-TRAIL.md|CHANGELOG.md|CLAUDE.md|CODE_OF_CONDUCT.md|CONTRIBUTING.md|Code|LICENSE|README.md|SECURITY.md|TRADEMARK.md|Upcoming Prompts|brand|docs|doctor.sh|init.sh|prompts|tests|'
+
+# refuse_not_fresh REASON — stop before the destructive boundary, saying which check refused.
+refuse_not_fresh() {
+  echo "init.sh: this does not look like a fresh Throughstone template checkout." >&2
+  echo "  $1" >&2
+  echo "  init.sh is one-time and destructive (it removes .git and template-only files), so it will" >&2
+  echo "  not run on an already-initialized project or on top of a repository that is not the" >&2
+  echo "  template — either would delete history it cannot give back." >&2
+  echo "  Download the template into a fresh, empty folder and run it there instead." >&2
+  exit 2
+}
+
+# 1. The root pointers carry a THROUGHSTONE-TEMPLATE-GUARD block that step 3 strips during
+#    initialization. It holds no {{PROJECT}} token, so — unlike the docs-hub directory name — it
+#    is never rewritten by placeholder substitution and stays a stable sentinel. Its absence means
+#    an already-initialized project, or a directory that was never the template.
+if ! grep -qlF 'THROUGHSTONE-TEMPLATE-GUARD' "$ROOT/AGENTS.md" "$ROOT/CLAUDE.md" 2>/dev/null; then
+  refuse_not_fresh "The root pointers carry no template marker."
+fi
+
+if [ -e "$ROOT/.git" ]; then
+  if git rev-parse --verify -q HEAD >/dev/null 2>&1; then
+    # 2. There is committed history, so it has to be the template's own. A clone of Throughstone
+    #    and a "Use this template" repo both carry the sentinel at HEAD, because init.sh has not
+    #    run yet to strip it. Someone else's history does not.
+    git cat-file -p HEAD:AGENTS.md 2>/dev/null | grep -qF 'THROUGHSTONE-TEMPLATE-GUARD' \
+      || refuse_not_fresh "This repository's committed history is not Throughstone's."
+    # 3. The sentinel at HEAD is necessary but not sufficient: someone who committed the extracted
+    #    template on top of their own history has it too, and their commits are still underneath.
+    #    A checkout that really is the template tracks nothing the template does not ship.
+    while IFS= read -r -d '' entry; do
+      case "$TEMPLATE_ROOT_ENTRIES" in
+        *"|$entry|"*) ;;
+        *) refuse_not_fresh "This repository tracks '$entry', which Throughstone does not ship." ;;
+      esac
+    done < <(git ls-tree -z --name-only HEAD)
+  else
+    # 4. No commits here yet. `git init` beside an unpacked template is a supported way to attach
+    #    an empty origin, so an unborn HEAD is fine by itself — but only if the repository really
+    #    is empty. A ref means commits survive on some other branch (`git checkout --orphan`
+    #    inside a live repo leaves exactly this shape), and a populated index means files were
+    #    staged and never committed.
+    if [ -n "$(git for-each-ref --count=1)" ]; then
+      refuse_not_fresh "This repository has branches or tags carrying history."
+    fi
+    if [ -n "$(git ls-files)" ]; then
+      refuse_not_fresh "This repository has staged files that were never committed."
+    fi
+  fi
+fi
+
 say "Throughstone — setup"
 
 # --- 1. Questions (flags/env pre-answer; otherwise prompt) -------------------

--- a/init.sh
+++ b/init.sh
@@ -67,6 +67,13 @@ validate_trunk_branch() {
 # Proprietary is a project-license posture, not a GitHub visibility setting. Open-source
 # projects choose a concrete permissive license template; proprietary projects intentionally
 # skip project LICENSE creation later.
+#
+# The project-type question defaults to private/proprietary because that is the recoverable
+# answer. Accepting it writes no project LICENSE at all, which anyone can change later by
+# choosing a license deliberately; accepting an open-source default would grant everyone an
+# irrevocable license to the project's code without the user ever having named one. The
+# open-source sub-question keeps its MIT default — by the time it is asked, open source is an
+# explicit choice and MIT is a reasonable one.
 choose_license_interactively() {
   local project_type license_input
 
@@ -74,7 +81,7 @@ choose_license_interactively() {
     echo "Is this project open source or private/proprietary?"
     echo "  1) Open source"
     echo "  2) Private / proprietary"
-    project_type="$(ask 'Choose 1 or 2' '1')"
+    project_type="$(ask 'Choose 1 or 2' '2')"
     case "$project_type" in
       1) break ;;
       2)

--- a/tests/init-fresh-template-guard.sh
+++ b/tests/init-fresh-template-guard.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for init.sh's fresh-template guard.
+#
+# init.sh is a one-time, destructive bootstrap: it removes .git and every template-only file. Run
+# anywhere other than a freshly downloaded template that destroys whatever is there — most
+# seriously, unpacking the template into a repository that already exists and running it in place
+# deletes that repository's history outright.
+#
+# The guard refuses before the destructive boundary. It has to refuse without over-refusing, so
+# every refusing case below is paired with a case that must still proceed:
+#
+#   proceeds                                   refuses
+#   --------                                   -------
+#   a fresh unpacked template (no .git)        an already-initialized project (no sentinel)
+#   a clone of the template's own history      history that is not the template's
+#   `git init` beside the template, empty      a repo tracking files the template does not ship
+#                                              an unborn HEAD with commits on another branch
+#                                              an unborn HEAD with files staged, never committed
+#
+# The last check pins the template's root-entry list, which the guard carries as a literal, to the
+# template itself so it cannot rot.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-fresh-guard-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# copy_template DEST — build an init.sh fixture from HEAD, then overlay current worktree changes so
+# this test covers uncommitted bootstrap edits (same helper as the sibling init tests).
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+seed_commit() { git -c user.name="Throughstone Test" -c user.email="throughstone-test@example.invalid" commit -qm "$1"; }
+
+init_once() { # DIR SLUG EXTRA_ARGS...
+  local dir="$1" slug="$2"; shift 2
+  ( cd "$dir" && ./init.sh \
+      --non-interactive --slug="$slug" --desc="Guard test" \
+      --license=private --collab=solo --remotes=no "$@" )
+}
+
+# assert_refused NAME DIR REASON_TEXT — init must exit non-zero and name the check that fired.
+assert_refused() {
+  local name="$1" dir="$2" reason="$3"
+  if init_once "$dir" "$name" --layout=multi >"$TMP_ROOT/$name.out" 2>&1; then
+    echo "FAIL: $name — init.sh ran where it should have refused" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    exit 1
+  fi
+  grep -Fq "does not look like a fresh Throughstone template checkout" "$TMP_ROOT/$name.out" \
+    || { echo "FAIL: $name — refusal did not print the fresh-template message" >&2; cat "$TMP_ROOT/$name.out" >&2; exit 1; }
+  grep -Fq "$reason" "$TMP_ROOT/$name.out" \
+    || { echo "FAIL: $name — refusal did not name the expected check ('$reason')" >&2; cat "$TMP_ROOT/$name.out" >&2; exit 1; }
+}
+
+# assert_history_intact NAME DIR SHA — refusing must leave the user's repository exactly as found.
+assert_history_intact() {
+  local name="$1" dir="$2" sha="$3"
+  [ -d "$dir/.git" ] \
+    || { echo "FAIL: $name — init.sh deleted .git before refusing" >&2; exit 1; }
+  git -C "$dir" cat-file -e "$sha" 2>/dev/null \
+    || { echo "FAIL: $name — init.sh destroyed the user's commit $sha before refusing" >&2; exit 1; }
+  [ -f "$dir/app.py" ] \
+    || { echo "FAIL: $name — init.sh removed the user's files before refusing" >&2; exit 1; }
+}
+
+# seed_user_repo DIR — a repository with history of its own, as a user would have before they ever
+# heard of Throughstone. Echoes the commit that must survive.
+seed_user_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  ( cd "$dir" && git init -q && printf 'our source\n' > app.py && git add -A && seed_commit "five years of history" )
+  git -C "$dir" rev-parse HEAD
+}
+
+# --- 1. A fresh template initializes normally (the guard must not over-fire). -----------------
+fresh="$TMP_ROOT/fresh"
+copy_template "$fresh"
+init_once "$fresh" acme --layout=mono >"$TMP_ROOT/fresh.out" 2>&1 \
+  || { echo "FAIL: guard blocked a fresh template checkout" >&2; cat "$TMP_ROOT/fresh.out" >&2; exit 1; }
+commits_before="$(git -C "$fresh" rev-list --count HEAD 2>/dev/null || echo 0)"
+[ "$commits_before" -ge 1 ] || { echo "FAIL: fresh init did not create a mono repo" >&2; exit 1; }
+
+# --- 2. Re-running init in that initialized project is refused, non-destructively. ------------
+if init_once "$fresh" acme --layout=mono >"$TMP_ROOT/rerun.out" 2>&1; then
+  echo "FAIL: init.sh re-ran inside an already-initialized project" >&2
+  cat "$TMP_ROOT/rerun.out" >&2
+  exit 1
+fi
+grep -Fq "The root pointers carry no template marker" "$TMP_ROOT/rerun.out" \
+  || { echo "FAIL: re-run refusal did not print the fresh-template message" >&2; cat "$TMP_ROOT/rerun.out" >&2; exit 1; }
+commits_after="$(git -C "$fresh" rev-list --count HEAD 2>/dev/null || echo 0)"
+[ "$commits_after" = "$commits_before" ] \
+  || { echo "FAIL: re-run destroyed the generated repo's history ($commits_before -> $commits_after)" >&2; exit 1; }
+[ -d "$fresh/Code/acme-docs" ] || { echo "FAIL: re-run mutated the initialized project" >&2; exit 1; }
+
+# --- 3. A clone of the template's own history proceeds. ---------------------------------------
+# The documented Quickstart clones this repo, and "Use this template" produces a repo whose single
+# commit is the unmodified template. Both arrive with committed history, and both are fresh.
+clone_seed="$TMP_ROOT/clone-seed"
+copy_template "$clone_seed"
+( cd "$clone_seed" && git init -q && git add -A && seed_commit "Template-created commit" && git branch -M main )
+git clone -q "$clone_seed" "$TMP_ROOT/cloned"
+init_once "$TMP_ROOT/cloned" cloned --layout=multi >"$TMP_ROOT/cloned.out" 2>&1 \
+  || { echo "FAIL: guard blocked a clone of the template's own history" >&2; cat "$TMP_ROOT/cloned.out" >&2; exit 1; }
+
+# --- 4. `git init` beside an unpacked template proceeds. --------------------------------------
+# Attaching an empty origin before bootstrap is supported (see tests/init-mono-origin-reuse.sh):
+# an unborn HEAD with no refs and nothing staged has nothing to lose.
+empty_repo="$TMP_ROOT/empty-repo"
+copy_template "$empty_repo"
+( cd "$empty_repo" && git init -q )
+init_once "$empty_repo" emptyrepo --layout=multi >"$TMP_ROOT/empty-repo.out" 2>&1 \
+  || { echo "FAIL: guard blocked an empty repo attached to a fresh template" >&2; cat "$TMP_ROOT/empty-repo.out" >&2; exit 1; }
+
+# --- 5. The template unpacked into a repository that already exists is refused. ---------------
+# This is the case people actually hit, and the sentinel alone never catches it: the extracted
+# template brings AGENTS.md and CLAUDE.md, and the marker with them.
+over_repo="$TMP_ROOT/over-repo"
+over_sha="$(seed_user_repo "$over_repo")"
+copy_template "$over_repo"
+assert_refused "over-repo" "$over_repo" "committed history is not Throughstone's"
+assert_history_intact "over-repo" "$over_repo" "$over_sha"
+
+# --- 6. …and refused just the same when the template was committed first. ---------------------
+# Committing before running a destructive script is the cautious thing to do, and it puts the
+# marker into HEAD. What gives it away is that the repository tracks the user's own files too.
+committed="$TMP_ROOT/committed"
+seed_user_repo "$committed" >/dev/null
+copy_template "$committed"
+( cd "$committed" && git add -A && seed_commit "add throughstone" )
+committed_sha="$(git -C "$committed" rev-parse HEAD)"
+assert_refused "committed" "$committed" "which Throughstone does not ship"
+assert_history_intact "committed" "$committed" "$committed_sha"
+
+# --- 7. An unborn HEAD inside a live repository is refused. -----------------------------------
+# `git checkout --orphan` leaves no HEAD and an index the user may well have cleared, but every
+# commit is still reachable from the branch they came from.
+orphan="$TMP_ROOT/orphan"
+orphan_sha="$(seed_user_repo "$orphan")"
+( cd "$orphan" && git checkout -q --orphan blank && git rm -rq --cached . )
+copy_template "$orphan"
+assert_refused "orphan" "$orphan" "branches or tags carrying history"
+[ -d "$orphan/.git" ] && git -C "$orphan" cat-file -e "$orphan_sha" 2>/dev/null \
+  || { echo "FAIL: orphan — init.sh destroyed history reachable from another branch" >&2; exit 1; }
+
+# --- 8. Files staged but never committed are refused. -----------------------------------------
+staged="$TMP_ROOT/staged"
+mkdir -p "$staged"
+( cd "$staged" && git init -q && printf 'our source\n' > app.py && git add -A )
+copy_template "$staged"
+assert_refused "staged" "$staged" "staged files that were never committed"
+[ -n "$(git -C "$staged" ls-files)" ] \
+  || { echo "FAIL: staged — init.sh cleared the user's index before refusing" >&2; exit 1; }
+
+# --- 9. The guard's root-entry list matches what the template actually ships. ------------------
+# The list is a literal inside init.sh, so it can rot the moment a root entry is added or removed.
+# Derive the truth from the template and compare, so adding one without the other fails here.
+expected="$TMP_ROOT/root-entries-expected"
+actual="$TMP_ROOT/root-entries-actual"
+git -C "$ROOT" ls-tree -z --name-only HEAD | tr '\0' '\n' | sort > "$expected"
+sed -n "s/^TEMPLATE_ROOT_ENTRIES='|\(.*\)|'$/\1/p" "$ROOT/init.sh" | tr '|' '\n' | sort > "$actual"
+[ -s "$actual" ] || { echo "FAIL: could not read TEMPLATE_ROOT_ENTRIES out of init.sh" >&2; exit 1; }
+diff -u "$expected" "$actual" \
+  || { echo "FAIL: init.sh's TEMPLATE_ROOT_ENTRIES has drifted from the template's root (- missing, + stale)" >&2; exit 1; }
+
+echo "init.sh fresh-template guard: PASS"

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -536,6 +536,7 @@ run_interactive_case \
   $'1\nMIT\n' \
   "MIT License"
 
+# Open source chosen explicitly, then the license sub-prompt's default taken: still MIT.
 run_interactive_case \
   "license-default" \
   $'1\n\n' \
@@ -560,6 +561,14 @@ run_private_case \
   "license-private" \
   bash -c \
   "printf '2\n' | ./init.sh --slug=license-private --desc='License validation test' --layout=multi --collab=solo --remotes=no"
+
+# Answering nothing at all must not license the project. The project-type question defaults to
+# private/proprietary precisely so that a user who presses Enter has granted nobody anything; an
+# open-source default would hand out an irrevocable license they never named.
+run_private_case \
+  "license-bare-enter" \
+  bash -c \
+  "printf '\n' | ./init.sh --slug=license-bare-enter --desc='License validation test' --layout=multi --collab=solo --remotes=no"
 
 run_private_case \
   "license-private-flag" \


### PR DESCRIPTION
Two safety fixes in `init.sh`, both measured rather than theorised. Neither has reached a user:
`README.md` still clones `v1.7.1`, and nothing is tagged past it.

One commit per fix.

## 1. `init.sh` could destroy a repository it was run inside

Reproduced first, before any code was written. A git repo with committed history, the template
unpacked into it — the obvious thing to try when you want Throughstone in a project you already
have — then `./init.sh --slug=… -y`:

**exit 0, `.git` deleted, the prior commit unrecoverable, no warning.** Working files survived; the
repository did not. `v1.7.1`, the published release, has this too.

The bootstrap is one-time and destructive by design — it removes the template's own git history and
every template-only file. It now establishes that it is looking at a fresh template checkout
*before* removing anything, and refuses with a message naming the reason when it is not.

The marker in the root pointers cannot answer that on its own: an unpacked template brings
`AGENTS.md` and `CLAUDE.md` along, marker and all. So git is asked too, and only when there is a
`.git` in the folder to lose — a checkout nested inside someone else's repository has nothing there
for the bootstrap to remove. A checkout counts as fresh when its committed history is the
template's own and it tracks nothing the template does not ship, or when it has no commits, no
branches and nothing staged.

Nine fixtures were probed to separate the cases before writing the check, four of which **must
still proceed**. Verified proceeding, unchanged: a fresh unpacked download; `git clone --branch
v1.7.1 …` (detached HEAD — the documented Quickstart) and its `--depth 1` variant; a "Use this
template" repo; `git init` beside the template to attach an empty origin. Verified refused, with
history intact afterwards and one `git checkout -- . && git clean -fd` restoring the repo exactly:
the template unpacked over a repo with history; the same having been committed first; an orphan
branch inside a live repo; files staged but never committed; a re-run inside an already-initialized
project.

`tests/init-fresh-template-guard.sh` holds both halves — every refusal paired with the case that
must not be refused — and derives the template's root-entry list from the template itself, so the
check cannot go stale as the root changes. Negative-tested in both drift directions.

## 2. Two bare Enters licensed a project MIT

`init.sh` asks whether the project is open source or private/proprietary. That question defaulted
to open source, and the license question after it defaults to MIT — so pressing Enter twice granted
everyone an irrevocable license to the project's code without the user ever naming a license.

The project-type question now defaults to **private / proprietary**. Accepting it writes no project
`LICENSE` at all, which anyone can change later by choosing a license deliberately. An unintended
MIT grant cannot be taken back. The open-source sub-question keeps its MIT default: by the time it
is asked, open source is an explicit choice.

`--license=…` and `--non-interactive` are untouched — they have always required the posture to be
stated, so no scripted bootstrap can be affected. `tests/init-license-validation.sh` gains a
fixture that answers nothing at all and asserts the project comes out proprietary with no `LICENSE`
written; reverting the default makes that fixture fail.

## Verification

- Full suite green, 12/12, run from the top at this branch's tip — including
  `tests/init-mono-origin-reuse.sh`, whose empty-origin flow is the must-proceed case an earlier
  attempt at this guard broke silently.
- Three generated projects built from `git archive` of this branch on deliberately varied postures
  — multi/private/solo, mono/apache-2.0/team, multi/bsd-3/team — each with `check.sh` and
  `links.sh` clean. No MIT-only fixture set.

## Release docs

`CHANGELOG.md` `[Unreleased]`: one **Fixed** entry (the guard), one **Changed** entry (the default).

`UPDATING-THROUGHSTONE.md`'s **1.8 migration** section: two paragraphs saying plainly that there is
**no action for existing projects**. Both fixes are in `init.sh`, which a project runs once at
creation and never again, so nothing of anyone's changes — worth saying rather than leaving silent.

Those paragraphs are written **self-contained** on purpose: the held `release-notes-1-8-completeness`
branch carries a rewrite of that same section, and this needs to survive its rebase. Whoever rebases
it should carry both paragraphs across, or fold their content into the rewritten section.
