### PR TITLE
Record who owns each repo and what it already provides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,28 @@ any project built with it.
   it, the first gaining the mono→multi special case (that STEP is branchless, and its number is
   reserved on trunk) and the second generalizing its thin-STEP note from the check-in alone to two
   families.
+- **Repo rows record who owns each repo and what it already provides.** `registries/repos.yml`
+  gains three per-row fields. **`origin:`** (`created` | `adopted`) says whether Throughstone made
+  the repo or took on one that was already there — a fact, written once when the repo is
+  registered, that never changes. **`control:`** (`managed` | `external`) says whether Throughstone
+  may write into that repo: `managed` is a standing permission, asked once per repository and never
+  per file, while `external` means the repo is recorded and referenced in full and never written
+  into. Control is a state that changes over time rather than a fact about who created the repo, so
+  a repo the method built can be handed over and a repo it never built can be placed under its
+  care. **A missing `control:` reads as `external`**, because control is a permission and an
+  unanswered permission is not granted — the repo is recorded, and nothing is written into it until
+  somebody answers. **`provides:`** records how each of the three things a repo needs — a README, a
+  stated licensing posture, a described CI gate — is actually met there, as a status (`ours`,
+  `extended`, `theirs`, `N/A`, `gap`) and a note; `gap` and `N/A` must say why. It goes only on
+  rows whose `location` is a repository, and never on a row the setup script seeds — a status
+  written before anyone had looked at the repo would be a guess rather than a record. Two
+  invariants hold across the pair: a `managed` repo has no `gap` — either the need is met, or the
+  repo is `external` — and an `external` repo has no `ours` and no `extended`. The registry's
+  header carries the whole schema, the default, and the five rules anything reading or rewriting
+  that file has to follow, because it is read by scripts that match line prefixes and do not parse
+  YAML. `mono` joins the `type:` enum for the workspace root of a mono-repo-for-now project.
+  Existing rows are not rewritten — `UPDATING-THROUGHSTONE.md`'s 1.8 section covers adding the
+  fields to a project you already have.
 
 ### Changed
 - **The interactive setup no longer licenses your project open source by default.** `init.sh` asks

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -158,8 +158,7 @@ folders inside the one repo until you split.
 
 Adding the fields is a **safe additive edit**: it inserts lines into each row and changes no existing
 data. `registries/repos.yml` is your project's own record, like `inputs/inputs-index.md`, so it is
-**never auto-overwritten** — updater tooling adds the lines for your review rather than replacing
-the file.
+**never auto-overwritten**.
 
 ### 1.7 migration
 

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -77,15 +77,19 @@ not fail the check.
 
 ### 1.8 migration
 
-**Upgrading from 1.7? Nothing is rewritten and nothing is required of you** unless you are about to
-split a repository. The release adds a runbook for that, and repeals one rule. Fast path:
+**Upgrading from 1.7? Nothing of yours is rewritten, and there is one small edit worth making** —
+two lines per row in `registries/repos.yml`. Beyond that nothing is required of you unless you are
+about to split a repository. The release adds a runbook for that, repeals one rule, and starts
+recording which of your repos Throughstone may write into. Fast path:
 
 1. Pull the process docs as one review-required group (the new `runbooks/splitting-repos.md`,
    `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §9, `prompts/README.md`, and
    the header comment in `registries/repos.yml`).
 2. If you were planning to split a repo **only** in order to add a second contributor — stop.
    That rule is gone, and nothing replaces it.
-3. Nothing else. A project that never splits reads none of this, and no file of yours changes.
+3. Add `origin:` and `control:` to each row of your `registries/repos.yml` — **details at the end of
+   this section.** It is the only edit 1.8 asks for, and nothing rewrites the file for you.
+4. Nothing else. A project that never splits reads none of the splitting material.
 
 **A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run
 anywhere but a fresh template checkout. Unpacking the template into a repository you already had and
@@ -132,6 +136,30 @@ appendix covers purging history first when that matters.
   `provenance:` is a new optional block recording that a repo was split out of another one — where
   it came from, and where the two histories part company. It is written **at** a split and only
   then, so existing rows do not gain it and a project that split before 1.8 does not backfill.
+
+**Add `origin:` and `control:` to each of your repo entries.** 1.8 gives repo rows three new fields
+— `origin:` (`created` | `adopted`, a fact written once), `control:` (`managed` | `external`, whether
+Throughstone may write into that repo), and `provides:` (how each repo's README, licensing posture
+and CI gate is actually met). The pulled `registries/repos.yml` header documents all three in full,
+along with the default, the invariants, and the rules anything reading that file has to follow.
+
+**The two worth adding by hand are `origin:` and `control:`**, because **a missing `control:` reads
+as `external`** — control is a permission, and an unanswered permission is not a granted one, so the
+method records the repo and writes nothing into it until somebody answers. Answering now means
+nothing changes under you; a row you leave alone arrives unanswered and gets surfaced and asked
+about rather than silently switched. Use `created` for a repo Throughstone made and `adopted` for one
+that was already there when you pointed the method at it, and `managed` for each repo you want the
+method to keep maintaining.
+
+**`provides:` can wait for your next check-in.** It records what is in each repo rather than what you
+have decided, so it is filled in by looking rather than remembering. A row whose `location` is not a
+repository never carries it at all — in a mono-repo-for-now workspace the rows below `repos:` are
+folders inside the one repo until you split.
+
+Adding the fields is a **safe additive edit**: it inserts lines into each row and changes no existing
+data. `registries/repos.yml` is your project's own record, like `inputs/inputs-index.md`, so it is
+**never auto-overwritten** — updater tooling adds the lines for your review rather than replacing
+the file.
 
 ### 1.7 migration
 

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -41,9 +41,7 @@
 #
 # **A missing `control:` reads as `external`**, because control is a permission and an unanswered
 # permission is not granted: the method records the repo and writes nothing into it until someone
-# answers. A defaulted row is surfaced rather than silently accepted. (Unrelated to the top-level
-# `throughstone:` key in `.throughstone/manifest.yml`, which versions the method itself — different
-# file, different scope.)
+# answers. A defaulted row is surfaced rather than silently accepted.
 #
 # `provides:` (per row) records how each of the three needs — README, licensing, CI — is met in that
 # repo. One entry per need, each carrying a status and a note:
@@ -62,11 +60,17 @@
 # `external` repo has no `ours` and no `extended`, because both mean an artifact Throughstone
 # maintains, which it cannot do in a repo it may not write into.
 #
+# **A key may be legitimately absent, and absent is not `gap`.** `gap` is an observation — the need
+# is unmet. An absent key is an observation still owed: nothing was true to write when the row was
+# written. Fill it in by looking at the repo, never by picking a status to complete the set; the
+# check that flags the absence is how it comes back.
+#
 # `origin:` and `control:` go on **every** row. `provides:` goes only on a row whose `location` is
-# a repository — in a mono-repo-for-now workspace the rows below are folders inside the single repo,
-# so they carry none until a split makes them repos of their own. The rows this file ships with
-# carry no `provides:` in either layout: the method's own repos are described by the method itself,
-# and a status written before anyone had looked at a repo would be a guess rather than a record.
+# a repository — in a mono-repo-for-now workspace a row pointing at a folder inside the single repo
+# is not one, and carries none until a split makes it a repo of its own. Seeded rows carry no
+# `provides:` whatever their location, in either layout: the method's own repos are described by the
+# method itself, and a status written before anyone had looked at a repo would be a guess rather
+# than a record.
 #
 # Rules for anything that reads or rewrites this file. The scripts that read it match line prefixes
 # and do not parse YAML, so all five are load-bearing:

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -27,16 +27,80 @@
 # the commented example below. `from:` is a historical name and may have no row of its own —
 # after a mono-repo-for-now split it never does, because the repo it names was retired; that is
 # what `archive_remote:` is for.
+#
+# `origin:` (per row) records whether Throughstone **created** the repo or **adopted** one that was
+# already there: `created` | `adopted`. It is a fact, written once when the repo is registered, and
+# it never changes — a repo that is later handed over was still created here. Nothing decides
+# anything from it; it is recorded so a later reader can tell why a repo looks the way it does.
+#
+# `control:` (per row) records whether Throughstone **controls** a repo — whether it may write what
+# its needs require into it. `managed` means yes, asked once per repository and never per file;
+# `external` means the repo is recorded and referenced but never written into. Control is a state
+# that changes over time, not a fact about who created the repo — a repo Throughstone created can be
+# handed over, and a repo it never created can be placed under its care.
+#
+# **A missing `control:` reads as `external`**, because control is a permission and an unanswered
+# permission is not granted: the method records the repo and writes nothing into it until someone
+# answers. A defaulted row is surfaced rather than silently accepted. (Unrelated to the top-level
+# `throughstone:` key in `.throughstone/manifest.yml`, which versions the method itself — different
+# file, different scope.)
+#
+# `provides:` (per row) records how each of the three needs — README, licensing, CI — is met in that
+# repo. One entry per need, each carrying a status and a note:
+#
+#     ours       Throughstone provided it
+#     extended   it was already there and Throughstone added to it — for a README, the
+#                `## Role in <project>` section, through to the next `##`
+#     theirs     already met by what is there; nothing of ours in it
+#     N/A        the need structurally does not apply. Uppercase, matching the method's spelling
+#                everywhere else, and CI only — README and licensing apply to every repo
+#     gap        unmet, and recorded as unmet
+#
+# `gap` and `N/A` **must** carry a note saying why. Every other entry carries one when the need is
+# met some way that is not obvious from the repo itself. Two invariants hold across the pair of
+# fields: a `managed` repo has no `gap` — either the need is met, or the repo is `external` — and an
+# `external` repo has no `ours` and no `extended`, because both mean an artifact Throughstone
+# maintains, which it cannot do in a repo it may not write into.
+#
+# `origin:` and `control:` go on **every** row. `provides:` goes only on a row whose `location` is
+# a repository — in a mono-repo-for-now workspace the rows below are folders inside the single repo,
+# so they carry none until a split makes them repos of their own. The rows this file ships with
+# carry no `provides:` in either layout: the method's own repos are described by the method itself,
+# and a status written before anyone had looked at a repo would be a guess rather than a record.
+#
+# Rules for anything that reads or rewrites this file. The scripts that read it match line prefixes
+# and do not parse YAML, so all five are load-bearing:
+#
+# 1. **No line inside a row block may begin, after leading whitespace, with a row-level field name
+#    followed by a colon**, whatever the nesting says. A note whose text began
+#    `location: /srv/acme/LICENSE` would be read as that row's location and cloned into.
+# 2. **Every value is a single-line scalar, and `provides:` entries are flow mappings** — the form
+#    in the example row below. A flow mapping cannot hold a block scalar, so a note cannot span
+#    lines, which makes rule 1 impossible to violate rather than merely discouraged.
+# 3. **Comment lines are skipped** (`^[[:space:]]*#`). The example row below is fully formed and
+#    commented out one `#` per line; a reader that counted it as a row would report it missing
+#    every field.
+# 4. **Row-level names and nested key names are two disjoint reserved sets, and adding a name to
+#    either is checked against the other — here, at the time it is added.** Today row-level is
+#    `name`, `location`, `type`, `description`, `remote`, `provenance`, `origin`, `control`,
+#    `provides`; nested is `from`, `split_on`, `split_commit`, `archive_remote`, `readme`,
+#    `license`, `ci`, `status`, `note`. The check is what carries forward, not the lists.
+# 5. **Anything that rewrites this file anchors on the row block** — from a row's `- name:` to the
+#    next `- name:`, respecting indentation — and never on a bare line prefix.
 
 repos:
   - name: "{{PROJECT}}-docs"
     location: "Code/{{PROJECT}}-docs/"
-    type: docs            # docs | service | library | app | infra | tests
+    type: docs            # docs | service | library | app | infra | tests | mono
+    origin: created
+    control: managed
     description: "Documentation hub: architecture, ADRs, standards, registries."
 
   - name: "prompts"
     location: "prompts/"
     type: docs
+    origin: created
+    control: managed
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
   # Service / app / library repos get added here as the architecture names them and they
@@ -44,8 +108,14 @@ repos:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service
+  #   origin: created                                      # created | adopted — written once
+  #   control: managed                                     # managed | external — absent reads as external
   #   remote: "git@example.com:TEAM/{{PROJECT}}-api.git"   # team mode: setup-workspace.sh clones this
   #   description: "..."
+  #   provides:                                            # only on a row whose location is a repo
+  #     readme:  { status: ours,   note: "" }
+  #     license: { status: theirs, note: "posture recorded project-wide in .throughstone/project-license" }
+  #     ci:      { status: ours,   note: "" }
   #   provenance:                                          # only on a repo that was split out
   #     from: "{{PROJECT}}-web"                            # the repo this used to be part of
   #     split_on: "2026-01-31"


### PR DESCRIPTION
`registries/repos.yml` gains three per-row fields, and its header gains the schema that documents
them. **Nothing reads them yet** — this is the record the repo-control work is built on.

## The fields

- **`origin:`** (`created` | `adopted`) — whether Throughstone made the repo or took on one that was
  already there. A fact, written once when the repo is registered, that never changes.
- **`control:`** (`managed` | `external`) — whether Throughstone may write into that repo. `managed`
  is a standing permission, asked once per repository and never per file; `external` means the repo
  is recorded and referenced in full and never written into. Control is a state that changes over
  time rather than a fact about who created the repo, so a repo the method built can be handed over
  and a repo it never built can be placed under its care. **A missing `control:` reads as
  `external`**, because control is a permission and an unanswered permission is not a granted one.
- **`provides:`** — how each of a repo's three needs (a README, a stated licensing posture, a
  described CI gate) is actually met there, as one of `ours` / `extended` / `theirs` / `N/A` / `gap`
  plus a note. `gap` and `N/A` must say why.
  A key may also be legitimately **absent**, and absent is not `gap`: `gap` is an observation that
  the need is unmet, while an absent key is an observation still owed — filled in by looking at the
  repo, never by picking a status to complete the set.

`origin:` and `control:` go on every row. `provides:` goes only on a row whose `location` is a
repository, and never on a row `init.sh` seeds — a status written before anyone had looked at the
repo would be a guess rather than a record. Two invariants hold across the pair: a `managed` repo has
no `gap`, and an `external` repo has no `ours` and no `extended`.

`mono` joins the `type:` enum, for the workspace root of a mono-repo-for-now project.

## The five parser rules

The header also carries the rules anything reading or rewriting this file has to follow.
`registries/repos.yml` is read by scripts that match line prefixes and know nothing about YAML
nesting, so these are load-bearing rather than stylistic — see below.

## Verification

Four generated projects, built from `git archive` rather than the working tree, and deliberately not
all-default:

| Configuration | `init.sh` | `check.sh` |
|---|---|---|
| multi-repo, private posture | ok | 0 fail, 0 warning |
| mono, private posture | ok | 0 fail, 0 warning |
| multi-repo, Apache-2.0 | ok | 0 fail, 0 warning |
| mono, Apache-2.0, `--registries=no` | ok | 0 fail, 0 warning |

Doctor output is **byte-identical to `main`** in all four apart from the fixture path. Seeded rows
carry `origin: created` / `control: managed` and no `provides:`, in both layouts, with no
unsubstituted placeholders.

Both live parsers were run against the finished file with a fully populated adopted row whose licence
note contains an absolute path: `setup-workspace.sh`'s clone loop yields exactly the intended pair
and does not pick that path up, and `init.sh`'s `record_registry_remote` inserts into the correct row
block and leaves valid YAML.

**Rule 1 was deliberately broken, to confirm it earns its place.** A note written as a block scalar
whose text begins `location: /tmp/…` makes `setup-workspace.sh` clone the repo to *that* path instead
of its own — silently, exit 0. Keeping every value a single-line scalar with each `provides:` entry a
flow mapping makes that unreachable, since YAML rejects a block scalar inside a flow mapping.

Suite green 12/12, unchanged from the baseline measured on `main` before the change.

## Upgrading

Existing rows are not rewritten. `UPDATING-THROUGHSTONE.md`'s 1.8 section covers adding the fields to
a project you already have, and says plainly that `origin:` and `control:` are the two worth adding
by hand while `provides:` can wait for the next check-in.

