### PR TITLE
Point the process docs at the registration action instead of a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,29 @@ any project built with it.
   value is an error. That last part is a small behavior change — the value used to be checked only
   in mono-repo layout, so `--registries=maybe --layout=multi` was silently accepted and now fails
   the way mono-repo already did.
+- **The process docs now name the registration action instead of describing a registry row.** Eight
+  shipped files still told an agent to go write a `registries/repos.yml` row by hand, or swept "all
+  repos" as though every one of them were on the machine. `AGENTS.md`, the substep prompt template
+  and `runbooks/collaboration.md` §8 now say *register it* and point at `runbooks/register-repo.md`;
+  none of them knows a field name any more, so they stay correct when the fields change — which is
+  the exact way the previous attempt at this rotted. The STEP plan template and the STEP index seed
+  record that a repository the method only references never appears in a STEP's Repos projection.
+  Two files change what they actually do. **The check-in's repo-README sweep is now driven by the
+  row**: the whole file where the method wrote that README, only the `## Role in <project>` section
+  where it augmented somebody else's, and nowhere else at all — there it edits nothing and re-asks
+  the one question the README answers for the project, whether someone standing in that repo can
+  still find their way back. The "do the setup steps still work from a clean checkout" check is
+  deliberately dropped for repositories the project does not own, since that is a judgement about
+  their repo rather than about our connection to it. The check-in also treats a registry row and its
+  Architecture Overview entry as **one** thing that drifts — re-run the registration, never edit
+  either by hand — and stops re-asking the licensing question per repository, which is settled once
+  for the whole project. **`runbooks/collaboration.md` §9's solo-to-team remote setup is scoped to
+  repositories the method created**: as written it would have created a second remote for a
+  repository someone else owns and pushed their history into it.
+  Three read-only sweeps — the check-in's full test run, the dependency audit, and the incident
+  runbook's hunt for similar issues — asked for "all repos" and now ask for every repo you can
+  reach, with the unreachable ones named. The failure that guards against is not missing a
+  repository; it is a partial sweep that reads as a complete one.
 
 ### Fixed
 - **One repository you cannot clone no longer costs you the whole workspace.**

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -125,7 +125,8 @@ pointers are committed files; see `METHOD.md` §7.) The repos are siblings:
 
 `registries/repos.yml` is the canonical inventory **and the index to the repos** — each
 entry points to a repo whose **README is its "about"** (what it is, how to set it up; plus an
-`ARCHITECTURE.md` if it has deep internals). **Before working in a repo, read its README
+`ARCHITECTURE.md` if it has deep internals). A repo joins it by being **registered**
+(`runbooks/register-repo.md`). **Before working in a repo, read its README
 first** — the same way you read the architecture docs before a design change.
 When creating an application-code repo, also apply the project-license posture recorded at
 bootstrap by running
@@ -167,9 +168,10 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
   rewrite an accepted ADR's decision — supersede it or append an amendment.
 - **Keep the docs true.** When implementation changes an architecture decision, update the
   affected `Code/{{PROJECT}}-docs/architecture/NN-*.md` and bump its Version Log, or write an
-  ADR. New code counts too: a new component or repo may need the Architecture Overview
-  architecture doc (`architecture/*-architecture-overview.md`) / `registries/repos.yml`, and
-  a new domain term may need the Glossary architecture doc — don't let a doc go stale (see
+  ADR. New code counts too: a new component may need the Architecture Overview architecture
+  doc (`architecture/*-architecture-overview.md`), a new **repo** is **registered**
+  (`runbooks/register-repo.md`), and a new domain term may need the Glossary architecture
+  doc — don't let a doc go stale (see
   `Code/{{PROJECT}}-docs/METHOD.md` §6).
 - **Inputs are point-in-time; `architecture/` is the living truth.** Treat anything in
   `Code/{{PROJECT}}-docs/inputs/` as a *starting point*, not a current source of truth: where a

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -88,10 +88,14 @@ recording means, in `METHOD.md` §7 and a second new runbook. Fast path:
 
 1. Pull the process docs as one review-required group (the new `runbooks/splitting-repos.md` and
    `runbooks/register-repo.md`, `runbooks/README.md`, `METHOD.md` §7,
-   `runbooks/collaboration.md` §9, `prompts/README.md`, and the header comment in
+   `runbooks/collaboration.md` §8 and §9, `prompts/README.md`, and the header comment in
    `registries/repos.yml`) — **and `templates/repo-readme-template.md` with them**, which is a
    template but belongs in this group: it carries the `## Role in <project>` section the new
-   runbook sends you to write into a repo that already exists.
+   runbook sends you to write into a repo that already exists. **The files that route to the new
+   runbook come with them**: `AGENTS.md`, `runbooks/check-in.md`,
+   `runbooks/dependency-supply-chain.md`, `runbooks/incident-postmortem.md`, and the three
+   templates you author STEPs and substeps from — `templates/substep-prompt-template.md`,
+   `templates/step-plan-template.md` and `templates/step-index-seed.md`.
 2. If you were planning to split a repo **only** in order to add a second contributor — stop.
    That rule is gone, and nothing replaces it.
 3. Add `origin:` and `control:` to each row of your `registries/repos.yml` — **details at the end of
@@ -136,15 +140,26 @@ fetches the other. The cost is stated plainly in the file
 appendix covers purging history first when that matters.
 
 - *Process docs* (`runbooks/splitting-repos.md`, `runbooks/register-repo.md`,
-  `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §9, `prompts/README.md`,
-  `registries/repos.yml`'s header, and `templates/repo-readme-template.md`): two new runbooks plus
-  the edits that route to them — `METHOD.md` §7 gains the mono→multi special case (that STEP is
+  `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §8 and §9,
+  `prompts/README.md`, `registries/repos.yml`'s header, `AGENTS.md`, `runbooks/check-in.md`,
+  `runbooks/dependency-supply-chain.md`, `runbooks/incident-postmortem.md`, and the templates
+  `repo-readme-template.md`, `substep-prompt-template.md`, `step-plan-template.md` and
+  `step-index-seed.md`): two new runbooks plus the edits that route to them —
+  `METHOD.md` §7 gains the mono→multi special case (that STEP is
   branchless, and its number is reserved on trunk), `collaboration.md` §9 gains a mono path
   through solo→team including the warning not to run `scripts/setup-workspace.sh` in a mono clone,
   and `prompts/README.md`'s thin-STEP note now names two families rather than the check-in alone.
-  `templates/repo-readme-template.md` travels with them despite being a template: it gained the
+  `AGENTS.md`, `check-in.md`, `collaboration.md` §8 and the substep template stop describing a
+  registry row and name the registration action; `check-in.md`,
+  `dependency-supply-chain.md` and `incident-postmortem.md` carry the reachability wording; the
+  two STEP templates carry the projection rule.
+  **Four templates travel with this group even though §2's buckets call templates future-only.**
+  `templates/repo-readme-template.md` gained the
   `## Role in <project>` augment form, which is what `runbooks/register-repo.md` sends you to when a
-  repo already has a README, so a 1.7 copy of it leaves the new runbook pointing at nothing.
+  repo already has a README, so a 1.7 copy of it leaves the new runbook pointing at nothing. The
+  other three are what you author STEPs and substeps from: a 1.7 substep template still sends an
+  agent off to write a registry row by hand, and the two 1.7 STEP templates carry no projection
+  rule at all.
   Apply them as a coherent group; they reference each other. No `status.sh` change, and no split-
   specific check: 1.8's new `check.sh` checks read `registries/repos.yml` for its own consistency
   and shape, and nothing detects registry drift *after a split* — a row that still describes a
@@ -189,6 +204,36 @@ control. And a repository the method only *references* never appears in a STEP's
 STEP is work Throughstone does, in repositories it controls. Both matter from the moment you mark a
 repo `external`, or run a STEP that writes into an adopted one; until then there is nothing to
 change.
+
+**Your process docs now point at that procedure, and two of them behave differently because of
+it.** Everything that used to send an agent off to write a `registries/repos.yml` row by hand —
+`AGENTS.md`, the substep prompt template, `runbooks/collaboration.md` §8 — names the registration
+action instead. None of them describes a row any more, which is what keeps them correct as the
+fields change. The two STEP templates carry the projection rule above. Two things actually behave
+differently:
+
+- **Your next check-in sweeps repo READMEs by row rather than uniformly.** Where the row says
+  Throughstone wrote that README, the sweep is what it always was — Overview, Setup / Running /
+  Testing, and any `ARCHITECTURE.md`. Where Throughstone only added a section to someone else's
+  README, the sweep is that section and nothing else. Anywhere else it edits nothing at all and
+  asks one question: can someone standing in this repo still find their way back to the project?
+  **The "do the setup steps still work from a clean checkout" check is deliberately gone for
+  repos you do not own** — that is a judgement about somebody else's repository rather than about
+  your connection to it. Two smaller shifts ride along: a registry row and its Architecture
+  Overview entry now count as **one** thing that drifts, fixed by re-running the registration
+  rather than by editing either side; and the licensing question is never re-asked per repo,
+  because that posture lives in one project-wide file.
+- **`runbooks/collaboration.md` §9 no longer stands up a remote for every repo.** Going solo to
+  team, the create-a-remote-and-push-your-history step is now scoped to repos Throughstone
+  created. As it stood, following it literally would have created a second remote for a
+  repository someone else owns and pushed their history into it. Recording a remote a repo
+  already has is unchanged, and every repo that has one still gets its `remote:` field.
+
+**Three read-only sweeps stop over-promising.** The check-in's full test run, the dependency
+audit and the incident runbook's hunt for similar issues each asked for "all repos"; they now ask
+for every repo you can reach, and for the ones you can't to be named. What that guards against is
+not missing a repo — it is a partial sweep that reads as a clean one. If every repo your project
+has is on your machine, nothing about these three changes for you.
 
 Adding the fields is a **safe additive edit**: it inserts lines into each row and changes no existing
 data. `registries/repos.yml` is your project's own record, like `inputs/inputs-index.md`, so it is

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -89,7 +89,9 @@ recording means, in `METHOD.md` §7 and a second new runbook. Fast path:
 1. Pull the process docs as one review-required group (the new `runbooks/splitting-repos.md` and
    `runbooks/register-repo.md`, `runbooks/README.md`, `METHOD.md` §7,
    `runbooks/collaboration.md` §9, `prompts/README.md`, and the header comment in
-   `registries/repos.yml`).
+   `registries/repos.yml`) — **and `templates/repo-readme-template.md` with them**, which is a
+   template but belongs in this group: it carries the `## Role in <project>` section the new
+   runbook sends you to write into a repo that already exists.
 2. If you were planning to split a repo **only** in order to add a second contributor — stop.
    That rule is gone, and nothing replaces it.
 3. Add `origin:` and `control:` to each row of your `registries/repos.yml` — **details at the end of
@@ -135,10 +137,14 @@ appendix covers purging history first when that matters.
 
 - *Process docs* (`runbooks/splitting-repos.md`, `runbooks/register-repo.md`,
   `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §9, `prompts/README.md`,
-  `registries/repos.yml`'s header): two new runbooks plus the edits that route to them — `METHOD.md` §7 gains the mono→multi special case (that
-  STEP is branchless, and its number is reserved on trunk), `collaboration.md` §9 gains a mono path
+  `registries/repos.yml`'s header, and `templates/repo-readme-template.md`): two new runbooks plus
+  the edits that route to them — `METHOD.md` §7 gains the mono→multi special case (that STEP is
+  branchless, and its number is reserved on trunk), `collaboration.md` §9 gains a mono path
   through solo→team including the warning not to run `scripts/setup-workspace.sh` in a mono clone,
   and `prompts/README.md`'s thin-STEP note now names two families rather than the check-in alone.
+  `templates/repo-readme-template.md` travels with them despite being a template: it gained the
+  `## Role in <project>` augment form, which is what `runbooks/register-repo.md` sends you to when a
+  repo already has a README, so a 1.7 copy of it leaves the new runbook pointing at nothing.
   Apply them as a coherent group; they reference each other. No `status.sh` change, and no split-
   specific check: 1.8's new `check.sh` checks read `registries/repos.yml` for its own consistency
   and shape, and nothing detects registry drift *after a split* — a row that still describes a

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -61,6 +61,12 @@ place; the Glossary architecture doc vs. the terms the code now uses. Also
 reconcile `architecture/README.md`'s index against the docs actually present (a row per doc,
 with its current version/status).
 
+**The repo registry drifts as a pair.** A repo with no row, or a row whose Architecture Overview
+entry disagrees with it, is fixed by **re-running the registration** (`register-repo.md`) —
+never by editing either side by hand, because the two move together. Rows the doctor named as
+carrying no control record are answered **as one list, once** rather than repo by repo, and
+never mechanically; `provides:` fills by looking at each repo you can reach.
+
 ### Conditional-session coverage
 
 Re-evaluate conditional architecture coverage against the system as it exists now. Enumerate
@@ -141,10 +147,14 @@ line (to `full` once the area is complete), updates related architecture docs an
 the check-in itself.
 
 Beyond the architecture docs, sweep four things that rot just as quietly:
-- **Repo READMEs** — every code repo has one, its **Overview** still describes what the repo
-  *is*, and the **Setup / Running / Testing** steps still work from a clean checkout. They're
-  stamped once at repo creation and otherwise never re-checked, so they're usually the stalest
-  doc a new contributor or agent hits first (and any `ARCHITECTURE.md` still matches the design).
+- **Repo READMEs** — usually the stalest doc a new contributor or agent hits first. Sweep each
+  repo present on this machine, led by its `readme:` status. **`ours`** — the whole file: the
+  **Overview** still describes what the repo *is*, the **Setup / Running / Testing** steps still
+  work from a clean checkout, and any `ARCHITECTURE.md` still matches the design. **`extended`**
+  — only our part, `## Role in <project>` through to the next `##`. **Anything else** — don't
+  edit it; just re-ask the one question a README has to answer for us: can someone standing in
+  this repo still find their way back to the project? Licensing is never re-asked per repo — one
+  posture, in `.throughstone/project-license`, covers the project.
 - **Interface contract artifacts** — any artifact named by `architecture/*-interface-contracts.md` (OpenAPI /
   GraphQL / protobuf / event schema / JSON Schema / public package interface, etc.) still
   matches what the service, worker, CLI, library, or import/export path actually exposes. A
@@ -215,7 +225,8 @@ Update `registries/security-reviews.yml` only when a review actually runs, not m
 the gate was evaluated.
 
 ## Part 2 — Run all tests  *(substep N.2)*
-- Run the **full** test suite (all repos), not just the area you last touched.
+- Run the **full** test suite — across every repo you can reach, not just the area you last
+  touched — and name any you can't, so a partial sweep reads as partial rather than as clean.
 - Record the result: pass/fail counts, anything skipped, and coverage if you track it. Put
   durable test-result or coverage-report details under `reports/test-results/` and summarize the
   important outcome in the check-in report.

--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -259,7 +259,7 @@ repos it touches — that single record is what keeps the history coherent acros
 - Its **PLAN lists the repos it touches and the order they merge in** (cross-repo
   sequencing). Reference commits / PRs / tags where ordering matters.
 - It uses the **same `step-NNNN` branch name in each repo** (§1).
-- If it creates a new repo, add it to `registries/repos.yml` (your-row-only, §5).
+- If it creates a new repo, **register it** (`register-repo.md`) — your row only (§5).
 
 ## 9. Going from solo to team
 The *structural* habits above you already practice solo — branch-per-STEP (§1) and allocating
@@ -270,11 +270,13 @@ flow (§6). The transition is mostly mechanical:
 
 1. **Stand up the shared remotes — and push your existing history to them first.** A solo
    dev has been committing locally with no remote, so the order matters: (a) create the remote
-   for `prompts/`, the docs hub, and each code repo, then **`git push` your existing history
-   to each** — otherwise newcomers clone empty repos and the STEP-number registry of record is
-   gone; (b) add the `remote:` fields in `registries/repos.yml`; (c) have each new contributor
-   run `scripts/setup-workspace.sh` to clone them. Number reservation (§2) relies on this
-   shared `prompts/` remote.
+   for `prompts/`, the docs hub, and each code repo **Throughstone created**, then **`git push`
+   your existing history to each** — otherwise newcomers clone empty repos and the STEP-number
+   registry of record is gone. **A repo Throughstone did not create gets neither** — never
+   create a remote for it and never push its history (`register-repo.md`); (b) add the
+   `remote:` fields in `registries/repos.yml`, for every repo that has one; (c) have each new
+   contributor run `scripts/setup-workspace.sh` to clone them. Number reservation (§2) relies
+   on this shared `prompts/` remote.
 
    **Mono-repo-for-now** (`METHOD.md` §7) has one repo, the workspace root, so this is one
    remote rather than several: create it, push the root repo's existing history to it, and have

--- a/Code/{{PROJECT}}-docs/runbooks/dependency-supply-chain.md
+++ b/Code/{{PROJECT}}-docs/runbooks/dependency-supply-chain.md
@@ -45,7 +45,9 @@ liability you're taking on — and the cheapest one is the one you don't add.
       reproducible and an upstream change can't silently alter what you ship.
 
 ## Part 2 — Periodic audit (on the check-in cadence)
-- [ ] **Scan for known vulnerabilities.** Run your ecosystem's audit across **all repos**.
+- [ ] **Scan for known vulnerabilities.** Run your ecosystem's audit across **every repo you
+      can reach** — and name any you can't, so a partial sweep reads as partial rather than
+      as clean.
       Triage the findings: patch the exploitable ones now; for any you consciously defer, record
       an **accepted-risk** row in `registries/risks.yml` with the trigger to revisit — the same
       discipline as a deferred threat in `architecture/*-security-threat-model.md` (a standing

--- a/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
+++ b/Code/{{PROJECT}}-docs/runbooks/incident-postmortem.md
@@ -69,10 +69,11 @@ doc was wrong, that's a fix for Part 4.
 ## Part 3 — Find similar issues  *(substep N.2)*
 The bug you saw is an *instance of a class*. Before fixing, **hunt the class**: search the
 codebase for the same pattern elsewhere — the same unchecked input, the same missing timeout,
-the same migration shape, the same assumption — across **all repos**, not just the file that
-broke. List every sibling you find. This is the step that turns one fix into "this whole
+the same migration shape, the same assumption — across **every repo you can reach**, not just
+the file that broke. List every sibling you find. This is the step that turns one fix into "this whole
 category can't bite us again," and it's the one most often skipped. Record what you searched for
-and what you found — including "searched X, found none," which is a real result, not a blank.
+and what you found — including "searched X, found none," which is a real result, not a blank —
+and name any repo you couldn't reach, so a partial sweep reads as partial rather than as clean.
 
 ## Part 4 — Fix & harden  *(substep N.3)*
 Fix the root cause **and** every sibling found in Part 3, in this STEP. Then close the loop so

--- a/Code/{{PROJECT}}-docs/templates/step-index-seed.md
+++ b/Code/{{PROJECT}}-docs/templates/step-index-seed.md
@@ -23,7 +23,9 @@ worked, and completed.
 > — two appended rows merge with no
 > conflict into a silent duplicate. See `runbooks/collaboration.md`.
 > **Owner** = who's on it; **Repos** = the repos it expects to touch (a *projection* that may
-> change — it powers the overlap warning, it doesn't reserve anything). Solo, leave them blank.
+> change — it powers the overlap warning, it doesn't reserve anything). A repo the method only
+> references (`control: external`) never appears there — a STEP is work Throughstone does, in
+> repositories it controls. Solo, leave them blank.
 
 ## Phase 1 — {{PHASE_1_NAME}}
 <!-- {{PHASE_1_NAME}}: kickoff (BOOTSTRAP-PROMPT.md Stage 1) fills this with the chosen phase

--- a/Code/{{PROJECT}}-docs/templates/step-plan-template.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan-template.md
@@ -5,7 +5,7 @@
 **Status:** Planned        <!-- Planned → In progress → Done; or Deferred / Abandoned (see METHOD.md §1) -->
 **Date:** {{DATE}}
 **Branch:** `step-{{NNNN}}-{{short-name}}`   <!-- same name in every repo this STEP touches -->
-**Repos (projection):** {{repos + merge order}}   <!-- same label as prompts/STEP-index.md; lists repos + merge order; powers the overlap warning -->
+**Repos (projection):** {{repos + merge order}}   <!-- same label as prompts/STEP-index.md; lists repos + merge order; powers the overlap warning. A repo the method only references (`control: external`) never appears here — a STEP is work Throughstone does, in repositories it controls. -->
 
 > One-paragraph statement of what this STEP delivers and why it comes now.
 

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
@@ -105,9 +105,10 @@ just change the code:
   architecture session (`METHOD.md` §4).
 - **New code, even when it overturns nothing:** adding a component, repo, or public surface,
   or coining a domain term, can outdate a doc that's still "correct." Update whatever's now
-  stale: the Architecture Overview architecture doc (`architecture/*-architecture-overview.md`) and `registries/repos.yml` for new
-  components/repos (a brand-new repo also gets a stamped **README whose Overview explains what
-  it is**); the **interface contract artifact** named in the Interface Contracts architecture doc
+  stale: the Architecture Overview architecture doc (`architecture/*-architecture-overview.md`)
+  for a new component — a new **repo** is registered instead (`runbooks/register-repo.md`),
+  which maintains that entry and its inventory row together; the **interface contract artifact**
+  named in the Interface Contracts architecture doc
   (`architecture/*-interface-contracts.md`) when you add or
   change an endpoint, event, webhook, CLI contract, library public API, or import/export format;
   the repo **README** when setup/run/test changes; the Glossary architecture doc
@@ -133,8 +134,9 @@ Leaving the doc stale is a defect, not a follow-up.
 - [ ] New/changed classes, functions, and methods carry docstrings (see
       `coding-standards/README.md`).
 - [ ] Any architecture decision this substep changed is reflected in the docs (Version Log
-      bumped) or recorded in an ADR — and any new component, repo, or domain term is reflected
-      in the relevant doc (overview / `repos.yml` / Glossary architecture doc).
+      bumped) or recorded in an ADR — any new component or domain term in the relevant doc
+      (overview / Glossary architecture doc), and any new repo **registered**
+      (`runbooks/register-repo.md`).
 - [ ] Any accepted risk or deferred technical debt created or changed by this substep is
       recorded in `registries/risks.yml` or explicitly marked not applicable.
 


### PR DESCRIPTION
`runbooks/register-repo.md` carries the procedure for registering a repository — its
`registries/repos.yml` row and its Architecture Overview entry, maintained together as one unit.
Eight shipped files did not know it existed. Three still told an agent to go write a row by hand,
describing the fields; three swept "all repos" as though every repository were on the machine; two
carried a STEP's Repos projection without the rule that a repository the method only *references*
never belongs in one.

This points all eight at the procedure, using **three patterns rather than eight wordings**, and
restates the control rule at none of them.

### Row-writers name the action

`AGENTS.md`, `templates/substep-prompt-template.md` and `runbooks/collaboration.md` §8 now say
*register it* and point at the runbook. None of them knows a field name any more, which is what
keeps a consumer correct when the fields change — describing the row is how the previous attempt at
this work rotted. `collaboration.md` §8 named only the registry and forgot the architecture doc;
naming the action fixes that for free, since the action maintains both. The substep template's *"a
brand-new repo also gets a stamped README"* clause goes with it: that is the registration ladder's
job now, and it is wrong for a repository the method adopted.

### Read-only sweeps stop over-promising

The check-in's full test run, the dependency audit and the incident runbook's hunt for similar
issues asked for "all repos". They now ask for every repo you can reach, and for the unreachable
ones to be named. The failure that guards against is not missing a repository — it is a partial
sweep that reads as a complete one.

### Two files change what they actually do

**`runbooks/check-in.md`'s repo-README sweep is driven by the row.** The whole file where the method
wrote that README; only the `## Role in <project>` section where it augmented somebody else's; and
anywhere else it edits nothing at all and re-asks the one question a README answers for the project
— whether someone standing in that repo can still find their way back. The *"do the setup steps
still work from a clean checkout"* check is dropped for repositories the project does not own: that
is a judgement about their repo rather than about our connection to it.

The check-in also treats a row and its Architecture Overview entry as **one** thing that drifts —
fixed by re-running the registration, never by editing either side — answers rows carrying no
control record as one list rather than repo by repo, and never re-asks the licensing question per
repository, which is settled once for the whole project in `.throughstone/project-license`.

**`runbooks/collaboration.md` §9's solo-to-team remote setup is scoped to repositories the method
created.** As written, following it literally would have created a second remote for a repository
someone else owns and pushed their history into it. Recording a remote a repository already has is
unchanged.

### Also in this PR

The first commit adds `templates/repo-readme-template.md` to the 1.8 review-required pull group, in
both places that group is enumerated. The new runbook sends an agent to that template for the
`## Role in <project>` form, and a 1.7 copy of it has no augment form at all — so an upgrader who
pulled exactly the enumerated group was left with the runbook pointing at nothing. It corrects an
unreleased section, so it carries no CHANGELOG line of its own.

### Release notes

A `CHANGELOG.md` entry, and an `UPDATING-THROUGHSTONE.md` migration entry covering both behavior
changes and the widened pull group — three STEP/substep templates travel with the process docs,
since a 1.7 substep template still sends an agent off to write a row by hand.

### Verification

- `links.sh` 0 fail; `check.sh` 0 fail / 2 warnings; suite **14/14** — all identical to the
  pre-change baseline.
- **No new tests, and the green suite is not evidence about this change.** These are prose rules in
  files no test reads. Reviewed rather than grep-tested.
- Every `runbooks/register-repo.md` pointer hand-checked to resolve, including the three inside
  `templates/`, which `links.sh` deliberately never walks.
- Measured while doing it: `links.sh` strips inline-code spans and HTML comments before parsing and
  only extracts `[text](path)` links, so backticked runbook pointers — the house style everywhere in
  this repo — are unchecked in every file, not only in `templates/`. Left as is; the mitigation is to
  hand-check pointers whenever a runbook's path moves.
- No script parses the template fields touched: `check.sh` reads `templates/step-index-seed.md` only
  for architecture-session numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
