### PR TITLE
Decide a repo exists by looking for a repository, not by reading its README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,27 @@ any project built with it.
   runbook's hunt for similar issues — asked for "all repos" and now ask for every repo you can
   reach, with the unreachable ones named. The failure that guards against is not missing a
   repository; it is a partial sweep that reads as a complete one.
+- **The planning session stops judging a repository by its README.** Its repo-scaffolding step
+  decided whether a repo the architecture names already existed by reading that repo's README — a
+  repo counted as already there only if it had a registry row **and** a README whose role one-liner
+  and Overview were filled in. That is a test of prose, and it failed in the direction that costs
+  you something: **a real repository with a thin README was judged absent and scaffolded over**,
+  which means a stack, a CI workflow, an `.env.example`, a `.gitignore` block and possibly a
+  license written into somebody's existing work. The step now asks the two questions that actually
+  answer it — is this repo already registered, and if not, is there a repository at that location,
+  meaning a repository's own work-tree root rather than a folder that looks finished. Asking the
+  registry first means a repo the project already knows about is never re-created, **including one
+  that is registered but not cloned on this machine**, which a disk test on its own would report
+  absent. Where no repository is found the step creates one exactly as before, with the whole
+  scaffolding list unchanged. Where one is found, **no stack wiring, no CI, no `.env.example`, no
+  `.gitignore` block and no project `LICENSE`** go into it, and it is registered instead — what
+  does land there is the registration action's call. Either way it goes through that one action,
+  which writes the registry row and the Architecture Overview entry together — a STEP's work, as
+  the creating always was; the session decides and outlines, and writes only the STEP-index rows.
+  A greenfield
+  first run is unchanged:
+  nothing is registered and no location holds a repository, so every repo is created exactly as it
+  is today.
 
 ### Fixed
 - **One repository you cannot clone no longer costs you the whole workspace.**

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -95,7 +95,8 @@ recording means, in `METHOD.md` §7 and a second new runbook. Fast path:
    runbook come with them**: `AGENTS.md`, `runbooks/check-in.md`,
    `runbooks/dependency-supply-chain.md`, `runbooks/incident-postmortem.md`, and the three
    templates you author STEPs and substeps from — `templates/substep-prompt-template.md`,
-   `templates/step-plan-template.md` and `templates/step-index-seed.md`.
+   `templates/step-plan-template.md` and `templates/step-index-seed.md` — **and
+   `templates/planning-session.md`**, whose repo-scaffolding step routes there too.
 2. If you were planning to split a repo **only** in order to add a second contributor — stop.
    That rule is gone, and nothing replaces it.
 3. Add `origin:` and `control:` to each row of your `registries/repos.yml` — **details at the end of
@@ -143,8 +144,9 @@ appendix covers purging history first when that matters.
   `runbooks/README.md`, `METHOD.md` §7, `runbooks/collaboration.md` §8 and §9,
   `prompts/README.md`, `registries/repos.yml`'s header, `AGENTS.md`, `runbooks/check-in.md`,
   `runbooks/dependency-supply-chain.md`, `runbooks/incident-postmortem.md`, and the templates
-  `repo-readme-template.md`, `substep-prompt-template.md`, `step-plan-template.md` and
-  `step-index-seed.md`): two new runbooks plus the edits that route to them —
+  `repo-readme-template.md`, `substep-prompt-template.md`, `step-plan-template.md`,
+  `step-index-seed.md` and `planning-session.md`): two new runbooks plus the edits that route to
+  them —
   `METHOD.md` §7 gains the mono→multi special case (that STEP is
   branchless, and its number is reserved on trunk), `collaboration.md` §9 gains a mono path
   through solo→team including the warning not to run `scripts/setup-workspace.sh` in a mono clone,
@@ -152,14 +154,17 @@ appendix covers purging history first when that matters.
   `AGENTS.md`, `check-in.md`, `collaboration.md` §8 and the substep template stop describing a
   registry row and name the registration action; `check-in.md`,
   `dependency-supply-chain.md` and `incident-postmortem.md` carry the reachability wording; the
-  two STEP templates carry the projection rule.
-  **Four templates travel with this group even though §2's buckets call templates future-only.**
+  two STEP templates carry the projection rule; and the planning session decides whether a repo
+  the architecture names already exists by looking for a repository rather than by reading a
+  README.
+  **Five templates travel with this group even though §2's buckets call templates future-only.**
   `templates/repo-readme-template.md` gained the
   `## Role in <project>` augment form, which is what `runbooks/register-repo.md` sends you to when a
   repo already has a README, so a 1.7 copy of it leaves the new runbook pointing at nothing. The
-  other three are what you author STEPs and substeps from: a 1.7 substep template still sends an
+  next three are what you author STEPs and substeps from: a 1.7 substep template still sends an
   agent off to write a registry row by hand, and the two 1.7 STEP templates carry no projection
-  rule at all.
+  rule at all. `templates/planning-session.md` is the fifth, and it is the one that changes
+  behavior — see below.
   Apply them as a coherent group; they reference each other. No `status.sh` change, and no split-
   specific check: 1.8's new `check.sh` checks read `registries/repos.yml` for its own consistency
   and shape, and nothing detects registry drift *after a split* — a row that still describes a
@@ -205,12 +210,12 @@ STEP is work Throughstone does, in repositories it controls. Both matter from th
 repo `external`, or run a STEP that writes into an adopted one; until then there is nothing to
 change.
 
-**Your process docs now point at that procedure, and two of them behave differently because of
+**Your process docs now point at that procedure, and three of them behave differently because of
 it.** Everything that used to send an agent off to write a `registries/repos.yml` row by hand —
 `AGENTS.md`, the substep prompt template, `runbooks/collaboration.md` §8 — names the registration
 action instead. None of them describes a row any more, which is what keeps them correct as the
-fields change. The two STEP templates carry the projection rule above. Two things actually behave
-differently:
+fields change. The two STEP templates carry the projection rule above. Three things actually
+behave differently:
 
 - **Your next check-in sweeps repo READMEs by row rather than uniformly.** Where the row says
   Throughstone wrote that README, the sweep is what it always was — Overview, Setup / Running /
@@ -228,6 +233,21 @@ differently:
   created. As it stood, following it literally would have created a second remote for a
   repository someone else owns and pushed their history into it. Recording a remote a repo
   already has is unchanged, and every repo that has one still gets its `remote:` field.
+- **The planning session no longer decides a repo exists by reading its README.** Its
+  repo-scaffolding step used to count a repo as already there only if it had a registry row
+  **and** a README whose role one-liner and Overview were filled in — so a real repository with a
+  thin README was judged absent and scaffolded over, writing a stack, CI, an `.env.example`, a
+  `.gitignore` block and possibly a license into somebody's existing work. It now asks whether the
+  repo is already registered, and if it is not, whether there is a repository at that location —
+  a work-tree root, not a folder that looks finished. Asking the registry first also means a repo
+  you have registered but **not cloned on this machine** is never re-created. Where no repository
+  is found, the step creates one exactly as before. Where one is found, **no stack wiring, no CI,
+  no `.env.example`, no `.gitignore` block and no project `LICENSE`** go into it, and it is
+  registered instead — what does land there is the registration action's call. Creating and
+  registering are both a STEP's
+  work, as they always were; the session decides and outlines. Adopt the reworded step.
+  Nothing of yours is rewritten, and a first run on a fresh project behaves exactly as it did in
+  1.7.
 
 **Three read-only sweeps stop over-promising.** The check-in's full test run, the dependency
 audit and the incident runbook's hunt for similar issues each asked for "all repos"; they now ask

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -64,17 +64,29 @@ STEP's PLAN with its owner rather than silently replacing its index row.
   to run that STEP (`prompts/README.md` → "Recipe: adding a new STEP"; `METHOD.md` §5).
 
 ## What to work through (with the user)
-1. **Repo scaffolding.** What repos does the Architecture Overview architecture doc
-   (`architecture/*-architecture-overview.md`) / `registries/repos.yml` name? On a first run none
-   of them exist yet, so you scaffold them all — the usual case. Just skip any that are
-   **already there:** a repo the architecture names is already there when it has a
-   `registries/repos.yml` row **with a filled-in README** (a real role one-liner + Overview, not
-   the template's placeholders), so don't re-create it. This only comes up on a **re-run** (a repo
-   you scaffolded in an earlier run is already registered) or when the project already has some of
-   these repos; if `registries/repos.yml` is absent or has no code-repo rows yet (that first run,
-   or a mono-repo), nothing is registered and every named repo scaffolds, exactly as before.
-   When repos still need creating — a first run, the usual case — the first implementation
-   STEP is almost always *"scaffold the repos and the skeleton"*: create each new code repo from
+1. **Repo scaffolding.** For each repo the Architecture Overview architecture doc
+   (`architecture/*-architecture-overview.md`) / `registries/repos.yml` names, two questions, in
+   order.
+
+   **Is it already registered?** A `registries/repos.yml` row naming that repo means it is
+   already recorded — the row and its Architecture Overview entry are one unit, maintained
+   together — so there is nothing to do here, whether or not it is cloned on this machine. On an
+   ordinary greenfield first run nothing is registered and every repo falls through to the next
+   question; on a **re-run**, this is what stops a repo an earlier run created or took on from
+   being proposed again.
+
+   **Otherwise: is there already a repository at that location?** The location is the path this
+   repo would occupy — its `Code/*` sibling by default (`METHOD.md` §7), or wherever the user
+   tells you it already lives. Ask whether that path is the **root of a repository**, or just a
+   directory inside one — a component folder in a mono repo is the latter; a repository that
+   happens to sit inside another's work tree is still the former, and one with **no commits yet**
+   is an empty slot rather than somebody's work, so treat it as absent. **A real repository with a
+   thin README is still a repository**, and scaffolding over it would write into somebody's work.
+
+   **No — create it.** The usual case on a first run. **If the path already holds files this
+   project did not put there, stop and settle that with the user rather than scaffolding into
+   it.** Otherwise the first implementation STEP is almost always *"scaffold the repos and the
+   skeleton"*: create each new code repo from
    `templates/repo-readme-template.md`, wire up the chosen stack, CI, and the environment/secrets
    baseline from the Environments architecture doc, plus any interface contract artifact placeholders or repo-local contract files
    named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each repo as its
@@ -91,13 +103,24 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    visibility is separate: when adding a remote for each code repo, choose private or public
    deliberately rather than inferring it from the license. Publishing a proprietary repo makes
    its source visible without granting open-source reuse rights, so call that out explicitly.
-   **Each
-   repo's README isn't just stamped — its role one-liner and Overview get filled in** (what
-   the repo is and the slice of the system it owns), and the repo gets a row in
-   `registries/repos.yml` with a one-line `description`; a repo isn't scaffolded until it can
-   explain itself. Confirm the repo list with the user — on a first run they're all new; note any
-   that already exist (already registered with a filled-in README) so you scaffold only the new
-   ones.
+   **Each repo's README isn't just stamped — its role one-liner and Overview get filled in**
+   (what the repo is and the slice of the system it owns); a repo isn't scaffolded until it can
+   explain itself.
+
+   **Yes — it is registered instead of scaffolded.** **No stack wiring, no CI, no `.env.example`,
+   no `.gitignore` block and no project `LICENSE`** go into it — it is an existing repository, not
+   an empty slot to scaffold into. What does land there is the register action's call, not this
+   step's.
+
+   **Both branches end at the one register action** (`runbooks/register-repo.md`), which writes
+   the row and the Architecture Overview entry together, never one without the other, and is safe
+   to re-run. **That is a STEP's work, not this session's** — the action writes on that STEP's
+   branch, and this session writes nothing but the STEP-index rows. Here you decide which repos
+   are on which branch and say so in the outline of the STEP that takes them on; **if any repo
+   needs creating or registering, make sure this phase has a STEP that does it** — a later phase
+   that only extends what already exists may have no scaffolding STEP to inherit the work.
+   Confirm the repo list with the user: which are new, which already exist, and name any you
+   could not reach.
 2. **The implementation STEP sequence.** Propose all the target phase's STEPs in dependency order —
    **build or extend what this milestone needs, given what already exists.** On a first run
    nothing is built yet, so scaffolding and the core data layer come first and you build


### PR DESCRIPTION
## What this changes

The implementation planning session's **Repo scaffolding** step decided whether a repo the
architecture names already existed by **reading that repo's README** — it counted as already there
only if it had a `registries/repos.yml` row **and** a README whose role one-liner and Overview were
filled in. That is a test of prose, and it failed in the expensive direction: **a real repository
with a thin README was judged absent and scaffolded over**, writing a stack, CI, an `.env.example`,
a `.gitignore` block and possibly a license into somebody's existing work.

The step now asks the two questions that actually answer it:

1. **Is it already registered?** A row means the repo is recorded — cloned on this machine or not —
   so there is nothing to do. Asking the registry first also stops a repo that is registered but
   **not checked out here** from being re-created, which a disk test on its own would report absent.
2. **Otherwise, is there a repository at that location?** The root of a repository rather than just
   a directory inside one. A component folder in a mono repo is not one; a repository that happens
   to sit inside another's work tree is, and the registration action records the containment rather
   than scaffolding over it. A repository with **no commits yet** counts as absent, so an empty repo
   prepared to receive the scaffold still gets it.

**Where no repository is found** the step creates one exactly as before — the scaffolding list is
unchanged — except that a path already holding files this project did not put there now stops for
the user rather than being scaffolded over. **Where one is found**, no stack wiring, no CI, no
`.env.example`, no `.gitignore` block and no project `LICENSE` go into it; it is registered instead,
and what does land there is the registration action's call.

Both branches end at the one registration action, which writes the registry row and the
Architecture Overview entry together — a STEP's work, as the creating always was. The session
decides and outlines; it writes only the STEP-index rows.

**A greenfield first run is unchanged.** Nothing is registered and no location holds a repository,
so every repo is created exactly as it is today.

`templates/planning-session.md` joins the 1.8 review-required pull group, in **both** places
`UPDATING-THROUGHSTONE.md` enumerates it, and the template count in that section moves with it.

## Related issue

None. Part of the planned line of work on how the method treats a repository it did not create;
the design and sequencing were settled before building rather than in a tracker.

## Type of change

- [ ] Bug fix
- [x] Documentation / wording
- [x] New or updated template / coding-standard
- [x] Methodology change — the session's behavior changes; planned and agreed before building
- [ ] Other:

## Review

Six passes: two reading passes and two adversarial passes by the author, one differential against
the shipped version, and **one independent cold review** of the whole change including both release
notes. The cold pass raised four issues; all four held, and one was a **regression** — an empty
repository prepared to receive the scaffold was being registered instead of scaffolded, which the
old version got right. It also caught a claim that contradicted the registration runbook: the adopt
branch said *none* of the create branch's list is written into an adopted repo, but that list
includes the README template and the Throughstone notice, and a `managed` adopted repo does get a
README section and that notice. The universal claim is gone; the enumerated exclusions, which were
each true, remain.

Three findings were declined with reasons recorded: the wrong repository occupying the intended
path, a repository existing only as an unmentioned remote, and two architecture identities
resolving to one work-tree root. All real, all pre-existing rather than introduced by this change,
and each needs the agent to know something it cannot observe; the user-confirmation step is the
existing mitigation.

## Testing

- Suite **14/14**, `links.sh` 0 fail / 104 links, `check.sh` 0 fail / 2 warnings — all
  byte-identical to `main`.
- **No new tests, deliberately.** This is prose in a template that no test reads, so a green suite
  is evidence about the rest of the repo and not about this change. Review is the gate here.
- `links.sh` does not parse backticked paths, so the pointers in the changed passage were
  hand-verified to resolve.
- **`init.sh` smoke test on a clean `git archive` of this branch**: completes, no leftover
  `{{PROJECT}}` placeholders in the changed file, the passage renders intact in the generated
  project, and the generated project's doctor reports **0 fail / 0 warning**.

## Checklist

- [ ] ~~If I changed shell~~ — N/A, no scripts changed
- [x] `Code/{{PROJECT}}-docs/scripts/check.sh` and the relevant `tests/*.sh` regressions pass
- [x] Ran a throwaway `init.sh` smoke test and confirmed a clean generated project
- [x] Kept the `{{PROJECT}}` placeholder convention intact
- [ ] Updated `METHOD.md` / `README.md` / `prompts/` for consistency — **deliberately not here.**
      `README.md`'s "Can I use this with an existing project?" answer still describes the 1.7
      behavior. It remains true, just narrower than what now happens, and it is version-attributed;
      the public-facing docs are updated together in a later change in this line of work.
