### PR TITLE
Finish assembling the workspace when a repo cannot be cloned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,19 @@ any project built with it.
   Existing rows are not rewritten — `UPDATING-THROUGHSTONE.md`'s 1.8 section covers adding the
   fields to a project you already have.
 
+- **`apply-project-license.sh --notice-only <repo>`** — write the Throughstone notice into a
+  repository and nothing else. The script's one mode writes three files keyed on the project's
+  license posture: the notice, a `LICENSING.md` summary, and the project `LICENSE` for an
+  open-source project. There was no way to ask for just the notice, which is what a repository the
+  method did not create needs — Throughstone-authored material there should say what it is, but
+  that project's own licensing is not ours to state. The new mode reads no posture, writes only
+  `LICENSE-THROUGHSTONE`, never touches the target's `LICENSE` or `LICENSING.md`, and leaves a
+  notice that is already there exactly as it is, whatever it says: a differing notice is the
+  ordinary state a re-run meets after the notice text changes, not a conflict to resolve. If the
+  notice cannot be written it says so and still returns success, so a caller is never stopped by
+  it. The existing mode is unchanged, including every case where it refuses to overwrite a file it
+  did not write.
+
 ### Changed
 - **The doctor now checks the repo registry, and a bad row fails the build.** `registries/repos.yml`
   records who owns each repo and what it already provides, and until now nothing read any of it. A
@@ -140,6 +153,27 @@ any project built with it.
   the way mono-repo already did.
 
 ### Fixed
+- **One repository you cannot clone no longer costs you the whole workspace.**
+  `scripts/setup-workspace.sh` is what every developer after the first runs to assemble the project
+  on their machine: it clones the repos `registries/repos.yml` gives a `remote:`, then writes the
+  workspace root's `AGENTS.md`, `CLAUDE.md` and `doctor.sh`. A clone that failed aborted the run
+  before it reached those files, so the contributor ended up with **no workspace at all** — over a
+  repository they may not even need. Three ordinary situations did it, all measured: a remote nobody
+  on the team can reach, a stray folder or half-finished clone already sitting where a repo should
+  go, and a `location:` left behind as an absolute path from the first developer's machine. A failed
+  clone is now reported and the run continues; the pointer files are written before the clone step
+  rather than after it; and the closing line says how many repos did not arrive instead of reporting
+  plain success. Fix a bad `remote:` or `location:`, or clone that repo by hand, and re-run — repos
+  already cloned are left alone.
+- **A `location:` outside the workspace root is no longer cloned into.** An absolute path, or one
+  reaching out with `..`, is now reported and skipped. It used to be used verbatim, so a registry
+  naming a path that happened to be writable placed a repository *outside* the workspace silently,
+  at exit 0 — and that is the ordinary shape whenever a repo is registered where it already lives
+  instead of created as a `Code/*` sibling. A `location:` that stays inside the workspace root still
+  clones exactly as before, including one outside the `Code/*` shell, and a repo already checked out
+  where its `location:` points is still left untouched. A repo registered outside the workspace root
+  is one each contributor clones onto their own machine, once; `METHOD.md` §7 and the registry
+  header carry the narrower rule.
 - **`init.sh` could destroy a repository it was run inside.** Unpacking the template into a
   repository you already had — the natural thing to try when you want Throughstone in a project
   that exists — and running `./init.sh` there deleted that repository's `.git` outright, every

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -495,8 +495,13 @@ above assume. A repo may instead be **registered in place by its `location:`** �
 created-as-sibling default, so a repo that lives elsewhere is referenced where it sits rather than
 created under `Code/`. `location:` records wherever the repo actually is; the optional `remote:` is
 unchanged (a cloneable URL when the repo has one).
-`scripts/setup-workspace.sh` honors `location:` verbatim either way — it clones from `remote:`
-into that path when a remote is set, and otherwise leaves the repo referenced where it sits.
+`scripts/setup-workspace.sh` honors `location:` verbatim, but it only ever *clones* into a path
+the workspace owns: a location inside the workspace root is cloned from `remote:` when a remote is
+set and nothing is there yet, and a location **outside** it — absolute, or reaching out with
+`..` — is reported and skipped rather than cloned into, because placing a repository outside the
+workspace is not that script's business even when the path happens to be writable. A repo already
+checked out at its `location:` is left alone either way, so an in-place repo outside the root is
+one each contributor clones onto their own machine once.
 Branch-per-STEP and the overlap warning (`runbooks/collaboration.md`) key on repo
 **identity** — its `repos.yml` entry, not where it lives — so an in-place repo participates in
 them exactly like a sibling. The `Code/*` sibling layout stays the default.

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -213,6 +213,23 @@ mono projects; `init.sh` runs once, so nothing places it in a project that alrea
 
 Multi-repo projects have nothing to do here.
 
+**A teammate whose workspace setup died part-way can now finish it.** If someone ran
+`Code/<project>-docs/scripts/setup-workspace.sh` and it stopped with a `git clone` error, leaving the
+workspace root with no `AGENTS.md`, no `CLAUDE.md` and no `doctor.sh`, that was one failing clone
+taking the whole run down with it. **Pull 1.8 into the docs hub and run the script again.** Nothing
+needs undoing first: repos already cloned are left alone, the pointer files are rewritten every run,
+and the run now finishes whatever happens to the clones. Its closing line says how many repos did not
+arrive, so fix the `remote:` or `location:` in `registries/repos.yml` — or clone that one repo by
+hand — and re-run to pick it up.
+
+**Look at any `location:` in your registry that points outside the workspace root.** An absolute
+path, or one reaching out with `..`, is now reported and skipped rather than cloned into; before 1.8
+the path was used verbatim, so a writable one put the repository outside the workspace silently. No
+edit is required and nothing of yours is rewritten — but a repo registered that way is now one each
+contributor clones onto their own machine once, rather than something the setup script fetches for
+them. A `location:` inside the workspace root is unaffected, including one outside the `Code/*`
+shell, and so is a repo already checked out where its `location:` points.
+
 ### 1.7 migration
 
 **Upgrading from 1.6? Start here.** This release rewrites no project files. Only two defaults

--- a/Code/{{PROJECT}}-docs/registries/README.md
+++ b/Code/{{PROJECT}}-docs/registries/README.md
@@ -9,7 +9,7 @@ itself, because tooling and CI parse it. Keep each file the **source of truth**;
 
 | File | What | Consumed by |
 |------|------|-------------|
-| [`repos.yml`](repos.yml) | The repo inventory — which repos exist, what each is, and where its docs live. See its header and `METHOD.md` §7. | `scripts/setup-workspace.sh` (clones from `remote:`); `runbooks/collaboration.md` (STEP-number reservation); CI. |
+| [`repos.yml`](repos.yml) | The repo inventory — which repos exist, what each is, and where its docs live. See its header and `METHOD.md` §7. | `scripts/setup-workspace.sh` (clones from `remote:` into locations the workspace owns); `runbooks/collaboration.md` (STEP-number reservation); CI. |
 | [`risks.yml`](risks.yml) | The accepted risk / tech-debt index — known risks, conscious deferrals, and debt with owners, revisit triggers, and references to the artifact that explains the detail. | Security session deferrals; dependency audits; incident follow-ups; `runbooks/check-in.md`. |
 | [`security-reviews.yml`](security-reviews.yml) | The security review ledger — latest S0/S1/S2 review dates, cadence, report paths, reviewed commit, rough SLOC snapshot, and deltas since the previous run. | `runbooks/security-review.md`; `runbooks/check-in.md` security gate. |
 

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -9,9 +9,11 @@
 # `location:` is where the repo lives — by default a `Code/*` sibling under the workspace root,
 # written workspace-root-relative (e.g. Code/{{PROJECT}}-api/). It MAY instead point OUTSIDE the
 # `Code/*` shell — an absolute path or any other arbitrary path — for a repo referenced in place
-# where it lives, rather than created as a sibling. setup-workspace.sh uses `location`
-# verbatim (clones from `remote` into it, or references it in place when there's no remote), so
-# keep `location` and `remote` distinct: a clone URL goes in `remote`, never folded into `location`.
+# where it lives, rather than created as a sibling. setup-workspace.sh uses `location` verbatim
+# but only ever CLONES into a path the workspace owns: a location outside the workspace root — an
+# absolute path, or one reaching out with `..` — is reported and skipped, so an in-place repo
+# there is one each contributor clones onto their own machine. Keep `location` and `remote`
+# distinct: a clone URL goes in `remote`, never folded into `location`.
 #
 # Mono-repo-for-now: the row whose `location` is `.` is the workspace root — the one repository
 # the project actually has. The rows below it are folders inside that repository, not separate

--- a/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
+++ b/Code/{{PROJECT}}-docs/scripts/apply-project-license.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 #
-# apply-project-license.sh TARGET_REPO — apply the bootstrap-selected project-license posture.
+# apply-project-license.sh [--notice-only] TARGET_REPO — apply the bootstrap-selected
+# project-license posture.
 #
 # The posture file is the durable source of truth, separate from LICENSE, so a missing or
 # extra license file cannot silently change whether the generated project is open-source or
 # proprietary. This helper is for newly scaffolded application-code repos that retain
 # Throughstone-authored README / CI material.
+#
+# --notice-only writes only LICENSE-THROUGHSTONE and reads no posture. It is for a repository
+# Throughstone did not create: our material there needs a notice, but the project's own
+# licensing is not ours to state, so no LICENSE and no LICENSING.md are written and an existing
+# notice is left alone. It warns rather than failing, so a caller is never stopped by it.
 
 set -euo pipefail
 
@@ -13,11 +19,26 @@ set -euo pipefail
 # Code/<project>-docs/scripts/ after initialization; derive the docs hub without resolving
 # the placeholder in this template checkout.
 DOCS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TARGET="${1:-}"
+NOTICE_ONLY=0
+TARGET=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --notice-only) NOTICE_ONLY=1 ;;
+    --*) echo "apply-project-license.sh: unknown option: $1" >&2; exit 2 ;;
+    *)
+      if [ -n "$TARGET" ]; then
+        echo "apply-project-license.sh: unexpected extra argument: $1" >&2
+        exit 2
+      fi
+      TARGET="$1"
+      ;;
+  esac
+  shift
+done
 POLICY_FILE="$DOCS_ROOT/.throughstone/project-license"
 
 if [ -z "$TARGET" ]; then
-  echo "usage: $0 TARGET_REPO" >&2
+  echo "usage: $0 [--notice-only] TARGET_REPO" >&2
   exit 2
 fi
 if [ ! -d "$TARGET" ]; then
@@ -50,6 +71,31 @@ copy_if_missing() {
     echo "$label: $target"
   fi
 }
+
+# --notice-only — leave the Throughstone notice and nothing else. This is what a repository the
+# method did not create needs: the notice covers Throughstone-authored material, not the
+# project's own licensing, so the mode reads no posture, writes no LICENSING.md, and never
+# touches the target's LICENSE. It deliberately does not use verify_compatible: a notice that is
+# already there is left exactly as it is, whatever it says, because a differing notice is the
+# ordinary state an idempotent re-run meets after the notice text changes, not a conflict to
+# resolve. Every way this can fall short is a warning and a zero exit — a caller registering a
+# repository must not be stopped by the notice.
+if [ "$NOTICE_ONLY" = "1" ]; then
+  if [ -e "$TARGET/LICENSE-THROUGHSTONE" ]; then
+    echo "Throughstone license: $TARGET/LICENSE-THROUGHSTONE (already present, left as it is)"
+    exit 0
+  fi
+  if [ ! -f "$DOCS_ROOT/LICENSE-THROUGHSTONE" ]; then
+    echo "apply-project-license.sh: no Throughstone notice to copy from $DOCS_ROOT/LICENSE-THROUGHSTONE; notice not written" >&2
+    exit 0
+  fi
+  cp "$DOCS_ROOT/LICENSE-THROUGHSTONE" "$TARGET/LICENSE-THROUGHSTONE" || {
+    echo "apply-project-license.sh: could not write $TARGET/LICENSE-THROUGHSTONE; notice not written" >&2
+    exit 0
+  }
+  echo "Throughstone license: $TARGET/LICENSE-THROUGHSTONE"
+  exit 0
+fi
 
 # The posture file is written during bootstrap and must contain one of the supported
 # project-license IDs. It decides the licensing path; LICENSE files are validated against it,

--- a/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
+++ b/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
@@ -3,9 +3,8 @@
 # setup-workspace.sh — set up a NEW developer's machine for an existing project.
 #
 # The first developer ran init.sh to create the project. Everyone after runs this to
-# assemble the workspace shell on their machine: clone the sibling repos and write the
-# per-machine pointer/helper files (CLAUDE.md / AGENTS.md / doctor.sh) that the workspace root
-# needs.
+# assemble the workspace shell on their machine: write the per-machine pointer/helper files
+# (CLAUDE.md / AGENTS.md / doctor.sh) that the workspace root needs, and clone the sibling repos.
 #
 # Multi-repo projects only. A mono-repo-for-now project (METHOD.md §7) is a single repo with
 # the pointers committed inside it — just clone that repo; there's nothing to assemble here.
@@ -28,34 +27,11 @@ cd "$ROOT"
 echo "Workspace root: $ROOT"
 echo "Docs hub:       $DOCS_REL"
 
-# --- 1. Clone sibling repos listed in the registry (if it has remotes) ------
-REG="$DOCS_DIR/registries/repos.yml"
-if [ -f "$REG" ]; then
-  echo "Cloning sibling repos with remotes from registries/repos.yml ..."
-  # Parse repos.yml block-aware: pair each repo's own location with its own remote.
-  # The registry is the multi-repo inventory, and remote: is optional. Walking each `- name:`
-  # block keeps locations and remotes aligned when only some repos are cloneable; comment lines
-  # and remote-less repos are skipped.
-  awk '
-    /^[[:space:]]*#/ { next }
-    /^[[:space:]]*-[[:space:]]*name:/ { if (loc != "" && rem != "") print loc "|" rem; loc=""; rem=""; next }
-    /^[[:space:]]*location:/ { loc=$0; sub(/^[^:]*:[[:space:]]*"?/,"",loc); sub(/"?[[:space:]]*$/,"",loc) }
-    /^[[:space:]]*remote:/   { rem=$0; sub(/^[^:]*:[[:space:]]*"?/,"",rem); sub(/"?[[:space:]]*$/,"",rem) }
-    END { if (loc != "" && rem != "") print loc "|" rem }
-  ' "$REG" \
-  | while IFS='|' read -r loc rem; do
-      [ -n "${rem:-}" ] || continue
-      # Clone side effect: create a missing sibling repo at its registry location. Existing git
-      # checkouts are left untouched so rerunning setup is safe for already-cloned repos.
-      [ -d "$loc/.git" ] && { echo "  exists: $loc"; continue; }
-      echo "  cloning $rem -> $loc"
-      git clone -q "$rem" "$loc"
-    done
-else
-  echo "No registries/repos.yml — skipping clone step."
-fi
-
-# --- 2. Write the per-machine root pointers/helpers --------------------------
+# --- 1. Write the per-machine root pointers/helpers --------------------------
+# These are written before the clone step deliberately, but the ordering is not what makes the
+# clone step safe — step 2 warns and continues instead of aborting, so it can no longer take the
+# workspace down with it. The ordering is insurance against the *next* fatal path someone adds:
+# whatever fails below, the contributor still ends up with AGENTS.md, CLAUDE.md and doctor.sh.
 echo "Writing per-machine pointers and helpers (CLAUDE.md, AGENTS.md, doctor.sh) ..."
 # The workspace root is a per-machine shell in multi-repo projects, not a durable repo. These
 # pointers are regenerated locally so agents opened at the root can find the canonical docs hub.
@@ -93,4 +69,62 @@ chmod +x "$ROOT/doctor.sh"
 
 mkdir -p "$ROOT/.claude"
 mkdir -p "$ROOT/.throughstone"
+
+# --- 2. Clone sibling repos listed in the registry (if it has remotes) ------
+# Nothing in this step is allowed to be fatal. A contributor who cannot reach one repository —
+# or whose registry names a path this workspace has no business writing to — must still end up
+# with a usable workspace, so every repo that does not arrive is reported and counted rather
+# than aborting the run.
+REG="$DOCS_DIR/registries/repos.yml"
+missing=0
+if [ -f "$REG" ]; then
+  echo "Cloning sibling repos with remotes from registries/repos.yml ..."
+  # Parse repos.yml block-aware: pair each repo's own location with its own remote.
+  # The registry is the multi-repo inventory, and remote: is optional. Walking each `- name:`
+  # block keeps locations and remotes aligned when only some repos are cloneable; comment lines
+  # and remote-less repos are skipped.
+  #
+  # The loop is fed by process substitution rather than a pipe for two reasons: the parser's
+  # exit status stays out of the pipeline, so a registry awk cannot read is not fatal either;
+  # and the loop body runs in this shell rather than a subshell, so the count below survives it.
+  while IFS='|' read -r loc rem; do
+    [ -n "${rem:-}" ] || continue
+    # Clone side effect: create a missing sibling repo at its registry location. Existing git
+    # checkouts are left untouched so rerunning setup is safe for already-cloned repos. This
+    # is also what leaves a repo registered in place alone: it is already where it belongs.
+    [ -d "$loc/.git" ] && { echo "  exists: $loc"; continue; }
+    # A location this workspace cannot own is referenced where it sits, never cloned into.
+    # Cloning would put the repository outside the workspace this script is assembling —
+    # silently, when the path happens to be writable. The test is textual on purpose: an
+    # absolute path from the first developer's machine must be skipped whether or not it
+    # resolves to anything here.
+    case "$loc" in
+      /* | .. | ../* | */../* | */..)
+        echo "  skipped: $loc — outside the workspace root; this script never clones there"
+        missing=$((missing + 1))
+        continue
+        ;;
+    esac
+    echo "  cloning $rem -> $loc"
+    git clone -q "$rem" "$loc" || {
+      echo "  warning: could not clone $rem -> $loc — continuing without it"
+      missing=$((missing + 1))
+    }
+  done < <(awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*-[[:space:]]*name:/ { if (loc != "" && rem != "") print loc "|" rem; loc=""; rem=""; next }
+    /^[[:space:]]*location:/ { loc=$0; sub(/^[^:]*:[[:space:]]*"?/,"",loc); sub(/"?[[:space:]]*$/,"",loc) }
+    /^[[:space:]]*remote:/   { rem=$0; sub(/^[^:]*:[[:space:]]*"?/,"",rem); sub(/"?[[:space:]]*$/,"",rem) }
+    END { if (loc != "" && rem != "") print loc "|" rem }
+  ' "$REG")
+else
+  echo "No registries/repos.yml — skipping clone step."
+fi
+
 echo "Done. Open this folder in your agent; it will discover the context via the pointers."
+if [ "$missing" -gt 0 ]; then
+  echo
+  echo "$missing repo(s) above did not arrive. The workspace itself is complete — fix the remote"
+  echo "or the location in registries/repos.yml, or clone the repo yourself, then re-run this"
+  echo "script to pick it up."
+fi

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -812,4 +812,156 @@ set -e
 assert_maintainer_tests_retained "license-missing-template" "$missing_template_work"
 grep -Fq "project license template is missing" "$TMP_ROOT/license-missing-template.out"
 
+# --- --notice-only: the Throughstone notice, and nothing else -----------------
+# A repository the method did not create needs a notice for our material, but its own licensing
+# is not ours to state. Every abort arm below fires on ordinary adopted repos in the default
+# mode — including on an open-source project, so it is not a proprietary-posture edge — and this
+# mode must clear all of them without ever touching the target's LICENSE.
+#
+# Both fixtures are reused from earlier cases so the two layouts and two non-MIT postures are
+# both exercised: license-private-flag is Proprietary and multi-repo, license-mono is Apache-2.0
+# and mono. Neither is an all-default configuration.
+notice_priv="$TMP_ROOT/license-private-flag"
+notice_open="$TMP_ROOT/license-mono"
+notice_priv_script="$notice_priv/Code/license-private-flag-docs/scripts/apply-project-license.sh"
+notice_open_script="$notice_open/Code/license-mono-docs/scripts/apply-project-license.sh"
+notice_priv_hub="$notice_priv/Code/license-private-flag-docs"
+[ -x "$notice_priv_script" ] || {
+  echo "FAIL: notice-only fixture is missing; did the cases above get reordered? $notice_priv_script" >&2
+  exit 1
+}
+[ -x "$notice_open_script" ] || {
+  echo "FAIL: notice-only fixture is missing; did the cases above get reordered? $notice_open_script" >&2
+  exit 1
+}
+
+# adopted_repo PATH — a repository the method did not create: it states its own license, which
+# is the thing the default mode refuses to work alongside.
+adopted_repo() {
+  rm -rf "$1"
+  mkdir -p "$1"
+  printf 'MIT License\n\nCopyright (c) 2020 Another Team\n' > "$1/LICENSE"
+  printf 'their license\n' > "$1/.license-fingerprint"
+  cp "$1/LICENSE" "$1/.license-fingerprint"
+}
+
+# A proprietary project meeting an adopted repo that has its own LICENSE — `exit 1` in the
+# default mode, because a proprietary project refuses to stand beside a target LICENSE at all.
+notice_target="$TMP_ROOT/notice-adopted-proprietary"
+adopted_repo "$notice_target"
+"$notice_priv_script" --notice-only "$notice_target" >"$TMP_ROOT/notice-priv.out" 2>&1
+cmp -s "$notice_priv_hub/LICENSE-THROUGHSTONE" "$notice_target/LICENSE-THROUGHSTONE"
+cmp -s "$notice_target/.license-fingerprint" "$notice_target/LICENSE"
+[ ! -e "$notice_target/LICENSING.md" ]
+grep -Fq "Throughstone license:" "$TMP_ROOT/notice-priv.out"
+
+# Idempotent: a second run has nothing to do and says so.
+"$notice_priv_script" --notice-only "$notice_target" >"$TMP_ROOT/notice-priv-again.out" 2>&1
+grep -Fq "already present, left as it is" "$TMP_ROOT/notice-priv-again.out"
+cmp -s "$notice_target/.license-fingerprint" "$notice_target/LICENSE"
+[ ! -e "$notice_target/LICENSING.md" ]
+
+# The default mode still refuses that same repo. --notice-only is an added mode, not a
+# loosening of the one that exists.
+set +e
+"$notice_priv_script" "$notice_target" >"$TMP_ROOT/notice-default-still-aborts.out" 2>&1
+notice_default_status=$?
+set -e
+[ "$notice_default_status" -eq 1 ]
+grep -Fq "project is proprietary, but target already has LICENSE" \
+  "$TMP_ROOT/notice-default-still-aborts.out"
+
+# An open-source project meeting the same repo — `exit 1` in the default mode for a different
+# reason, which is what shows the abort is about the target's license, not the project's posture.
+notice_open_target="$TMP_ROOT/notice-adopted-open"
+adopted_repo "$notice_open_target"
+"$notice_open_script" --notice-only "$notice_open_target" >"$TMP_ROOT/notice-open.out" 2>&1
+cmp -s \
+  "$notice_open/Code/license-mono-docs/LICENSE-THROUGHSTONE" \
+  "$notice_open_target/LICENSE-THROUGHSTONE"
+cmp -s "$notice_open_target/.license-fingerprint" "$notice_open_target/LICENSE"
+[ ! -e "$notice_open_target/LICENSING.md" ]
+set +e
+"$notice_open_script" "$notice_open_target" >"$TMP_ROOT/notice-open-default.out" 2>&1
+notice_open_status=$?
+set -e
+[ "$notice_open_status" -eq 1 ]
+grep -Fq "refusing to overwrite different project license" "$TMP_ROOT/notice-open-default.out"
+
+# A notice that is already there is left exactly as it is, whatever it says. This is the state
+# an idempotent re-run meets after the notice text changes, and the default mode aborts on it.
+notice_stale="$TMP_ROOT/notice-stale"
+rm -rf "$notice_stale"
+mkdir -p "$notice_stale"
+printf 'An older Throughstone notice.\n' > "$notice_stale/LICENSE-THROUGHSTONE"
+"$notice_priv_script" --notice-only "$notice_stale" >"$TMP_ROOT/notice-stale.out" 2>&1
+grep -Fxq "An older Throughstone notice." "$notice_stale/LICENSE-THROUGHSTONE"
+grep -Fq "already present, left as it is" "$TMP_ROOT/notice-stale.out"
+set +e
+"$notice_priv_script" "$notice_stale" >"$TMP_ROOT/notice-stale-default.out" 2>&1
+notice_stale_status=$?
+set -e
+[ "$notice_stale_status" -eq 1 ]
+grep -Fq "refusing to overwrite different Throughstone license" "$TMP_ROOT/notice-stale-default.out"
+
+# The mode reads no posture. With the posture file gone the default mode cannot run at all,
+# and --notice-only is unaffected — which is what makes it usable from a caller that has not
+# asked, and never will ask, what the project's license is.
+notice_noposture="$TMP_ROOT/notice-no-posture"
+rm -rf "$notice_noposture"
+mkdir -p "$notice_noposture"
+mv "$notice_priv_hub/.throughstone/project-license" "$TMP_ROOT/posture-stash"
+"$notice_priv_script" --notice-only "$notice_noposture" >"$TMP_ROOT/notice-noposture.out" 2>&1
+cmp -s "$notice_priv_hub/LICENSE-THROUGHSTONE" "$notice_noposture/LICENSE-THROUGHSTONE"
+set +e
+"$notice_priv_script" "$notice_noposture" >"$TMP_ROOT/notice-noposture-default.out" 2>&1
+notice_noposture_status=$?
+set -e
+[ "$notice_noposture_status" -eq 1 ]
+grep -Fq "missing project-license posture" "$TMP_ROOT/notice-noposture-default.out"
+mv "$TMP_ROOT/posture-stash" "$notice_priv_hub/.throughstone/project-license"
+
+# Nothing to copy is a warning, not a failure: a caller registering a repository must not be
+# stopped by the notice.
+notice_nosource="$TMP_ROOT/notice-no-source"
+rm -rf "$notice_nosource"
+mkdir -p "$notice_nosource"
+mv "$notice_priv_hub/LICENSE-THROUGHSTONE" "$TMP_ROOT/notice-stash"
+set +e
+"$notice_priv_script" --notice-only "$notice_nosource" >"$TMP_ROOT/notice-nosource.out" 2>&1
+notice_nosource_status=$?
+set -e
+mv "$TMP_ROOT/notice-stash" "$notice_priv_hub/LICENSE-THROUGHSTONE"
+[ "$notice_nosource_status" -eq 0 ]
+[ ! -e "$notice_nosource/LICENSE-THROUGHSTONE" ]
+grep -Fq "notice not written" "$TMP_ROOT/notice-nosource.out"
+
+# The flag reads in either position, and a caller's mistake is still a usage error rather than
+# a path: a misspelled flag must not be taken for a target directory.
+notice_order="$TMP_ROOT/notice-flag-after"
+rm -rf "$notice_order"
+mkdir -p "$notice_order"
+"$notice_priv_script" "$notice_order" --notice-only >"$TMP_ROOT/notice-order.out" 2>&1
+[ -f "$notice_order/LICENSE-THROUGHSTONE" ]
+[ ! -e "$notice_order/LICENSING.md" ]
+
+set +e
+"$notice_priv_script" --notice_only "$notice_order" >"$TMP_ROOT/notice-badflag.out" 2>&1
+notice_badflag_status=$?
+"$notice_priv_script" "$notice_order" "$notice_order" >"$TMP_ROOT/notice-twotargets.out" 2>&1
+notice_twotargets_status=$?
+"$notice_priv_script" --notice-only "$TMP_ROOT/notice-does-not-exist" >"$TMP_ROOT/notice-nodir.out" 2>&1
+notice_nodir_status=$?
+"$notice_priv_script" >"$TMP_ROOT/notice-noargs.out" 2>&1
+notice_noargs_status=$?
+set -e
+[ "$notice_badflag_status" -eq 2 ]
+grep -Fq "unknown option: --notice_only" "$TMP_ROOT/notice-badflag.out"
+[ "$notice_twotargets_status" -eq 2 ]
+grep -Fq "unexpected extra argument" "$TMP_ROOT/notice-twotargets.out"
+[ "$notice_nodir_status" -eq 2 ]
+grep -Fq "target directory does not exist" "$TMP_ROOT/notice-nodir.out"
+[ "$notice_noargs_status" -eq 2 ]
+grep -Fq "[--notice-only] TARGET_REPO" "$TMP_ROOT/notice-noargs.out"
+
 echo "init.sh license choice validation: PASS"

--- a/tests/setup-workspace-resilience.sh
+++ b/tests/setup-workspace-resilience.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for scripts/setup-workspace.sh — the script every developer after the
+# first runs to assemble the project on their machine.
+#
+# One property is under test: the workspace always gets assembled. The script clones the repos
+# the registry lists, and every measured way a clone could go wrong used to abort it under
+# `set -e` — leaving the contributor with no AGENTS.md, no CLAUDE.md and no doctor.sh at all,
+# over a repository they may not even need. So every case below asserts the same two things:
+# the run exits 0, and the three workspace files are there.
+#
+# The second half is about where a clone is allowed to land. A location the workspace does not
+# own — an absolute path from the first developer's machine, or one reaching out with `..` —
+# used to be cloned into verbatim, which put a repository outside the workspace silently
+# whenever the path happened to be writable. Those cases assert the absence of a clone, not
+# just the presence of a message.
+#
+# Assertions read the output as well as the exit status: after this change almost everything
+# exits 0, so a test that only looked at $? could not tell a clone from a refusal.
+
+set -uo pipefail
+export LC_ALL=C
+# A contributor who cannot reach a remote must fail fast rather than block on a credential
+# prompt. The unreachable-remote fixtures below would otherwise hang.
+export GIT_TERMINAL_PROMPT=0
+export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=5"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-setup-workspace-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+note() { printf '  %s\n' "$1"; }
+bad()  { printf 'FAIL: %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+# copy_template DEST — build a template fixture from HEAD, then overlay current worktree
+# changes. Archiving rather than copying the live tree leaves ignored maintainer files behind,
+# so the fixture is the shape a user downloads; the overlay keeps uncommitted edits under test.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+# bootstrap NAME LAYOUT LICENSE — generate a project and echo its workspace root. Never an
+# all-default configuration: a fixture that always picks the same license is how a hardcoded
+# example row survived three review passes in an earlier line of this work.
+bootstrap() {
+  local name="$1" layout="$2" license="$3"
+  local work="$TMP_ROOT/$name"
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Workspace setup resilience test" \
+      --license="$license" \
+      --holder="Throughstone Test" \
+      --layout="$layout" \
+      --collab=team \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.init.out" 2>&1 || {
+    bad "$name: init.sh failed"
+    sed -n '1,40p' "$TMP_ROOT/$name.init.out" >&2
+    return 1
+  }
+  printf '%s\n' "$work"
+}
+
+# teammate LABEL DOCS_SRC — build the workspace a second developer actually starts from: the
+# docs hub cloned by hand into Code/<project>-docs/, and nothing else. Every pointer file is
+# absent, which is what makes "the workspace was assembled" a real assertion rather than a
+# statement about files the fixture already had.
+teammate() {
+  local label="$1" docs_src="$2"
+  local tw="$TMP_ROOT/tw-$label"
+  rm -rf "$tw"
+  mkdir -p "$tw/Code"
+  cp -R "$docs_src" "$tw/Code/$(basename "$docs_src")"
+  printf '%s\n' "$tw"
+}
+
+registry_of() { set -- "$1"/Code/*-docs/registries/repos.yml; printf '%s\n' "$1"; }
+setup_of()    { set -- "$1"/Code/*-docs/scripts/setup-workspace.sh; printf '%s\n' "$1"; }
+
+# add_row TW — append a registry row, read from stdin, to a teammate workspace's registry.
+add_row() { cat >> "$(registry_of "$1")"; }
+
+# run_setup TW — run the workspace setup from the workspace root, capturing output and status
+# in the globals SETUP_OUT / SETUP_STATUS.
+run_setup() {
+  local tw="$1" script
+  script="$(setup_of "$tw")"
+  SETUP_OUT="$(cd "$tw" && "$script" 2>&1)"
+  SETUP_STATUS=$?
+}
+
+# assert_assembled LABEL TW — the guarantee the whole script exists to provide.
+assert_assembled() {
+  local label="$1" tw="$2" f
+  [ "$SETUP_STATUS" -eq 0 ] || bad "$label: expected exit 0, got $SETUP_STATUS"
+  for f in AGENTS.md CLAUDE.md doctor.sh; do
+    [ -e "$tw/$f" ] || bad "$label: the workspace has no $f"
+  done
+  [ -x "$tw/doctor.sh" ] || bad "$label: doctor.sh is not executable"
+}
+
+assert_out() {
+  case "$SETUP_OUT" in
+    *"$2"*) ;;
+    *) bad "$1: output does not mention: $2" ;;
+  esac
+}
+assert_not_out() {
+  case "$SETUP_OUT" in
+    *"$2"*) bad "$1: output should not mention: $2" ;;
+  esac
+}
+assert_cloned() {
+  [ -d "$2/.git" ] || bad "$1: expected a clone at $2"
+}
+assert_not_cloned() {
+  [ -e "$2" ] && bad "$1: nothing should have been written to $2"
+}
+
+# A real, local, cloneable remote. Without one, "the clone was refused" and "the clone failed"
+# look identical, and the out-of-workspace cases below are exactly about a clone that would
+# otherwise have succeeded.
+REACHABLE="$TMP_ROOT/reachable.git"
+git init -q --bare "$REACHABLE"
+seed="$TMP_ROOT/seed"
+mkdir -p "$seed"
+(
+  cd "$seed"
+  git init -q
+  printf 'seed\n' > README.md
+  git add -A
+  git -c user.email=test@example.com -c user.name=Test commit -qm "seed"
+  git branch -M main
+  git push -q "$REACHABLE" main
+) >/dev/null 2>&1 || bad "fixture: could not prepare the reachable remote"
+
+UNREACHABLE="git@setup-workspace-test.invalid:team/partner-billing.git"
+
+echo "Generating projects in both layouts ..."
+multi="$(bootstrap multi multi apache-2.0)" || exit 1
+mono="$(bootstrap mono mono bsd-3)" || exit 1
+MULTI_DOCS="$multi/Code/multi-docs"
+MONO_DOCS="$mono/Code/mono-docs"
+note "multi: $MULTI_DOCS"
+note "mono:  $MONO_DOCS"
+
+# --- Part 1. A clone that cannot happen never costs the contributor the workspace -----------
+
+echo "A repo whose remote nobody can reach ..."
+tw="$(teammate unreachable "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "partner-billing"
+    location: "Code/partner-billing/"
+    type: service
+    origin: adopted
+    control: external
+    remote: "$UNREACHABLE"
+    description: "A repo this contributor cannot reach."
+EOF
+run_setup "$tw"
+assert_assembled "unreachable remote" "$tw"
+assert_out "unreachable remote" "warning: could not clone"
+assert_out "unreachable remote" "did not arrive"
+
+echo "Something that is not a git checkout already sitting at the location ..."
+tw="$(teammate occupied "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "multi-api"
+    location: "Code/multi-api/"
+    type: service
+    origin: created
+    control: managed
+    remote: "$REACHABLE"
+    description: "A slot a stray folder already occupies."
+EOF
+mkdir -p "$tw/Code/multi-api"
+printf 'stray\n' > "$tw/Code/multi-api/notes.txt"
+run_setup "$tw"
+assert_assembled "occupied location" "$tw"
+assert_out "occupied location" "warning: could not clone"
+
+echo "A registry the parser cannot read ..."
+tw="$(teammate unreadable "$MULTI_DOCS")"
+chmod 000 "$(registry_of "$tw")"
+run_setup "$tw"
+chmod 644 "$(registry_of "$tw")"
+assert_assembled "unreadable registry" "$tw"
+
+echo "A project with no registries/ at all ..."
+tw="$(teammate noregistry "$MULTI_DOCS")"
+rm -rf "$tw"/Code/*-docs/registries
+run_setup "$tw"
+assert_assembled "no registries/" "$tw"
+assert_out "no registries/" "skipping clone step"
+
+# --- Part 2. A clone only ever lands where the workspace can own it -------------------------
+
+echo "An absolute location left over from the first developer's machine ..."
+tw="$(teammate absolute "$MULTI_DOCS")"
+outside="$TMP_ROOT/outside-the-workspace/partner-billing"
+rm -rf "$TMP_ROOT/outside-the-workspace"
+add_row "$tw" <<EOF
+
+  - name: "partner-billing"
+    location: "$outside"
+    type: service
+    origin: adopted
+    control: managed
+    remote: "$REACHABLE"
+    description: "An absolute path, with a remote that really does work."
+EOF
+run_setup "$tw"
+assert_assembled "absolute location" "$tw"
+assert_out "absolute location" "outside the workspace root"
+assert_not_out "absolute location" "cloning $REACHABLE -> $outside"
+assert_out "absolute location" "did not arrive"
+assert_not_cloned "absolute location" "$outside"
+
+echo "A location reaching out of the workspace with .. ..."
+tw="$(teammate dotdot "$MULTI_DOCS")"
+escaped="$TMP_ROOT/tw-dotdot-escaped"
+rm -rf "$escaped"
+add_row "$tw" <<EOF
+
+  - name: "escaper"
+    location: "../tw-dotdot-escaped/"
+    type: service
+    origin: adopted
+    control: managed
+    remote: "$REACHABLE"
+    description: "A relative path that leaves the workspace."
+EOF
+run_setup "$tw"
+assert_assembled "dotdot location" "$tw"
+assert_out "dotdot location" "outside the workspace root"
+assert_out "dotdot location" "did not arrive"
+assert_not_cloned "dotdot location" "$escaped"
+
+echo "A repo already checked out at an absolute location is left alone, not reported missing ..."
+tw="$(teammate inplace "$MULTI_DOCS")"
+inplace="$TMP_ROOT/in-place-repo"
+rm -rf "$inplace"
+git clone -q "$REACHABLE" "$inplace" >/dev/null 2>&1
+add_row "$tw" <<EOF
+
+  - name: "partner-billing"
+    location: "$inplace"
+    type: service
+    origin: adopted
+    control: managed
+    remote: "$REACHABLE"
+    description: "Registered in place, and really there."
+EOF
+run_setup "$tw"
+assert_assembled "in-place repo" "$tw"
+assert_out "in-place repo" "exists: $inplace"
+assert_not_out "in-place repo" "outside the workspace root"
+assert_not_out "in-place repo" "did not arrive"
+
+echo "A location outside Code/ but inside the workspace is still cloned ..."
+tw="$(teammate vendored "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "partner-lib"
+    location: "vendor/partner-lib/"
+    type: library
+    origin: adopted
+    control: managed
+    remote: "$REACHABLE"
+    description: "Outside the Code/* shell, inside the workspace root."
+EOF
+run_setup "$tw"
+assert_assembled "vendored location" "$tw"
+assert_cloned "vendored location" "$tw/vendor/partner-lib"
+assert_not_out "vendored location" "did not arrive"
+
+# --- Part 3. The ordinary paths still work --------------------------------------------------
+
+echo "The happy path, a re-run over it, and a location containing a space ..."
+tw="$(teammate happy "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "multi-api"
+    location: "Code/multi-api/"
+    type: service
+    origin: created
+    control: managed
+    remote: "$REACHABLE"
+    description: "An ordinary sibling repo."
+
+  - name: "multi web"
+    location: "Code/multi web/"
+    type: app
+    origin: created
+    control: managed
+    remote: "$REACHABLE"
+    description: "A location with a space in it."
+EOF
+run_setup "$tw"
+assert_assembled "happy path" "$tw"
+assert_cloned "happy path" "$tw/Code/multi-api"
+assert_cloned "space in location" "$tw/Code/multi web"
+assert_not_out "happy path" "did not arrive"
+
+run_setup "$tw"
+assert_assembled "re-run" "$tw"
+assert_out "re-run" "exists: Code/multi-api/"
+assert_not_out "re-run" "did not arrive"
+
+echo "A target directory that exists but is empty ..."
+tw="$(teammate emptydir "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "multi-api"
+    location: "Code/multi-api/"
+    type: service
+    origin: created
+    control: managed
+    remote: "$REACHABLE"
+    description: "An empty slot waiting for the clone."
+EOF
+mkdir -p "$tw/Code/multi-api"
+run_setup "$tw"
+assert_assembled "empty target dir" "$tw"
+assert_cloned "empty target dir" "$tw/Code/multi-api"
+
+# The mono layout's registry is a different shape — it carries a row whose location is `.`, the
+# workspace root itself, plus rows for folders inside that one repository. It is exercised here
+# for the parser's sake only: collaboration.md §9 tells a mono project not to run this script,
+# and this fixture is a multi-repo workspace root holding a mono project's registry.
+echo "The registry a mono project generates ..."
+tw="$(teammate monoshape "$MONO_DOCS")"
+run_setup "$tw"
+assert_assembled "mono registry" "$tw"
+assert_not_out "mono registry" "did not arrive"
+
+echo "A mono root row that has been given a remote ..."
+tw="$(teammate monoroot "$MONO_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "extra-root"
+    location: "."
+    type: mono
+    origin: created
+    control: managed
+    remote: "$REACHABLE"
+    description: "The workspace root, which is never an empty clone target."
+EOF
+run_setup "$tw"
+assert_assembled "mono root with a remote" "$tw"
+assert_out "mono root with a remote" "warning: could not clone"
+
+if [ "$failures" -eq 0 ]; then
+  printf 'PASS: setup-workspace.sh assembles the workspace in every measured failure shape\n'
+  exit 0
+fi
+printf 'FAILED: %d assertion(s)\n' "$failures" >&2
+exit 1


### PR DESCRIPTION
## What this does

`scripts/setup-workspace.sh` is what every developer after the first runs to assemble the project
on their machine. It cloned every repo `registries/repos.yml` gives a `remote:`, under `set -e`,
and wrote the workspace root's `AGENTS.md`, `CLAUDE.md` and `doctor.sh` **afterwards** — so any
clone that failed aborted the run before those files existed, and the contributor was left with
**no workspace at all**, over a repository they may not even need.

Three ordinary situations reproduce it, all measured this session on `git archive` fixtures: a
remote nobody on the team can reach, a stray folder or half-finished clone already sitting where a
repo should go, and a `location:` left behind as an absolute path from the first developer's
machine. Each one exits 128 with an empty workspace root.

**A failed clone is now reported and the run continues.** The pointer files are written before the
clone step, and the closing line says how many repos did not arrive instead of printing plain
success whether everything worked or nothing did. The loop is fed by process substitution rather
than a pipe, so the parser's exit status is not the script's fate and the count survives the loop
instead of dying in a subshell.

Writing the pointers first is **insurance against the next fatal path someone adds, not the fix for
this one** — and that is now proven rather than asserted: moving them back after the loop changes
nothing, because the loop can no longer abort.

**A `location:` the workspace cannot own — absolute, or reaching outside the root with `..` — is
reported and skipped rather than cloned into.** It used to be used verbatim, so a path that
happened to be writable placed a repository *outside* the workspace silently, at exit 0 — the
ordinary shape whenever a repo is registered where it already lives instead of created as a
`Code/*` sibling. The test is textual and touches no filesystem. A `location:` inside the workspace
root still clones exactly as before, including one outside the `Code/*` shell, and a repo already
checked out where its `location:` points is still left alone.

**`scripts/apply-project-license.sh` gains `--notice-only`** — write the Throughstone notice and
nothing else. The existing mode writes three files keyed on the project's license posture, and
there was no way to ask for just the notice, which is what a repository the method did not create
needs: Throughstone-authored material there should say what it is, but that project's own licensing
is not ours to state. The mode reads no posture, never touches the target's `LICENSE` or
`LICENSING.md`, and does not inherit `verify_compatible` — an existing notice is left exactly as it
is, whatever it says, because a differing notice is the state an idempotent re-run meets after the
notice text changes rather than a conflict to resolve. Every way it can fall short warns and
returns success, so a caller is never stopped by it.

Measured: **all three of the existing mode's abort arms fire on ordinary adopted repositories**,
including on an open-source project — so the abort was never a proprietary-posture edge. That mode
is unchanged, including every case where it refuses to overwrite a file it did not write.

## One thing found while building

**The behavior being narrowed shipped in 1.7 as a documented feature.** `METHOD.md` §7, the
`registries/repos.yml` header and `registries/README.md` all said `setup-workspace.sh` clones from
`remote:` into a `location:` outside `Code/*` — *"an absolute path, or any other arbitrary path"* —
and the 1.7.0 notes announced it as needing **no tooling change**. `v1.7.1` is tagged and
`README.md:114` clones it, so this is in users' hands. All three live passages are corrected here,
and the narrowing is stated plainly in both release-note files rather than shipped quietly. The
1.7.0 entries are left untouched: they record what shipped.

## Tests

New `tests/setup-workspace-resilience.sh` (380 lines). Both layouts are bootstrapped from a
`git archive HEAD` fixture with non-default licenses, and each case asserts the same two things —
the run exits 0, and all three workspace files exist. It covers every failure shape above, the
out-of-workspace cases by the **absence of a clone** rather than the presence of a message, plus
the happy path, a re-run, an empty target directory, a `location:` containing a space, a repo
already checked out at an absolute `location:`, a relative path outside `Code/*` that must still
clone, and a project with no `registries/` at all.

`tests/init-license-validation.sh` gains the new mode, exercised against the three arms that abort
without it, plus idempotence, argument errors, and a proof that the mode reads no posture: with the
posture file removed the default mode cannot run and `--notice-only` is unaffected.

**21 mutations, 21 caught** — 10 against `setup-workspace.sh`, 11 against
`apply-project-license.sh`. Two assertions were *not* load-bearing when first written and were
strengthened before that run: nothing pinned that a skipped repo is counted, and the
flag-after-target case passed with the flag ignored, because the default mode also writes a notice.
One mutation deliberately survives — the pointer ordering — and that survival is the result quoted
above. Suite 14/14.

## Release notes

`CHANGELOG.md` under Unreleased: the clone fix and the location narrowing under Fixed,
`--notice-only` under Added.

`UPDATING-THROUGHSTONE.md`'s 1.8 section tells a teammate whose run died part-way to pull and
re-run — nothing needs undoing, already-cloned repos are left alone — and to look at any
`location:` pointing outside the workspace root, which is now skipped rather than cloned into. No
edit is required and nothing of theirs is rewritten, but that repo becomes one each contributor
clones onto their own machine once.

**`--notice-only` deliberately carries no migration entry.** It is a new flag; no existing
invocation changes and there is nothing for a project to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
