### PR TITLE
Ship registries/ with every project, and record the mono root repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,19 @@ any project built with it.
   reading a session file now finds the work list under one name instead of learning a per-file name.
   `METHOD.md` §4 records the skeleton as part of the contract for adding a session, and a new
   maintainer test enforces it.
+- **`registries/` now ships with every project, and `--registries` is deprecated.** The flag pruned
+  the directory in mono-repo layout, on the reasoning that one self-contained repo has no siblings
+  to inventory. But `registries/` is not only `repos.yml`: pruning it also took `risks.yml`, the
+  accepted-risk and tech-debt register, and `security-reviews.yml`, the security-review ledger —
+  two registers that reasoning never covered, and that the docs hub's own index, `METHOD.md` and
+  several runbooks reference unconditionally. A project bootstrapped with `--registries=no` started
+  life citing files it did not have, and `scripts/check.sh` called it clean. The directory now
+  always ships, in both layouts, and the interactive mono-repo question offering to drop it is
+  gone. `--registries` still parses, so an existing scripted bootstrap keeps working: `yes` is
+  accepted silently, `no` keeps the directory and prints a deprecation notice, and an unrecognized
+  value is an error. That last part is a small behavior change — the value used to be checked only
+  in mono-repo layout, so `--registries=maybe --layout=multi` was silently accepted and now fails
+  the way mono-repo already did.
 
 ### Fixed
 - **`init.sh` could destroy a repository it was run inside.** Unpacking the template into a
@@ -124,10 +137,10 @@ any project built with it.
 - **`init.sh`'s closing backup tip was wrong for a mono-repo project.** It told every project to
   "create empty repos on your host, add their URLs to `registries/repos.yml`, and push each local
   repo's `main` branch" — which is what `runbooks/collaboration.md` §9 expressly tells a mono
-  project *not* to do, since those rows describe folders inside the one repo rather than repos to
-  clone. The tip is now layout-conditional: mono is told to create one repo, push the root repo's
-  trunk, and leave the registry rows alone. The mono + team kickoff note stopped citing the
-  repealed split-before-a-teammate rule in the same change — the observation under it still holds
+  project *not* to do, since no row in that file is a repo to clone. The tip is now
+  layout-conditional: mono is told to create one repo, push the root repo's trunk, and leave the
+  registry rows alone. The mono + team kickoff note stopped citing the repealed
+  split-before-a-teammate rule in the same change — the observation under it still holds
   and is still printed, but it now points at the fallback `collaboration.md` §4 prescribes rather
   than telling you to split.
 - **`11-interface-contracts.md` punctuation drift.** Its go-ahead paragraph had ASCII hyphens where
@@ -153,6 +166,30 @@ any project built with it.
   written like every other header field, so the literal phrase never appears, and now that its value
   is a sentence it is further still from matching. The sweep now reads the `Coverage:` **field** and
   takes anything other than `full`, which is what stops a deferral from quietly becoming permanent.
+- **A mono-repo project's method-integrity gate had never run.** `method-check.yml` ships inside the
+  docs hub, at `Code/<project>-docs/.github/workflows/`. In a multi-repo project the hub is its own
+  repository, so that path is a repository root and the workflow is live the moment you push it. In
+  a mono-repo-for-now project the workspace root is the repository and the hub is a folder inside
+  it — and GitHub reads workflows only at a repository root, so nothing ever triggered and no run
+  ever appeared to be missing. The manual copy was documented, but only in the workflow's own header
+  comment and `templates/ci/README.md`, neither of which is where you look to find out whether your
+  CI exists. `init.sh` now places the workflow at the workspace root when it creates a mono-repo
+  project, and the docs hub keeps its own copy, which is what gives the hub CI of its own if the
+  project later splits. `init.sh` runs once and never again, so nothing places the file in a project
+  that already exists: `UPDATING-THROUGHSTONE.md`'s 1.8 section carries the one-file copy as a
+  migration step, and says plainly that the first run is likely to report findings that have been
+  accumulating unseen.
+- **A mono-repo project's registry left out the only repository it had.** `registries/repos.yml`
+  calls itself the source of truth for which repos exist, and in a mono-repo-for-now project it
+  listed the docs hub and `prompts/` — both folders — while the workspace root, the project's one
+  actual repository and the only git work tree in it, had no row at all. `init.sh` now seeds that
+  row: `location: "."`, `type: mono`, `origin: created`, `control: managed`, and no `provides:`,
+  which is the carve-out every seeded row gets. Nothing reads the row yet and nothing behaves
+  differently because of it — `scripts/check.sh`, `scripts/links.sh` and the clone parser in
+  `scripts/setup-workspace.sh` were each measured against it, and the parser passes over the row
+  because it carries no `remote:`. Prose describing a mono project's registry rows as folders
+  inside the single repo has been corrected wherever it appeared — the registry header, the setup
+  script's closing tip, the solo-to-team runbook and this file. Existing projects are not rewritten.
 
 ## [1.7.1] - 2026-08-10
 

--- a/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
+++ b/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
@@ -10,9 +10,11 @@
 # sibling `prompts/` repo, so those checks skip here with a note and run in full whenever the
 # whole workspace is checked out (locally, and during the periodic check-in).
 #
-# Mono-repo-for-now project? The workspace root is the single repo, so copy this file to the
-# ROOT `.github/workflows/` (a workflow nested under Code/<project>-docs/ won't trigger there).
-# The run step below auto-detects the doctor path in either layout. See templates/ci/README.md.
+# Mono-repo-for-now project? The workspace root is the single repo, and a workflow nested under
+# Code/<project>-docs/ won't trigger there — so this file also belongs at the ROOT
+# `.github/workflows/`. init.sh puts it there when it creates the project; a project created
+# before it did needs that copy made by hand. The run step below auto-detects the doctor path in
+# either layout. See templates/ci/README.md.
 
 name: method-check
 

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -77,10 +77,11 @@ not fail the check.
 
 ### 1.8 migration
 
-**Upgrading from 1.7? Nothing of yours is rewritten, and there is one small edit worth making** —
-two lines per row in `registries/repos.yml`. Beyond that nothing is required of you unless you are
-about to split a repository. The release adds a runbook for that, repeals one rule, and starts
-recording which of your repos Throughstone may write into. Fast path:
+**Upgrading from 1.7? Nothing of yours is rewritten. There is one small edit worth making** —
+two lines per row in `registries/repos.yml` — **and, if your project is mono-repo-for-now, one
+thing to check**: whether your CI gate has ever actually run. Beyond those, nothing is required of
+you unless you are about to split a repository. The release adds a runbook for that, repeals one
+rule, and starts recording which of your repos Throughstone may write into. Fast path:
 
 1. Pull the process docs as one review-required group (the new `runbooks/splitting-repos.md`,
    `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §9, `prompts/README.md`, and
@@ -88,8 +89,10 @@ recording which of your repos Throughstone may write into. Fast path:
 2. If you were planning to split a repo **only** in order to add a second contributor — stop.
    That rule is gone, and nothing replaces it.
 3. Add `origin:` and `control:` to each row of your `registries/repos.yml` — **details at the end of
-   this section.** It is the only edit 1.8 asks for, and nothing rewrites the file for you.
-4. Nothing else. A project that never splits reads none of the splitting material.
+   this section.** Nothing rewrites the file for you.
+4. **Mono-repo-for-now only: check that `method-check.yml` is at your workspace root.** If it is
+   not, the method-integrity gate has never run on your project — details below.
+5. Nothing else. A project that never splits reads none of the splitting material.
 
 **A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run
 anywhere but a fresh template checkout. Unpacking the template into a repository you already had and
@@ -153,12 +156,29 @@ method to keep maintaining.
 
 **`provides:` can wait for your next check-in.** It records what is in each repo rather than what you
 have decided, so it is filled in by looking rather than remembering. A row whose `location` is not a
-repository never carries it at all — in a mono-repo-for-now workspace the rows below `repos:` are
-folders inside the one repo until you split.
+repository never carries it at all — in a mono-repo-for-now workspace a row pointing at a folder
+inside the one repo is not one, and carries none until a split makes it a repo of its own.
 
 Adding the fields is a **safe additive edit**: it inserts lines into each row and changes no existing
 data. `registries/repos.yml` is your project's own record, like `inputs/inputs-index.md`, so it is
 **never auto-overwritten**.
+
+**Mono-repo-for-now? Your CI gate has probably never run.** `method-check.yml` ships inside the docs
+hub, at `Code/<project>-docs/.github/workflows/`. In a multi-repo project the hub is its own
+repository, so that is a repository root and the workflow is live from day one. In a mono-repo-for-now
+project the workspace root is the repository and the hub is a folder inside it — and **GitHub reads
+workflows only at a repository root**, so a workflow nested that deep never triggers. Unless you
+followed the manual copy step (it is documented, but only in the workflow's own header comment and
+`templates/ci/README.md`), the gate has been silently absent for the life of the project.
+
+**Copy `Code/<project>-docs/.github/workflows/method-check.yml` to `.github/workflows/` at your
+workspace root, and commit it.** No edit is needed: the workflow finds the doctor in either layout,
+and from the root it also sees `prompts/`, so the STEP-index checks run too. Leave the hub's copy
+where it is — that is the copy that gives the docs hub its own CI if you ever split. Expect the first
+run to report findings that have been accumulating unseen. 1.8 places the file for you in **new**
+mono projects; `init.sh` runs once, so nothing places it in a project that already exists.
+
+Multi-repo projects have nothing to do here.
 
 ### 1.7 migration
 

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -1,4 +1,4 @@
-# Canonical repo inventory for {{PROJECT}} (multi-repo projects).
+# Canonical repo inventory for {{PROJECT}}.
 # The source of truth for which repos exist and what each is — and the index to their docs:
 # each entry's `location` points to a repo whose own README.md (plus an optional
 # ARCHITECTURE.md) is the detailed "about". To orient in a multi-repo project, read this map
@@ -13,9 +13,11 @@
 # verbatim (clones from `remote` into it, or references it in place when there's no remote), so
 # keep `location` and `remote` distinct: a clone URL goes in `remote`, never folded into `location`.
 #
-# Mono-repo-for-now: the entries below are folders inside the single repo, not separate repos
-# yet — this inventory describes the post-split (multi-repo) target. When you do split them
-# apart, follow `runbooks/splitting-repos.md`, and delete this note once the repos are real.
+# Mono-repo-for-now: the row whose `location` is `.` is the workspace root — the one repository
+# the project actually has. The rows below it are folders inside that repository, not separate
+# repos yet, and for those this inventory describes the post-split (multi-repo) target. When you
+# do split them apart, follow `runbooks/splitting-repos.md`, and delete this note once the repos
+# are real.
 #
 # Teams: give each repo a `remote:` field (any cloneable git URL). scripts/setup-workspace.sh clones from
 # it, and the STEP-number reservation in runbooks/collaboration.md relies on a shared remote

--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -279,13 +279,13 @@ flow (§6). The transition is mostly mechanical:
    **Mono-repo-for-now** (`METHOD.md` §7) has one repo, the workspace root, so this is one
    remote rather than several: create it, push the root repo's existing history to it, and have
    each new contributor clone that single repo. Don't add `remote:` fields to
-   `registries/repos.yml` and **don't run `scripts/setup-workspace.sh`** — those rows describe
-   folders inside your one repo rather than repos to clone, and the script is for multi-repo
-   workspaces: run in a mono clone it overwrites the committed root `CLAUDE.md`, `AGENTS.md`
-   and `doctor.sh` with per-machine pointers asserting the root is not a repo. Everything else
-   is the same, including number reservation, which needs a shared remote and not a particular
-   number of them. Whether to split is a separate question, answered by the architecture rather
-   than by the size of the team — see `splitting-repos.md`.
+   `registries/repos.yml` and **don't run `scripts/setup-workspace.sh`** — no row in that file is
+   a repo to clone (one *is* the repository you already have; the rest are folders inside it),
+   and the script is for multi-repo workspaces: run in a mono clone it overwrites the committed
+   root `CLAUDE.md`, `AGENTS.md` and `doctor.sh` with per-machine pointers asserting the root is
+   not a repo. Everything else is the same, including number reservation, which needs a shared
+   remote and not a particular number of them. Whether to split is a separate question, answered
+   by the architecture rather than by the size of the team — see `splitting-repos.md`.
 2. **Have each contributor create their local profile** (`.throughstone/local-user.md`) during
    onboarding. This records their own Experience level and Communication style; do not copy
    the original solo maintainer's preferences into project docs.

--- a/Code/{{PROJECT}}-docs/templates/ci/README.md
+++ b/Code/{{PROJECT}}-docs/templates/ci/README.md
@@ -18,9 +18,11 @@ at `Code/{{PROJECT}}-docs/.github/workflows/method-check.yml`, so in a **multi-r
   docs); the `STEP-index` lives in the `prompts/` repo, so those checks skip here and run in full
   when the whole workspace is checked out (locally and at each check-in).
 - **Mono-repo-for-now:** the workspace root is the single repo, and a workflow nested under
-  `Code/<project>-docs/` does **not** trigger there — **copy** `method-check.yml` to the **root**
-  `.github/workflows/`. The workflow auto-detects `Code/<project>-docs/scripts/check.sh`;
-  from the root, that script sees `prompts/` too, so the STEP-index checks run as well.
+  `Code/<project>-docs/` does **not** trigger there — so `method-check.yml` also belongs at the
+  **root** `.github/workflows/`. `init.sh` puts it there when it creates the project; if yours
+  predates that, **copy** it across by hand — until you do, the gate has never run. The workflow
+  auto-detects `Code/<project>-docs/scripts/check.sh`; from the root, that script sees `prompts/`
+  too, so the STEP-index checks run as well.
 
 ## 2. Code-repo tests — `code-repo-ci.yml`  *(template; stamp per repo)*
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ matching environment variables.
 | `--license=NAME` | `INIT_LICENSE` | `mit`, `bsd-3`, `apache-2.0`, `private` | Project license posture. |
 | `--holder=NAME` | `INIT_HOLDER` | text | Copyright holder for open-source licenses. |
 | `--layout=LAYOUT` | `INIT_LAYOUT` | `multi`, `mono` | Repo layout; default is `multi`. |
-| `--registries=yes\|no` | `INIT_REGISTRIES` | `yes`, `no` | Keep `registries/` in mono-repo mode; default is `yes`. |
+| `--registries=yes\|no` | `INIT_REGISTRIES` | `yes`, `no` | **Deprecated and ignored.** `registries/` always ships in both layouts; `no` keeps the directory and prints a deprecation notice. |
 | `--collab=MODE` | `INIT_COLLAB` | `solo`, `team` | Collaboration wording and ADR authority defaults; default is `solo`. |
 | `--adr-authority=TEXT` | `INIT_ADR_AUTHORITY` | text | Who accepts ADRs in team mode. |
 | `--trunk-branch=NAME` | `INIT_TRUNK_BRANCH` | valid Git branch name | Generated repo trunk branch; default is `main`. |

--- a/init.sh
+++ b/init.sh
@@ -166,7 +166,7 @@ Options:
   --license=NAME        mit | bsd-3 | apache-2.0 | private
   --holder=NAME         Copyright holder (required for open-source licenses)
   --layout=LAYOUT       multi | mono                    (default: multi)
-  --registries=yes|no   Keep registries/ (mono-repo only; default: yes)
+  --registries=yes|no   Deprecated and ignored; registries/ always ships
   --collab=MODE         solo | team                     (default: solo)
   --adr-authority=TEXT  Who accepts ADRs (team only; default: consensus of maintainers)
   --trunk-branch=NAME   Generated repo trunk branch     (default: main)
@@ -420,19 +420,20 @@ else
   LAYOUT="$(ask 'Choose 1 or 2' '1')"
 fi
 
-# registries/ is always kept in multi-repo because setup-workspace.sh and remote recording use
-# it as the sibling-repo inventory. Mono can prune it because the root repo is self-contained.
-KEEP_REGISTRIES=1
-if [ "$LAYOUT" = "2" ]; then
-  if [ -n "$REGISTRIES_IN" ]; then
-    case "$(printf '%s' "$REGISTRIES_IN" | tr '[:upper:]' '[:lower:]')" in
-      y|yes|true|1) KEEP_REGISTRIES=1 ;;
-      n|no|false|0) KEEP_REGISTRIES=0 ;;
-      *) echo "init.sh: invalid --registries '$REGISTRIES_IN' (yes | no)." >&2; exit 2 ;;
-    esac
-  elif [ "$NONINTERACTIVE" != "1" ]; then
-    yesno "Include registries/ (repo inventory; useful for multi-repo)?" || KEEP_REGISTRIES=0
-  fi
+# registries/ always ships, in both layouts. It carries the repo inventory that
+# setup-workspace.sh and remote recording read, plus the accepted-risk and security-review
+# registers — and the docs hub, METHOD.md and several runbooks reference all three
+# unconditionally, so a project without the directory cites files it does not have. The flag is
+# still parsed so existing automation keeps working, and its value is still validated: an
+# unrecognized one is an error in either layout, and `no` is ignored with a deprecation notice.
+if [ -n "$REGISTRIES_IN" ]; then
+  case "$(printf '%s' "$REGISTRIES_IN" | tr '[:upper:]' '[:lower:]')" in
+    y|yes|true|1) : ;;
+    n|no|false|0)
+      echo "init.sh: --registries=no is ignored; registries/ always ships and is kept." >&2
+      echo "         The flag is deprecated and will be removed in a future release." >&2 ;;
+    *) echo "init.sh: invalid --registries '$REGISTRIES_IN' (yes | no)." >&2; exit 2 ;;
+  esac
 fi
 
 # Solo vs. team. This does NOT create a behavioral mode: branch-per-STEP, STEP-number
@@ -809,10 +810,10 @@ if [ -f "$DOCS/LICENSE-THROUGHSTONE" ]; then
   fi
 fi
 
-# --- 4. Prune optional pieces -----------------------------------------------
-# runbooks/ is kept: it now ships method-level runbooks (check-in, collaboration) that
-# AGENTS.md and METHOD.md reference.
-[ "$KEEP_REGISTRIES" = "0" ] && rm -rf "$DOCS/registries" && echo "  pruned registries/"
+# --- 4. Stamp per-project options -------------------------------------------
+# Nothing is pruned here. runbooks/ ships method-level runbooks (check-in, collaboration) that
+# AGENTS.md and METHOD.md reference, and registries/ ships the repo inventory and the risk and
+# security-review registers that the docs hub and those same runbooks cite unconditionally.
 
 # Replace the visible ADR authority marker, not arbitrary prose. Solo records the default
 # single-author posture; team records the selected acceptance authority for future handoffs.
@@ -845,6 +846,36 @@ fi
 if [ ! -f "prompts/STEP-index.md" ]; then
   cp "$DOCS/templates/step-index-seed.md" "prompts/STEP-index.md"
   echo "  created prompts/STEP-index.md (seeded from template)"
+fi
+
+# --- 5c. Mono-repo-for-now layout files -------------------------------------
+# In this layout the workspace root is the project's one repository, so two things multi-repo
+# gets for free have to be placed here before the initial commit.
+if [ "$LAYOUT" = "2" ]; then
+  # The registry calls itself the source of truth for which repos exist, and until now it
+  # omitted the only repository a mono project has. A seeded row carries no `provides:` — a
+  # status written before anyone has looked at a repo is a guess, not a record.
+  if [ -f "$DOCS/registries/repos.yml" ]; then
+    SLUG="$SLUG" perl -0pi -e '
+      my $row = qq{  - name: "$ENV{SLUG}"\n}
+              . qq{    location: "."\n}
+              . qq{    type: mono\n}
+              . qq{    origin: created\n}
+              . qq{    control: managed\n}
+              . qq{    description: "The workspace root: the one repository this project lives in until it is split."\n\n};
+      s{^repos:\n}{repos:\n$row}m;
+    ' "$DOCS/registries/repos.yml"
+    echo "  registry: recorded the workspace root repo"
+  fi
+  # GitHub reads workflows only at a repository root, and step 2 removed .github along with the
+  # template's own health files — so the method-check gate has never actually run in a mono
+  # project. The docs hub keeps its own copy, which is what gives it CI after a split; the
+  # workflow's run step finds the doctor in either layout.
+  if [ -f "$DOCS/.github/workflows/method-check.yml" ]; then
+    mkdir -p "$ROOT/.github/workflows"
+    cp "$DOCS/.github/workflows/method-check.yml" "$ROOT/.github/workflows/method-check.yml"
+    echo "  CI: method-check workflow placed at the workspace root"
+  fi
 fi
 
 # --- 6. Initialise repo(s) --------------------------------------------------
@@ -1057,12 +1088,12 @@ else
 fi
 
 # --- 7. Done ----------------------------------------------------------------
-# Mono keeps ONE shared remote for the single root repo; registries/repos.yml's rows are folders
-# inside it, not repos to clone (runbooks/collaboration.md §9).
+# Mono keeps ONE shared remote for the single root repo. registries/repos.yml records that repo
+# and the folders inside it; no row in it is a repo to clone (runbooks/collaboration.md §9).
 if [ "$LAYOUT" = "2" ]; then
   REMOTE_TIP="If you did not set up remotes during init, create one empty repo on your host
   and push the root repo's ${TRUNK_BRANCH} branch to it. Leave registries/repos.yml's rows
-  alone — they describe folders inside your one repo, not repos to clone."
+  alone — they record your one repo and the folders inside it, not repos to clone."
 else
   REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
   their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -263,6 +263,133 @@ run_mono_case() {
   assert_maintainer_tests_removed "$name" "$work"
 }
 
+# first_registry_row FILE — print the first repo row block. Rows start at column-2 `- name:`;
+# the commented example row is indented behind a `#` and so is never picked up.
+first_registry_row() {
+  awk '/^[[:space:]]*-[[:space:]]*name:/ { n++ } n == 1' "$1"
+}
+
+# run_registry_mono_case — registries/ always ships and the deprecated flag only warns; the mono
+# layout additionally gets the two things its single-repo shape needs — a registry row for the
+# workspace root, which is the only repository it has, and the method-check workflow somewhere
+# GitHub will actually read it.
+run_registry_mono_case() {
+  local name="registry-mono"
+  local work="$TMP_ROOT/$name"
+  local reg root_row field
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Registry seeding test" \
+      --license=bsd-3 \
+      --holder="Throughstone Test" \
+      --layout=mono \
+      --collab=team \
+      --adr-authority="the CTO" \
+      --registries=no \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  # The flag is accepted, ignored, and says so. It used to delete the whole directory, taking the
+  # risk and security-review registers with it — both cited unconditionally by the generated docs.
+  grep -Fq -- "--registries=no is ignored" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not warn that --registries=no is ignored" >&2
+    return 1
+  }
+  for field in repos.yml risks.yml security-reviews.yml; do
+    [ -f "$work/Code/$name-docs/registries/$field" ] || {
+      echo "FAIL: $name pruned registries/$field" >&2
+      return 1
+    }
+  done
+
+  # The workspace root leads the inventory. Being a seeded row it carries no `provides:`, and with
+  # no `remote:` the clone parser in setup-workspace.sh passes over it.
+  reg="$work/Code/$name-docs/registries/repos.yml"
+  root_row="$(first_registry_row "$reg")"
+  for field in "name: \"$name\"" 'location: "."' 'type: mono' 'origin: created' 'control: managed'; do
+    printf '%s\n' "$root_row" | grep -Fq "$field" || {
+      echo "FAIL: $name workspace-root row is missing $field" >&2
+      printf '%s\n' "$root_row" >&2
+      return 1
+    }
+  done
+  for field in 'provides:' 'remote:'; do
+    if printf '%s\n' "$root_row" | grep -Fq "$field"; then
+      echo "FAIL: $name workspace-root row carries $field" >&2
+      return 1
+    fi
+  done
+
+  # A workflow nested under Code/<project>-docs/ never triggers when the workspace root is the
+  # repository. The hub keeps its copy: that is what gives the hub CI of its own after a split.
+  cmp -s "$work/.github/workflows/method-check.yml" \
+    "$work/Code/$name-docs/.github/workflows/method-check.yml" || {
+    echo "FAIL: $name did not place the docs hub's method-check.yml at the workspace root" >&2
+    return 1
+  }
+  git -C "$work" ls-files --error-unmatch .github/workflows/method-check.yml >/dev/null 2>&1 || {
+    echo "FAIL: $name left the root method-check.yml out of the initial commit" >&2
+    return 1
+  }
+
+  # The new row must change nothing the shipped tooling reports. check.sh exits 0 on warnings, so
+  # assert the summary line rather than the status.
+  ( cd "$work" && bash "Code/$name-docs/scripts/check.sh" ) >"$TMP_ROOT/$name-check.out" 2>&1 || true
+  grep -Fq "0 fail(s), 0 warning(s)" "$TMP_ROOT/$name-check.out" || {
+    echo "FAIL: $name doctor was not clean with the workspace-root row present" >&2
+    cat "$TMP_ROOT/$name-check.out" >&2
+    return 1
+  }
+
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
+# run_registry_multi_case — the same flag in the other layout: still ignored, still warns, and
+# neither of the mono-only additions appears. The workspace root is not a repository here.
+run_registry_multi_case() {
+  local name="registry-multi"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Registry seeding test" \
+      --license=apache-2.0 \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --registries=no \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  grep -Fq -- "--registries=no is ignored" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not warn that --registries=no is ignored" >&2
+    return 1
+  }
+  [ -f "$work/Code/$name-docs/registries/repos.yml" ] || {
+    echo "FAIL: $name pruned registries/ in multi-repo layout" >&2
+    return 1
+  }
+  if grep -Fq 'location: "."' "$work/Code/$name-docs/registries/repos.yml"; then
+    echo "FAIL: $name seeded a workspace-root row in multi-repo layout" >&2
+    return 1
+  fi
+  [ ! -e "$work/.github" ] || {
+    echo "FAIL: $name created a workspace-root .github in multi-repo layout" >&2
+    return 1
+  }
+
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
 # run_visibility_case NAME VISIBILITY — verify GitHub repo creation receives the requested
 # visibility flag for both generated multi-repo remotes.
 run_visibility_case() {
@@ -594,6 +721,12 @@ run_flag_case \
 run_mono_case
 run_private_mono_case
 
+# --- registries/ always ships ------------------------------------------------
+# The directory carries the repo inventory and the risk / security-review registers, all of which
+# the generated docs cite unconditionally. --registries survives as a deprecated no-op.
+run_registry_mono_case
+run_registry_multi_case
+
 # --- GitHub visibility behavior ----------------------------------------------
 # Visibility is remote metadata. It must not change the selected project-license posture.
 run_visibility_case "visibility-public" "public"
@@ -631,6 +764,31 @@ set -e
 [ -d "$invalid_work/Code/{{PROJECT}}-docs" ]
 assert_maintainer_tests_retained "license-invalid-flag" "$invalid_work"
 grep -Fq "invalid --license 'not-a-license'" "$TMP_ROOT/license-invalid-flag.out"
+
+# A deprecated flag still validates its value, and does it in both layouts. The check used to run
+# only in mono-repo mode, so a multi-repo caller could pass anything and be silently ignored.
+registry_invalid_work="$TMP_ROOT/registry-invalid-flag"
+copy_template "$registry_invalid_work"
+set +e
+(
+  cd "$registry_invalid_work"
+  ./init.sh \
+    --non-interactive \
+    --slug="registry-invalid-flag" \
+    --desc="Registry validation test" \
+    --license=private \
+    --layout=multi \
+    --registries=maybe \
+    --collab=solo \
+    --remotes=no
+) >"$TMP_ROOT/registry-invalid-flag.out" 2>&1
+registry_invalid_status=$?
+set -e
+
+[ "$registry_invalid_status" -eq 2 ]
+[ -d "$registry_invalid_work/Code/{{PROJECT}}-docs" ]
+assert_maintainer_tests_retained "registry-invalid-flag" "$registry_invalid_work"
+grep -Fq "invalid --registries 'maybe'" "$TMP_ROOT/registry-invalid-flag.out"
 
 missing_template_work="$TMP_ROOT/license-missing-template"
 copy_template "$missing_template_work"


### PR DESCRIPTION
## What this changes

`registries/` could be pruned in mono-repo layout, on the reasoning that one self-contained repo has no siblings to inventory. But the directory is not only `repos.yml`: pruning it also took `risks.yml`, the accepted-risk and tech-debt register, and `security-reviews.yml`, the security-review ledger — two registers that reasoning never covered, and that the docs hub's own index, `METHOD.md` and several runbooks reference unconditionally. A project bootstrapped that way started life citing files it did not have, and `scripts/check.sh` called it clean.

It now always ships, in both layouts. The interactive mono-repo question offering to drop it is gone. `--registries` still parses, so an existing scripted bootstrap keeps working.

Guaranteeing the directory is what makes the next two fixes possible.

## Two mono-repo-for-now gaps that close with it

**The registry left out the only repository the project had.** `registries/repos.yml` calls itself the source of truth for which repos exist, and in a mono project it listed the docs hub and `prompts/` — both folders — while the workspace root, the project's one actual repository and the only git work tree in it, had no row. `init.sh` now seeds it: `location: "."`, `type: mono`, `origin: created`, `control: managed`, and no `provides:`, which is the carve-out every seeded row gets.

**The method-integrity gate had never run.** `method-check.yml` ships inside the docs hub. In multi-repo the hub is its own repository, so that is a repository root and the workflow is live. In mono the workspace root is the repository and the hub is a folder inside it — and GitHub reads workflows only at a repository root, so nothing ever triggered, and no absent run ever looked absent. `init.sh` now places the workflow at the workspace root before the initial commit. The hub keeps its own copy, which is what gives the hub CI of its own if the project later splits — that is why this is a copy and not a move; `splitting-repos.md` never mentions the file, so a move would leave the hub with no CI and nothing to restore it.

## One small behavior change

`--registries`'s value used to be validated only in mono-repo layout. Measured on `main`: `--layout=multi --registries=maybe` exits **0** silently, `--layout=mono --registries=maybe` exits 2. The flag is layout-independent now and the code has to interpret the value anyway to decide whether to warn, so an unrecognized value is an error in both. Called out in the changelog entry.

The deprecation notice says the flag goes "in a future release" rather than naming a version, since that decision isn't settled.

## Release notes

Both are in this PR: a `CHANGELOG.md` entry under **Changed** and two under **Fixed**, and an `UPDATING-THROUGHSTONE.md` migration step. The migration matters — `init.sh` runs once, so **nothing places the workflow in a project that already exists**. A mono project upgrading is told, in plain terms, that its gate has never run and to copy one file. That also falsified two sentences already in the 1.8 section ("there is one small edit worth making", "It is the only edit 1.8 asks for"); both are corrected here rather than left for later.

## Prose corrections

The workspace-root row *is* a repository, so every passage saying a mono project's registry rows are folders inside the single repo stops being true of it. A repo-wide sweep found five, all corrected: the registry header, `init.sh`'s closing backup tip, `runbooks/collaboration.md`'s solo-to-team section, the migration guide, and an unreleased changelog entry. Separately, the workflow's own header comment and `templates/ci/README.md` told a mono user to copy the file by hand — an instruction that would have shipped already satisfied, with the header comment travelling *inside* the copy that lands at the root. Both now say the setup script places it and name the manual copy as the older project's path.

## Verification

Suite green **12/12**.

Five configurations exercised on `git archive` fixtures, none all-default — mono/BSD-3/team with `--registries=no`, multi/Apache-2.0 with `--registries=no`, mono/proprietary with no flag, `--registries=maybe` in both layouts, and interactive mono:

- With the new row present, `check.sh` reports 0 fail / 0 warning, `links.sh` 0 fail, and `setup-workspace.sh`'s clone parser yields nothing — the row carries no `remote:`.
- `init.sh`'s own `record_registry_remote` was run against a registry containing the row: it neither matched nor disturbed it.
- The root workflow is byte-identical to the hub's, tracked by the initial commit, and its run step selects the hub's `check.sh` and reports clean when executed from the root.
- Multi-repo gets neither the row nor a root `.github`.
- An invalid flag value exits 2 with the template intact, in both layouts.

`tests/init-license-validation.sh` gains a mono case, a multi-repo case and an invalid-value case. Every new assertion was checked against a deliberately broken `init.sh` — no row, no workflow, moved instead of copied, no deprecation notice, a row seeded in the wrong layout, the workflow placed after the initial commit, and the directory pruned again — and each mutation fails the test for its own reason.

## Where to look first

`init.sh`'s new section 5c: it runs on the one path where a mistake is expensive, and it writes into the generated project before its first commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
