### PR TITLE
Check the repo registry in the project doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,34 @@ any project built with it.
   fields to a project you already have.
 
 ### Changed
+- **The doctor now checks the repo registry, and a bad row fails the build.** `registries/repos.yml`
+  records who owns each repo and what it already provides, and until now nothing read any of it. A
+  row could say Throughstone controls a repo *and* that one of that repo's needs is unmet — a
+  combination the file's own schema forbids — and the project would report clean. `scripts/check.sh`
+  gains three checks. The first reads the file only, so it holds everywhere the doctor runs, CI
+  included: statuses come from the closed set, `origin:` and `control:` do too, a `managed` repo has
+  no `gap`, an `external` repo has no `ours` or `extended`, and `gap` and `N/A` say why. The second
+  looks at disk: a row whose `location` is the root of a git work tree, and that Throughstone adopted
+  rather than created, has to record what that repo provides — naming the individual missing entry
+  rather than the row, because an entry is left out on purpose while the observation is still owed.
+  Rows whose location is not on the machine running the doctor are skipped, counted, and said out
+  loud, since silence about them is indistinguishable from a pass. Missing fields are a warning;
+  fields that contradict each other are a failure.
+  The third check is about the file's shape rather than its contents, and it closes a real hole: the
+  scripts that read this registry match line prefixes and know nothing about YAML nesting, so a note
+  written across several lines whose text happened to begin `location: /srv/acme/LICENSE` made
+  `scripts/setup-workspace.sh` clone a repository into that path — exit 0, no warning. The registry's
+  header has carried rules against this since the fields were added; three of the five are properties
+  of the file and are now enforced. Values must be single-line, `provides:` entries must be flow
+  mappings, no line inside a row may begin with a row-level field name, and row-level and nested
+  names stay disjoint. Those fail rather than warn: a violation is a clone to the wrong folder, not
+  a thin record. The two remaining rules constrain the scripts rather than the file and stay prose,
+  because a checker reading the registry cannot see them.
+  The reserved name sets are read from the registry header's own `reserved-row-level:` and
+  `reserved-nested:` lines, so there is one list, it sits where the schema is, and removing or
+  overlapping it fails loudly instead of quietly disarming the checks.
+  `scripts/check.sh` also gains its first test.
+
 - **The interactive setup no longer licenses your project open source by default.** `init.sh` asks
   whether the project is open source or private/proprietary, and that question used to default to
   open source, with the license question after it defaulting to MIT — so two bare Enters granted

--- a/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
+++ b/Code/{{PROJECT}}-docs/.github/workflows/method-check.yml
@@ -2,7 +2,9 @@
 # and pull request, so structural drift fails the build instead of slipping through review:
 # duplicate STEP/ADR numbers, invalid statuses, architecture docs missing Version/Status/
 # Version-Log, an ADR registry that disagrees with the files on disk, architecture-session
-# numbering drift, and incomplete conditional-session template contracts.
+# numbering drift, incomplete conditional-session template contracts, and repo-registry rows
+# that contradict themselves or are shaped so the scripts reading registries/repos.yml by line
+# prefix would misread them.
 #
 # This file ships LIVE in the docs-hub repo — it is active from day one in a multi-repo project
 # (the hub is its own repo, so this sits at that repo's .github/workflows/). In the hub it

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -78,8 +78,10 @@ not fail the check.
 ### 1.8 migration
 
 **Upgrading from 1.7? Nothing of yours is rewritten. There is one small edit worth making** —
-two lines per row in `registries/repos.yml` — **and, if your project is mono-repo-for-now, one
-thing to check**: whether your CI gate has ever actually run. Beyond those, nothing is required of
+two lines per row in `registries/repos.yml`, which the project doctor now asks for by name —
+**one shape to look at in that same file**, since every value there has to sit on one line —
+**and, if your project is mono-repo-for-now, one thing to check**: whether your CI gate has ever
+actually run. Beyond those, nothing is required of
 you unless you are about to split a repository. The release adds a runbook for that, repeals one
 rule, and starts recording which of your repos Throughstone may write into. Fast path:
 
@@ -90,9 +92,12 @@ rule, and starts recording which of your repos Throughstone may write into. Fast
    That rule is gone, and nothing replaces it.
 3. Add `origin:` and `control:` to each row of your `registries/repos.yml` — **details at the end of
    this section.** Nothing rewrites the file for you.
-4. **Mono-repo-for-now only: check that `method-check.yml` is at your workspace root.** If it is
+4. **If any value in `registries/repos.yml` is wrapped across two lines, join it onto one** and
+   quote it. `scripts/check.sh` now fails on a multi-line value — details at the end of this
+   section. Nothing else in 1.8 can turn a passing run red on its own.
+5. **Mono-repo-for-now only: check that `method-check.yml` is at your workspace root.** If it is
    not, the method-integrity gate has never run on your project — details below.
-5. Nothing else. A project that never splits reads none of the splitting material.
+6. Nothing else. A project that never splits reads none of the splitting material.
 
 **A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run
 anywhere but a fresh template checkout. Unpacking the template into a repository you already had and
@@ -132,9 +137,10 @@ appendix covers purging history first when that matters.
   STEP is branchless, and its number is reserved on trunk), `collaboration.md` §9 gains a mono path
   through solo→team including the warning not to run `scripts/setup-workspace.sh` in a mono clone,
   and `prompts/README.md`'s thin-STEP note now names two families rather than the check-in alone.
-  Apply them as a coherent group; they reference each other. No `status.sh` / `check.sh` change, and
-  no new check — nothing detects registry drift after a split, which is accepted rather than
-  overlooked.
+  Apply them as a coherent group; they reference each other. No `status.sh` change, and no split-
+  specific check: 1.8's new `check.sh` checks read `registries/repos.yml` for its own consistency
+  and shape, and nothing detects registry drift *after a split* — a row that still describes a
+  folder that is now its own repo — which is accepted rather than overlooked.
 - *Project state* (your existing `registries/repos.yml` rows and your repos): never auto-updated.
   `provenance:` is a new optional block recording that a repo was split out of another one — where
   it came from, and where the two histories part company. It is written **at** a split and only
@@ -162,6 +168,33 @@ inside the one repo is not one, and carries none until a split makes it a repo o
 Adding the fields is a **safe additive edit**: it inserts lines into each row and changes no existing
 data. `registries/repos.yml` is your project's own record, like `inputs/inputs-index.md`, so it is
 **never auto-overwritten**.
+
+**What the doctor will say about that file after you pull 1.8.** `scripts/check.sh` reads
+`registries/repos.yml` for the first time in this release, so it will report on rows it has never
+looked at before. Three shapes of finding, and only one of them can fail your run:
+
+- **A row with no `origin:` or `control:` is a warning**, listed by name, and a warning does not
+  change the exit code. The message says those rows carry no control record. It is **not** a
+  statement about how old your project is — nothing on disk records which version of the method you
+  installed, so the doctor cannot tell a project written before these fields existed from one whose
+  registration simply did not fill them in. Answering the two fields, as above, is what clears it.
+- **A row that contradicts itself is a failure**: a status outside `ours` / `extended` / `theirs` /
+  `N/A` / `gap`, an `origin:` or `control:` that is not one of its two values (a typo counts — it
+  reads as neither), a `managed` repo recording a `gap`, an `external` repo recording `ours` or
+  `extended`, or a `gap` or `N/A` with no note saying why. None of these can arise from leaving the
+  file alone; each one needs a row that was written and is wrong.
+- **A value written across more than one line is a failure.** This is the only finding here that can
+  turn a run red without you having changed anything, so it is worth looking for before you upgrade:
+  a long `description:` written as a YAML block scalar (`description: |`) is the likely case. Put the
+  text on one line and quote it. The reason is not tidiness — the scripts that read this registry
+  match line prefixes and know nothing about YAML nesting, so a wrapped value whose second line began
+  `location: /srv/…` made `scripts/setup-workspace.sh` clone a repository into that path and exit
+  successfully. Single-line values make that impossible rather than merely discouraged.
+
+**Rows for repos that are not on your machine are skipped, counted, and said so** — "2 row(s) not
+present on this machine". The doctor only judges what it can see, so a teammate with three of eight
+repos cloned gets findings about those three and a count for the rest, rather than silence that
+looks like a pass.
 
 **Mono-repo-for-now? Your CI gate has probably never run.** `method-check.yml` ships inside the docs
 hub, at `Code/<project>-docs/.github/workflows/`. In a multi-repo project the hub is its own

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -87,10 +87,16 @@
 #    commented out one `#` per line; a reader that counted it as a row would report it missing
 #    every field.
 # 4. **Row-level names and nested key names are two disjoint reserved sets, and adding a name to
-#    either is checked against the other — here, at the time it is added.** Today row-level is
-#    `name`, `location`, `type`, `description`, `remote`, `provenance`, `origin`, `control`,
-#    `provides`; nested is `from`, `split_on`, `split_commit`, `archive_remote`, `readme`,
-#    `license`, `ci`, `status`, `note`. The check is what carries forward, not the lists.
+#    either is checked against the other — here, at the time it is added.** The two sets are the
+#    two lines directly below. They are the register of record, not a restatement of one: nothing
+#    else lists these names. scripts/check.sh reads them by their `reserved-` prefixes and fails
+#    if the sets overlap, if the file uses a name absent from the matching set, or if either line
+#    is missing — so keep both lines, keep the names space-separated on one line each, and add a
+#    new field to exactly one of them at the time you add it. The check is what carries forward,
+#    not the lists.
+#
+#    reserved-row-level: name location type description remote provenance origin control provides
+#    reserved-nested: from split_on split_commit archive_remote readme license ci status note
 # 5. **Anything that rewrites this file anchors on the row block** — from a row's `- name:` to the
 #    next `- name:`, respecting indentation — and never on a bare line prefix.
 

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -32,8 +32,9 @@ it fixes docs, files bugs, and proves the tests pass.
 > **Start with the mechanical pass.** Run `scripts/check.sh` first — in seconds it catches the
 > *structural* drift this part otherwise checks by hand: duplicate STEP/ADR numbers, invalid
 > statuses, architecture docs missing `Version`/`Status`/Version-Log, and an ADR registry that
-> disagrees with the files on disk, plus architecture-session numbering and conditional-template
-> contract drift. Fix anything it flags, then do the judgment-based review below (which a
+> disagrees with the files on disk, plus architecture-session numbering, conditional-template
+> contract drift, and repo-registry rows that contradict themselves or have never recorded who
+> owns the repo. Fix anything it flags, then do the judgment-based review below (which a
 > script can't: does the doc still describe what the system actually *does*?).
 
 For each **non-`Deprecated`** `architecture/NN-*.md`, compare the doc against the system as it

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -17,6 +17,9 @@
 #   8. Architecture-session template numbers match the STEP-index seed
 #   9. Conditional-session templates expose the metadata generic review gates require
 #  10. overview.md's optional CHECK-IN-CADENCE marker, if present, is a positive integer
+#  11. registries/repos.yml rows are internally consistent (statuses, control/gap invariants)
+#  12. Every repo row records who owns it, and a repo on this machine records what it provides
+#  13. registries/repos.yml is shaped so the scripts that read it by line prefix stay correct
 #
 # Usage:  from anywhere — Code/<project>-docs/scripts/check.sh
 # Exit:   non-zero if any hard check FAILs; warnings alone do not fail the run.
@@ -37,6 +40,7 @@ ARCH_DIR="$DOCS_DIR/architecture"
 ADR_DIR="$DOCS_DIR/adr"
 SESSION_TEMPLATE_DIR="$DOCS_DIR/templates/architecture-sessions"
 STEP_INDEX_SEED="$DOCS_DIR/templates/step-index-seed.md"
+REPOS_REGISTRY="$DOCS_DIR/registries/repos.yml"
 
 shopt -s nullglob
 
@@ -401,6 +405,291 @@ if [ -f "$OVERVIEW" ]; then
   fi
 else
   pass "no overview.md yet (project not initialized?) — skipping check-in cadence check"
+fi
+
+# --- 11-13. Repo registry (registries/repos.yml) ------------------------------
+# The registry is read by scripts that match line prefixes and know nothing about YAML nesting
+# (setup-workspace.sh's clone loop, init.sh's remote recorder), so three things are worth
+# checking: what a row says (11), whether its control record was ever filled in (12), and
+# whether the file is shaped so those readers stay correct (13). Nothing here reads another
+# repository's contents — that stays with the check-in; 12 only asks git whether a location is
+# the root of a work tree.
+#
+# registry_rows FILE flattens the registry once for all three. One tab-separated record per
+# meaningful line inside a row block:
+#     row-number  line-number  class  parent  key  value
+# class is head (the `- name:` line), field (row level), nested (deeper than row level), or
+# other (a line that is not `key: value` at all — a continuation of a multi-line value).
+# Comment lines are skipped, which is the registry's own rule 3: the example row is commented
+# out one `#` per line and is documentation, not data.
+registry_rows() {
+  awk '
+    BEGIN { SQ = sprintf("%c", 39) }
+    function ltrim(s) { sub(/^[[:space:]]+/, "", s); return s }
+    function clean(v) {
+      # A trailing `# ...` comment is stripped only from values carrying no quote and no brace,
+      # so a quoted description or a flow mapping containing a "#" is never truncated.
+      if (v !~ /["{]/ && index(v, SQ) == 0) sub(/[[:space:]]+#.*$/, "", v)
+      sub(/[[:space:]]+$/, "", v)
+      if (v ~ /^".*"$/) return substr(v, 2, length(v) - 2)
+      if (length(v) > 1 && substr(v, 1, 1) == SQ && substr(v, length(v), 1) == SQ)
+        return substr(v, 2, length(v) - 2)
+      return v
+    }
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*-[[:space:]]*name:/ {
+      # The row block starts here, and its field indent is the column the name starts in.
+      rown++
+      base = index($0, "name:") - 1
+      parent = ""
+      printf "%d\t%d\thead\t\tname\t%s\n", rown, NR, clean(ltrim(substr($0, index($0, "name:") + 5)))
+      next
+    }
+    rown == 0 { next }
+    {
+      ind = match($0, /[^ \t]/) - 1
+      t = ltrim($0)
+      if (ind < base) {
+        # Dedenting a line out of the row block does not put it out of reach: the readers match
+        # line prefixes at any indent, so a `location:` at column 0 below the last row is read
+        # as the location of that row, exactly as a nested one is. Reported, not skipped.
+        if (t ~ /^[A-Za-z_][A-Za-z0-9_-]*:([[:space:]]|$)/) {
+          k = t; sub(/:.*$/, "", k)
+          printf "%d\t%d\tstray\t\t%s\t\n", rown, NR, k
+        }
+        next
+      }
+      if (t ~ /^[A-Za-z_][A-Za-z0-9_-]*:([[:space:]]|$)/) {
+        k = t; sub(/:.*$/, "", k)
+        v = t; sub(/^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*/, "", v)
+        if (ind == base) { parent = k; printf "%d\t%d\tfield\t\t%s\t%s\n", rown, NR, k, clean(v) }
+        else             { printf "%d\t%d\tnested\t%s\t%s\t%s\n", rown, NR, parent, k, clean(v) }
+      } else {
+        printf "%d\t%d\tother\t%s\t\t%s\n", rown, NR, parent, t
+      }
+    }
+  ' "$1"
+}
+
+REG_PRESENT=0
+REG_FLAT=""
+if [ -f "$REPOS_REGISTRY" ]; then
+  REG_PRESENT=1
+  REG_FLAT="$(registry_rows "$REPOS_REGISTRY")"
+fi
+
+hdr "11. Repo registry record consistency (registries/repos.yml)"
+# Invariant: a row says one thing about itself. This reads the file only — no filesystem — so it
+# holds everywhere check.sh runs, CI included, and it is the half that carries the control model:
+# control is permission, so a managed repo cannot also record an unmet need.
+if [ "$REG_PRESENT" -eq 0 ]; then
+  warn "no registries/repos.yml — skipping repo registry checks"
+  hint "every project ships registries/; restore the directory from the scaffold, or re-run bootstrap for a project created with --registries=no."
+else
+  reg_bad="$(printf '%s\n' "$REG_FLAT" | awk -F'\t' '
+    BEGIN { SQ = sprintf("%c", 39) }
+    # provides: entries are flow mappings, so status and note are read out of one line.
+    function fmhas(s, key) { return (s ~ (key ":")) }
+    function fmval(s, key,   t, q) {
+      t = s
+      sub(".*" key ":[[:space:]]*", "", t)
+      q = substr(t, 1, 1)
+      if (q == "\"" || q == SQ) { t = substr(t, 2); sub(q ".*$", "", t); return t }
+      sub(/[,}].*$/, "", t)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", t)
+      return t
+    }
+    $3 == "head" { nm[$1] = $6; if ($1 + 0 > maxr) maxr = $1 + 0 }
+    $3 == "field" && $5 == "origin"  { org[$1] = $6; orgln[$1] = $2 }
+    $3 == "field" && $5 == "control" { ctl[$1] = $6; ctlln[$1] = $2 }
+    $3 == "nested" && $4 == "provides" { pv[$1 SUBSEP $5] = $6; pl[$1 SUBSEP $5] = $2; pk[$1] = pk[$1] " " $5 }
+    END {
+      split("created adopted", a, " ");            for (i in a) okorg[a[i]] = 1
+      split("managed external", b, " ");           for (i in b) okctl[b[i]] = 1
+      split("ours extended theirs N/A gap", c, " "); for (i in c) okst[c[i]] = 1
+      for (r = 1; r <= maxr; r++) {
+        if ((r in org) && !(org[r] in okorg))
+          printf "line %d: %s -> origin: \"%s\" is not created or adopted\n", orgln[r], nm[r], org[r]
+        if ((r in ctl) && !(ctl[r] in okctl))
+          printf "line %d: %s -> control: \"%s\" is not managed or external\n", ctlln[r], nm[r], ctl[r]
+        n = split(pk[r], keys, " ")
+        for (j = 1; j <= n; j++) {
+          k = keys[j]; v = pv[r SUBSEP k]; ln = pl[r SUBSEP k]
+          if (!fmhas(v, "status")) {
+            printf "line %d: %s -> provides: %s carries no status\n", ln, nm[r], k
+            continue
+          }
+          st = fmval(v, "status")
+          if (!(st in okst)) {
+            printf "line %d: %s -> provides: %s status \"%s\" is not ours/extended/theirs/N/A/gap\n", ln, nm[r], k, st
+            continue
+          }
+          note = fmhas(v, "note") ? fmval(v, "note") : ""
+          if ((st == "gap" || st == "N/A") && note == "")
+            printf "line %d: %s -> provides: %s is %s and carries no note saying why\n", ln, nm[r], k, st
+          if ((r in ctl) && ctl[r] == "managed" && st == "gap")
+            printf "line %d: %s -> control: managed with a gap in %s\n", ln, nm[r], k
+          if ((r in ctl) && ctl[r] == "external" && (st == "ours" || st == "extended"))
+            printf "line %d: %s -> control: external with %s in %s\n", ln, nm[r], st, k
+        }
+      }
+    }
+  ')"
+  if [ -n "$reg_bad" ]; then
+    fail "inconsistent repo registry row(s):"
+    while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$reg_bad"
+    hint "make each row say one thing: a managed repo has no gap (either the need is met, or the repo is external), an external repo has no ours/extended, and gap/N/A say why. See the schema at the top of registries/repos.yml."
+  else
+    reg_rows="$(printf '%s\n' "$REG_FLAT" | awk -F'\t' '$3 == "head"' | grep -c . || true)"
+    pass "$reg_rows row(s) consistent: statuses, control/gap invariants, notes on gap and N/A"
+  fi
+fi
+
+hdr "12. Repo registry control record (registries/repos.yml)"
+# Invariant: every row records who owns the repo, and a row that is actually a repository on
+# this machine records what it already provides. Absence is a WARN, not a FAIL: it means the
+# record was never filled in, and nothing on disk says when the project was created, so absence
+# cannot be read as age. A row whose location is not on this machine is skipped and counted —
+# staying silent about it is indistinguishable from a pass.
+if [ "$REG_PRESENT" -eq 0 ]; then
+  pass "no registries/repos.yml — nothing to check (reported in check 11)"
+else
+  reg_summary="$(printf '%s\n' "$REG_FLAT" | awk -F'\t' '
+    $3 == "head" { nm[$1] = $6; if ($1 + 0 > maxr) maxr = $1 + 0 }
+    $3 == "field" && $5 == "location" { loc[$1] = $6 }
+    $3 == "field" && $5 == "origin"   { org[$1] = $6 }
+    $3 == "field" && $5 == "control"  { ctl[$1] = $6 }
+    $3 == "nested" && $4 == "provides" { pk[$1] = pk[$1] " " $5 }
+    END { for (r = 1; r <= maxr; r++) printf "%s\t%s\t%s\t%s\t%s\n", nm[r], loc[r], org[r], ctl[r], pk[r] }
+  ')"
+  reg_incomplete=""
+  reg_total=0
+  reg_absent=0
+  reg_here=0
+  while IFS=$'\t' read -r r_name r_loc r_origin r_control r_provides; do
+    [ -n "${r_name:-}" ] || continue
+    reg_total=$((reg_total + 1))
+    miss=""
+    [ -n "${r_origin:-}" ] || miss="${miss}${miss:+; }no origin:"
+    [ -n "${r_control:-}" ] || miss="${miss}${miss:+; }no control:"
+    if [ -z "${r_loc:-}" ]; then
+      miss="${miss}${miss:+; }no location:"
+    else
+      case "$r_loc" in /*) abs="$r_loc" ;; *) abs="$ROOT/$r_loc" ;; esac
+      if [ ! -d "$abs" ]; then
+        reg_absent=$((reg_absent + 1))
+      else
+        reg_here=$((reg_here + 1))
+        # The work-tree-root test is the comparison itself, on physical paths both sides: a
+        # trailing slash, a symlinked workspace root, a repository subdirectory and a plain
+        # folder all answer correctly, and a submodule or linked worktree — where .git is a
+        # file, not a directory — is still a repository.
+        top="$(git -C "$abs" rev-parse --show-toplevel 2>/dev/null)"
+        if [ -n "$top" ] && [ "$top" = "$(cd "$abs" && pwd -P)" ]; then
+          # A repo Throughstone created carries no observation debt; a repo it adopted — or a
+          # row that never said — owes all three, and the missing key is named, because the
+          # register action leaves one out on purpose when it could not look.
+          if [ -z "${r_origin:-}" ] || [ "$r_origin" = "adopted" ]; then
+            for need in readme license ci; do
+              case " ${r_provides:-} " in
+                *" $need "*) : ;;
+                *) miss="${miss}${miss:+; }provides: no $need" ;;
+              esac
+            done
+          fi
+        fi
+      fi
+    fi
+    [ -n "$miss" ] && reg_incomplete="${reg_incomplete}${r_name} -> ${miss}"$'\n'
+  done <<< "$reg_summary"
+  reg_incomplete="${reg_incomplete%$'\n'}"
+  if [ -n "$reg_incomplete" ]; then
+    warn "$(printf '%s\n' "$reg_incomplete" | grep -c .) of $reg_total row(s) carry no control record, or an incomplete one:"
+    while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$reg_incomplete"
+    hint "add origin: and control: to each row, and fill provides: by looking at the repo rather than by picking a status. See the schema at the top of registries/repos.yml, and UPDATING-THROUGHSTONE.md."
+  elif [ "$reg_absent" -eq 0 ]; then
+    pass "all $reg_total row(s) carry a complete control record"
+  else
+    # Claim only what was looked at: a row whose location is not here had its provides: skipped.
+    pass "all $reg_total row(s) carry origin and control; provides: checked on the $reg_here here"
+  fi
+  [ "$reg_absent" -gt 0 ] && printf '         %d of %d row(s) not present on this machine; provides: not checked there\n' "$reg_absent" "$reg_total"
+fi
+
+hdr "13. Repo registry file shape (registries/repos.yml)"
+# Invariant: the file stays readable by parsers that match line prefixes. These FAIL rather than
+# warn — a violation of rule 1 is a clone into the wrong path, not a thin record. The two
+# reserved-name sets are read from the registry header's own `reserved-` lines, which are the
+# register of record for them; rules 3 and 5 are not here because they constrain scripts rather
+# than this file, and a checker reading the registry cannot see them.
+if [ "$REG_PRESENT" -eq 0 ]; then
+  pass "no registries/repos.yml — nothing to check (reported in check 11)"
+else
+  reserved_row="$(sed -n 's/^#[[:space:]]*reserved-row-level:[[:space:]]*//p' "$REPOS_REGISTRY" | head -1)"
+  reserved_nested="$(sed -n 's/^#[[:space:]]*reserved-nested:[[:space:]]*//p' "$REPOS_REGISTRY" | head -1)"
+  if [ -z "$reserved_row" ] || [ -z "$reserved_nested" ]; then
+    fail "registry header has no reserved-row-level: / reserved-nested: line — the reserved name sets cannot be read"
+    hint "restore both lines under rule 4 at the top of registries/repos.yml, one space-separated list each; scripts/check.sh reads them by those prefixes."
+  else
+    # tr rather than word-splitting: an unquoted expansion here would also glob against the
+    # working directory if a name ever picked up a wildcard character.
+    to_lines() { printf '%s' "$1" | tr -s '[:space:]' '\n'; }
+    overlap="$(comm -12 <(emit "$(to_lines "$reserved_row")") <(emit "$(to_lines "$reserved_nested")") | tr '\n' ' ')"
+    reg_shape="$(printf '%s\n' "$REG_FLAT" | awk -F'\t' -v rowset="$reserved_row" -v nestset="$reserved_nested" '
+      BEGIN {
+        n = split(rowset, a, /[[:space:]]+/);  for (i = 1; i <= n; i++) if (a[i] != "") rowlvl[a[i]] = 1
+        m = split(nestset, b, /[[:space:]]+/); for (i = 1; i <= m; i++) if (b[i] != "") nested[b[i]] = 1
+      }
+      $3 == "head" { nm[$1] = $6; seen[$1 SUBSEP "name"] = 1 }
+      $3 == "field" {
+        # Two row-level fields of one name in one block: every reader takes the last one.
+        if (($1 SUBSEP $5) in seen)
+          printf "1\tline %d: %s -> a second row-level %s: in the same row block\n", $2, nm[$1], $5
+        seen[$1 SUBSEP $5] = 1
+        if (!($5 in rowlvl))
+          printf "4\tline %d: %s -> row-level field %s: is not in reserved-row-level\n", $2, nm[$1], $5
+        if ($6 ~ /^[|>]/)
+          printf "2\tline %d: %s -> %s: opens a block scalar; values are single-line\n", $2, nm[$1], $5
+      }
+      $3 == "nested" {
+        if ($5 in rowlvl)
+          printf "1\tline %d: %s -> nested %s: shadows a row-level field name\n", $2, nm[$1], $5
+        else if (!($5 in nested))
+          printf "4\tline %d: %s -> nested key %s: is not in reserved-nested\n", $2, nm[$1], $5
+        if ($6 ~ /^[|>]/)
+          printf "2\tline %d: %s -> %s: opens a block scalar; values are single-line\n", $2, nm[$1], $5
+        if ($4 == "provides" && $6 !~ /^\{.*\}$/)
+          printf "2\tline %d: %s -> provides: %s is not a flow mapping { status: ..., note: ... }\n", $2, nm[$1], $5
+      }
+      $3 == "other" { printf "2\tline %d: %s -> not a single-line key: value\n", $2, nm[$1] }
+      $3 == "stray" {
+        if ($5 in rowlvl)
+          printf "1\tline %d: %s -> %s: sits outside any row block and would still be read as that row\n", $2, nm[$1], $5
+      }
+    ')"
+    shape_ok=1
+    if [ -n "$overlap" ]; then
+      fail "reserved-row-level and reserved-nested share name(s): $overlap"
+      shape_ok=0
+    fi
+    for rule in 1 2 4; do
+      hits="$(printf '%s\n' "$reg_shape" | awk -F'\t' -v r="$rule" '$1 == r { print $2 }')"
+      [ -n "$hits" ] || continue
+      case "$rule" in
+        1) fail "row-level field name(s) used where a reader would misread them (rule 1):" ;;
+        2) fail "value(s) that are not single-line scalars (rule 2):" ;;
+        4) fail "field name(s) missing from the registry's reserved sets (rule 4):" ;;
+      esac
+      while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$hits"
+      shape_ok=0
+    done
+    if [ "$shape_ok" -eq 1 ]; then
+      pass "parser rules hold: no shadowed field names, single-line values, disjoint name sets"
+    else
+      hint "put every value on one line (provides: entries are flow mappings), keep nested keys out of the row-level names, and add a new field to exactly one of the reserved- lines. See rules 1-5 at the top of registries/repos.yml."
+    fi
+  fi
 fi
 
 # --- Summary ------------------------------------------------------------------

--- a/Code/{{PROJECT}}-docs/templates/ci/README.md
+++ b/Code/{{PROJECT}}-docs/templates/ci/README.md
@@ -9,8 +9,10 @@ checks and the test gate the Test Strategy architecture doc calls for
 
 Runs the project "doctor" (`scripts/check.sh` in the docs hub): duplicate STEP/ADR numbers,
 invalid statuses, architecture-doc frontmatter, ADR registry vs. files on disk, root hygiene,
-numbered-session/seed alignment, and the conditional-session template contract required by
-the Cross-Cutting Review and periodic check-in. It is **already installed** in the docs hub
+numbered-session/seed alignment, the conditional-session template contract required by
+the Cross-Cutting Review and periodic check-in, and `registries/repos.yml` — that each row is
+consistent with itself, that it records who owns the repo and what the repo already provides,
+and that the file stays shaped for the scripts that read it by line prefix. It is **already installed** in the docs hub
 at `Code/{{PROJECT}}-docs/.github/workflows/method-check.yml`, so in a **multi-repo** project
 (the hub is its own repo) it's active the moment you push the hub — nothing to place.
 

--- a/tests/check-repo-control.sh
+++ b/tests/check-repo-control.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for scripts/check.sh's repo-registry checks (11, 12, 13) — the doctor's
+# first test of its own.
+#
+# Two halves. The first bootstraps real projects in both layouts and proves the checks are
+# inert on a project the method just created: a greenfield registry must stay silent, or the
+# checks would be reporting on every project from the day they ship. The second mutates that
+# generated registry one defect at a time and proves each finding fires, and fires for its own
+# reason — an assertion that cannot fail looks exactly like one that works.
+#
+# Assertions read the summary line, not just the exit status: a WARN does not change the exit
+# code, so a test that only looked at $? could not see checks 12's findings at all.
+
+set -uo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-check-repo-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+note() { printf '  %s\n' "$1"; }
+bad()  { printf 'FAIL: %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+# copy_template DEST — build a template fixture from HEAD, then overlay current worktree
+# changes. Archiving rather than copying the live tree leaves ignored maintainer files behind,
+# so the fixture is the shape a user downloads; the overlay keeps uncommitted edits under test.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+# bootstrap NAME LAYOUT LICENSE — generate a project and echo its workspace root. Never an
+# all-default configuration: a fixture that always picks the same license is how a hardcoded
+# example row survived three review passes in an earlier line of this work.
+bootstrap() {
+  local name="$1" layout="$2" license="$3"
+  local work="$TMP_ROOT/$name"
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Repo control check test" \
+      --license="$license" \
+      --holder="Throughstone Test" \
+      --layout="$layout" \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.init.out" 2>&1 || {
+    bad "$name: init.sh failed"
+    sed -n '1,40p' "$TMP_ROOT/$name.init.out" >&2
+    return 1
+  }
+  printf '%s\n' "$work"
+}
+
+registry_of() { set -- "$1"/Code/*-docs/registries/repos.yml; printf '%s\n' "$1"; }
+doctor_of()   { set -- "$1"/Code/*-docs/scripts/check.sh;      printf '%s\n' "$1"; }
+
+# doctor WORK — run the generated project's doctor, capturing output and exit status in the
+# globals DOC_OUT / DOC_STATUS.
+doctor() {
+  DOC_OUT="$(bash "$(doctor_of "$1")" 2>&1)"
+  DOC_STATUS=$?
+}
+
+# reg_rows WORK — replace everything below `repos:` with rows read from stdin, leaving the
+# schema header (and its reserved- lines) exactly as shipped.
+reg_rows() {
+  local reg tmp
+  reg="$(registry_of "$1")"
+  tmp="$TMP_ROOT/reg.tmp"
+  awk '{ print } /^repos:/ { exit }' "$reg" > "$tmp"
+  cat >> "$tmp"
+  mv "$tmp" "$reg"
+}
+
+has()     { case "$DOC_OUT" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+expect()  { has "$1" || bad "$2 — expected output to contain: $1"; }
+refute()  { has "$1" && bad "$2 — output should NOT contain: $1"; return 0; }
+
+# case_fires WORK LABEL EXPECTED — mutate, run, and require the finding plus a failing summary.
+case_fires() {
+  local work="$1" label="$2" expected="$3"
+  doctor "$work"
+  expect "$expected" "$label"
+  expect "RESULT: FAIL" "$label"
+  [ "$DOC_STATUS" -eq 1 ] || bad "$label — expected exit 1, got $DOC_STATUS"
+}
+
+# --- 1. Greenfield is silent, in both layouts --------------------------------
+# The checks must be inert on a project the method just created, or they report on every
+# project from the day they ship. Both layouts, because the seeded registry differs between
+# them: mono carries a workspace-root row whose location IS a work-tree root.
+for spec in "greenfield-multi multi apache-2.0" "greenfield-mono mono bsd-3"; do
+  set -- $spec
+  name="$1" layout="$2" license="$3"
+  work="$(bootstrap "$name" "$layout" "$license")" || continue
+  doctor "$work"
+  note "$name: $(printf '%s\n' "$DOC_OUT" | grep -E '^  [0-9]+ fail')"
+  expect "11. Repo registry record consistency" "$name"
+  expect "12. Repo registry control record" "$name"
+  expect "13. Repo registry file shape" "$name"
+  expect "row(s) consistent: statuses, control/gap invariants" "$name"
+  expect "carry a complete control record" "$name"
+  expect "parser rules hold" "$name"
+  # The guard against an assertion that cannot fail: a clean project must show none of the
+  # findings the rest of this file goes on to provoke.
+  refute "[FAIL]" "$name"
+  refute "carry no control record" "$name"
+  [ "$DOC_STATUS" -eq 0 ] || bad "$name — clean project should exit 0, got $DOC_STATUS"
+done
+
+# The mono workspace-root row is the first row the disk check meets in the commonest generated
+# layout: it IS a work-tree root, and it must still owe no provides: because it is origin:
+# created. Measured here rather than assumed.
+mono="$TMP_ROOT/greenfield-mono"
+mono_reg="$(registry_of "$mono")"
+grep -qE '^[[:space:]]*location:[[:space:]]*"\."' "$mono_reg" \
+  || bad "mono registry has no workspace-root row (location: \".\")"
+[ -e "$mono/.git" ] || bad "mono workspace root is not a repository"
+doctor "$mono"
+refute "greenfield-mono ->" "mono root row"
+
+# --- 2. Check 11 — the record contradicts itself ------------------------------
+work="$(bootstrap "record-checks" multi mit)" || exit 1
+
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: adopted
+    control: managed
+    description: "Order intake."
+    provides:
+      readme:  { status: ours,   note: "" }
+      license: { status: theirs, note: "org-wide LICENSE in acme-platform" }
+      ci:      { status: gap,    note: "no pipeline yet" }
+EOF
+case_fires "$work" "managed + gap" "control: managed with a gap in ci"
+
+reg_rows "$work" <<'EOF'
+  - name: "partner-billing"
+    location: "Code/partner-billing/"
+    type: service
+    origin: adopted
+    control: external
+    description: "Partner billing."
+    provides:
+      readme:  { status: extended, note: "added a Role section" }
+      license: { status: theirs,   note: "their own LICENSE" }
+      ci:      { status: theirs,   note: "their Buildkite pipeline" }
+EOF
+case_fires "$work" "external + extended" "control: external with extended in readme"
+
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: adopted
+    control: external
+    description: "Order intake."
+    provides:
+      readme:  { status: theirs, note: "their README" }
+      license: { status: gap,    note: "" }
+      ci:      { status: N/A,    note: "" }
+EOF
+doctor "$work"
+expect "provides: license is gap and carries no note saying why" "gap needs a note"
+expect "provides: ci is N/A and carries no note saying why" "N/A needs a note"
+expect "RESULT: FAIL" "notes required"
+
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: creatd
+    control: manged
+    description: "Order intake."
+    provides:
+      readme:  { status: mine, note: "" }
+      license: { status: ours, note: "" }
+      ci:      { status: ours, note: "" }
+EOF
+doctor "$work"
+# A mistyped control: is neither absent nor external, so without this it would slip past both
+# invariant checks and read as controlled to anyone skimming the file.
+expect 'origin: "creatd" is not created or adopted' "origin closed set"
+expect 'control: "manged" is not managed or external' "control closed set"
+expect 'provides: readme status "mine" is not ours/extended/theirs/N/A/gap' "status closed set"
+expect "RESULT: FAIL" "closed sets"
+
+# --- 3. Check 13 — the file is shaped so a reader would misread it -----------
+# The measured exploit: a note written across lines whose text begins with a row-level field
+# name. setup-workspace.sh's clone loop resolves that line as the row's location and clones
+# into it, exit 0, no warning.
+reg_rows "$work" <<'EOF'
+  - name: "acme-docs"
+    location: "Code/acme-docs/"
+    type: docs
+    origin: created
+    control: managed
+    remote: "git@example.com:acme/docs.git"
+    description: |
+      the org LICENSE lives at
+      location: /srv/acme/LICENSE
+      and covers this repo
+EOF
+doctor "$work"
+expect "nested location: shadows a row-level field name" "rule 1 exploit"
+expect "description: opens a block scalar; values are single-line" "rule 2 block scalar"
+expect "not a single-line key: value" "rule 2 continuation line"
+expect "RESULT: FAIL" "rule 1 + 2"
+# Rule 2 is what makes rule 1 unreachable, so both must speak, not just the symptom.
+[ "$DOC_STATUS" -eq 1 ] || bad "exploit — expected exit 1, got $DOC_STATUS"
+
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: created
+    control: managed
+    owner: "platform-team"
+    provides:
+      readme:
+        status: ours
+      docs:    { status: ours, note: "" }
+EOF
+doctor "$work"
+expect "provides: readme is not a flow mapping" "rule 2 flow mapping"
+expect "row-level field owner: is not in reserved-row-level" "rule 4 unknown row field"
+expect "nested key docs: is not in reserved-nested" "rule 4 unknown nested key"
+expect "RESULT: FAIL" "rules 2 + 4"
+
+# The same rule one level down: a block scalar opened inside provenance:, where no
+# flow-mapping rule would catch it and only the opener names the line to fix.
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: created
+    control: managed
+    provenance:
+      from: |
+        acme-web
+      split_on: "2026-01-31"
+EOF
+doctor "$work"
+expect "from: opens a block scalar; values are single-line" "rule 2 nested block scalar"
+expect "RESULT: FAIL" "rule 2 nested"
+
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: created
+    control: managed
+    location: "Code/somewhere-else/"
+EOF
+case_fires "$work" "duplicate field" "a second row-level location: in the same row block"
+
+# The same exploit reached by dedenting instead of nesting. setup-workspace.sh matches line
+# prefixes at any indent, so a location: at column 0 below the last row is still read as that
+# row's location — a check that stopped at the block boundary would never see it.
+reg_rows "$work" <<'EOF'
+  - name: "acme-docs"
+    location: "Code/acme-docs/"
+    type: docs
+    origin: created
+    control: managed
+    remote: "git@example.com:acme/docs.git"
+location: /srv/acme/LICENSE
+EOF
+case_fires "$work" "dedented field" "location: sits outside any row block and would still be read as that row"
+
+# The reserved sets are the registry header's own two lines. Overlapping them, or removing
+# them, must fail loudly — otherwise editing the header silently disarms rules 1 and 4.
+reg="$(registry_of "$work")"
+cp "$reg" "$TMP_ROOT/reg.good"
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: created
+    control: managed
+EOF
+cp "$(registry_of "$work")" "$TMP_ROOT/reg.rows"
+
+sed 's/^#\([[:space:]]*\)reserved-nested: /#\1reserved-nested: location /' \
+  "$TMP_ROOT/reg.rows" > "$reg"
+case_fires "$work" "overlapping reserved sets" "reserved-row-level and reserved-nested share name(s): location"
+
+grep -v 'reserved-row-level:' "$TMP_ROOT/reg.rows" > "$reg"
+case_fires "$work" "reserved line removed" "the reserved name sets cannot be read"
+
+# --- 4. Check 12 — the control record, and what counts as a repository -------
+cp "$TMP_ROOT/reg.rows" "$reg"
+mkdir -p "$work/Code/acme-api" "$work/Code/plain"
+git -C "$work/Code/acme-api" init -q
+git -C "$work/Code/acme-api" commit -q --allow-empty -m seed
+mkdir -p "$work/Code/acme-api/sub"
+
+reg_rows "$work" <<'EOF'
+  - name: "acme-api"
+    location: "Code/acme-api/"
+    type: service
+    origin: adopted
+    control: managed
+    provides:
+      license: { status: theirs, note: "org-wide LICENSE" }
+
+  - name: "acme-sub"
+    location: "Code/acme-api/sub/"
+    type: library
+    origin: adopted
+    control: managed
+
+  - name: "acme-plain"
+    location: "Code/plain/"
+    type: docs
+    description: "a folder, not a repo yet"
+
+  - name: "not-here"
+    location: "Code/not-here/"
+    type: service
+    origin: adopted
+    control: managed
+EOF
+doctor "$work"
+# Named per key, not per row: the register action leaves a key out on purpose when it could
+# not look, and a check written over the block alone would pass that row silently.
+expect "acme-api -> provides: no readme; provides: no ci" "per-key naming"
+# A directory inside a repository is not a repository, so nothing is owed for it.
+refute "acme-sub ->" "subdirectory owes nothing"
+# A plain folder owes no provides:, but every row owes origin: and control:.
+expect "acme-plain -> no origin:; no control:" "row-level fields always owed"
+# Silence about a row that could not be checked is indistinguishable from a pass.
+expect "row(s) not present on this machine; provides: not checked there" "absent rows counted"
+# A warning must not change the exit code — which is why these assertions read the summary.
+expect "RESULT: OK" "warnings do not fail the run"
+[ "$DOC_STATUS" -eq 0 ] || bad "control record warnings — expected exit 0, got $DOC_STATUS"
+# The warn must never claim the project is old: nothing on disk records the installed version.
+refute "this project is old" "no age claim"
+
+# A submodule and a linked worktree both present .git as a FILE and both are real repositories,
+# which is why the check compares work-tree roots rather than testing for a .git directory.
+git -C "$work/Code/acme-api" worktree add -q "$work/Code/wt" -b wtbranch
+mkdir -p "$work/Code/parent"
+git -C "$work/Code/parent" init -q
+git -C "$work/Code/parent" commit -q --allow-empty -m seed
+git -C "$work/Code/parent" -c protocol.file.allow=always \
+  submodule add -q "$work/Code/acme-api" vendor/lib >/dev/null 2>&1
+for f in "$work/Code/wt/.git" "$work/Code/parent/vendor/lib/.git"; do
+  [ -f "$f" ] || bad "fixture is not exercising the shape it claims: $f is not a file"
+done
+reg_rows "$work" <<'EOF'
+  - name: "linked-worktree"
+    location: "Code/wt/"
+    type: service
+    origin: adopted
+    control: managed
+
+  - name: "submodule"
+    location: "Code/parent/vendor/lib/"
+    type: library
+    origin: adopted
+    control: managed
+EOF
+doctor "$work"
+expect "linked-worktree -> provides: no readme" "linked worktree is a repository"
+expect "submodule -> provides: no readme" "submodule is a repository"
+
+# A repo the method created carries no observation debt, so the same work trees stay silent
+# once their rows say origin: created. This is what keeps the check greenfield-inert.
+reg_rows "$work" <<'EOF'
+  - name: "linked-worktree"
+    location: "Code/wt/"
+    type: service
+    origin: created
+    control: managed
+
+  - name: "submodule"
+    location: "Code/parent/vendor/lib/"
+    type: library
+    origin: created
+    control: managed
+EOF
+doctor "$work"
+refute "provides: no readme" "created rows owe no provides"
+expect "RESULT: OK" "created rows are clean"
+
+# --- 5. No registry at all ----------------------------------------------------
+# Pre-1.8 projects bootstrapped with --registries=no have no file. That is reported once,
+# rather than three times or not at all.
+mv "$reg" "$TMP_ROOT/reg.away"
+doctor "$work"
+expect "no registries/repos.yml — skipping repo registry checks" "missing registry warns once"
+expect "nothing to check (reported in check 11)" "missing registry is not silent"
+expect "RESULT: OK" "missing registry does not fail the run"
+mv "$TMP_ROOT/reg.away" "$reg"
+
+if [ "$failures" -ne 0 ]; then
+  printf 'check.sh repo-registry checks: %d FAILURE(S)\n' "$failures" >&2
+  exit 1
+fi
+echo "check.sh repo-registry checks: PASS"

--- a/tests/doctor-dispatcher.sh
+++ b/tests/doctor-dispatcher.sh
@@ -22,7 +22,8 @@ assert_contains() {
 
 # Build a minimal generated-workspace shape with fake helper scripts. The dispatcher test
 # cares that doctor.sh finds and execs the right helper while forwarding any extra arguments;
-# status.sh/check.sh behavior is covered by their own tests.
+# status.sh and check.sh behavior is covered by their own tests (tests/status-*.sh,
+# tests/check-repo-control.sh).
 fixture="$TMP_ROOT/workspace"
 mkdir -p "$fixture/Code/acme-docs/scripts"
 cp -p "$ROOT/doctor.sh" "$fixture/doctor.sh"


### PR DESCRIPTION
## What this does

`registries/repos.yml` records who owns each repo in a project and what each repo already
provides — a README, a stated licensing posture, a CI gate. Nothing read any of it. A row could
say Throughstone controls a repo **and** that one of that repo's needs is unmet, which the file's
own schema forbids, and the project would report clean.

This teaches the project doctor to read that file. `scripts/check.sh` goes from ten checks to
thirteen; a clean run grows from 35 lines to 44.

**11 — record consistency.** Reads the file only, so it holds everywhere the doctor runs, CI
included. Artifact statuses come from `ours` / `extended` / `theirs` / `N/A` / `gap`; `origin:`
and `control:` come from their own two-value sets, because a typo like `control: manged` is
neither absent nor `external` and would otherwise slip past both invariants below. A `managed`
repo has no `gap`, an `external` repo has no `ours` or `extended`, and `gap` and `N/A` say why.
FAIL.

**12 — the control record.** A row whose `location` is the root of a git work tree, and that
Throughstone adopted rather than created, has to record what that repo provides — and the finding
names the individual missing entry rather than the row, because an entry is left out on purpose
while the observation is still owed. Rows whose location is not on the machine running the doctor
are skipped, **counted, and said out loud**, since silence about them is indistinguishable from a
pass. WARN, and the wording never claims the project is old: nothing on disk records which version
it installed.

**13 — file shape.** The scripts that read this registry match line prefixes and know nothing
about YAML nesting. A note written across several lines whose text began
`location: /srv/acme/LICENSE` made `scripts/setup-workspace.sh` clone a repository into that path
— exit 0, no warning. Reproduced this session. Three of the header's five rules are properties of
the file and are now enforced: values are single-line, `provides:` entries are flow mappings, and
row-level and nested names stay disjoint. These FAIL rather than warn — a violation is a clone to
the wrong folder, not a thin record. The other two rules constrain the scripts rather than the
file and stay prose, because a checker reading the registry cannot see them.

The reserved name sets are read from the registry header's own `reserved-row-level:` and
`reserved-nested:` lines, so there is one list, it sits where the schema is, and removing or
overlapping it fails loudly instead of quietly disarming the checks.

## Two things found while building

- **Dedenting evades nesting.** The readers match line prefixes at *any* indent, so a
  `location:` at column 0 below the last row is read as that row's location just as a nested one
  is. Reproduced against the live clone parser, and now reported.
- **The nested block-scalar check had no fixture.** It survived mutation because the exploit
  fixture opens its block scalar at row level. A `provenance:` fixture now covers it.

## Tests

`scripts/check.sh` has never had a test. `tests/check-repo-control.sh` is the first.

Both layouts are bootstrapped from a `git archive` fixture with non-default licenses and proved
**silent** — a check that fired on a fresh project would fire on every project — including the
mono workspace-root row, which *is* a work-tree root and must still owe nothing because the method
created it. Then that generated registry is mutated one defect at a time. Assertions read the
summary line rather than the exit status, since a warning does not change the exit code.

Every new assertion was mutation-checked against a deliberately broken `check.sh` — 21 mutations,
21 caught, including replacing the work-tree comparison with a `.git` *directory* test, which a
linked worktree and a submodule both fail because their `.git` is a file.

Suite 13/13. Verified inert on five more configurations: mono + team + proprietary,
multi + proprietary, and mono with `--registries=no`.

## Release notes

`CHANGELOG.md` under Unreleased. `UPDATING-THROUGHSTONE.md`'s 1.8 section gains what the doctor
will now say about that file, and one new fast-path step: **a value wrapped across two lines now
fails**, which is the only thing in this change that can turn a passing run red without the user
having changed anything. The fix is one edit and the message names the line.

Also corrects the four passages that enumerate what the doctor checks — the CI workflow header,
`templates/ci/README.md`, `runbooks/check-in.md`, and the 1.8 migration's "no `check.sh` change"
clause — plus the dispatcher test's comment claiming `check.sh` was covered by a test of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
