### PR TITLE
Describe what lands in a repo the method did not create

### DIFF
--- a/Code/{{PROJECT}}-docs/ONBOARDING.md
+++ b/Code/{{PROJECT}}-docs/ONBOARDING.md
@@ -39,16 +39,18 @@ From the workspace root, run the generated setup helper:
 Code/<project>-docs/scripts/setup-workspace.sh
 ```
 
-The helper clones sibling repos listed in `Code/<project>-docs/registries/repos.yml` when
-they have remotes, then writes the per-machine root files. Verify these exist at the
+The helper writes the per-machine root files first, then clones the sibling repos that
+`Code/<project>-docs/registries/repos.yml` gives a remote. Verify these exist at the
 workspace root:
 
 - `AGENTS.md`
 - `CLAUDE.md`
 - `doctor.sh`
 
-If a sibling repo has no remote in `registries/repos.yml`, `setup-workspace.sh` cannot clone
-it. Read its registry entry and ask the maintainer how that repo is provided.
+If a repo did not arrive, `setup-workspace.sh` names it and says why as it runs, then closes
+with a count. The one case it stays quiet about is a repo with no `remote:` in
+`registries/repos.yml` — it was never going to be cloned. Read its registry entry and ask the
+maintainer how that repo is provided.
 
 ## 3. Create your local user profile
 

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -41,5 +41,5 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 > this repo's `LICENSE` is the canonical project-license file copied unchanged into each
 > application-code repo when it is created. `.throughstone/project-license` records the durable
 > selection independently, and the repo-scaffolding helper validates the two before copying.
-> It also copies `LICENSE-THROUGHSTONE` for retained Throughstone-authored README and CI
-> templates and writes `LICENSING.md` so its limited scope is visible.
+> A repo Throughstone creates also gets `LICENSE-THROUGHSTONE` for the scaffold README and CI
+> templates it keeps, plus a `LICENSING.md` making that notice's limited scope visible.

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -35,7 +35,7 @@ multiple repos, turn it into a tracked STEP before applying it.
 | **Tools / scripts** | `scripts/status.sh`, `scripts/check.sh`, `scripts/setup-workspace.sh` | Review required. May be replaced when local still matches the installed baseline, but still report behavioral implications. |
 | **Process docs** | `METHOD.md`, `AGENTS.md`, `UPDATING-THROUGHSTONE.md`, `prompts/README.md`, `runbooks/*.md`, `coding-standards/*.md` | Review required. Changes may alter how contributors or agents work. Apply as a coherent group when files reference each other. |
 | **Templates for future use** | `templates/*.md`, `templates/architecture-sessions/*.md`, `templates/ci/*.yml` | Future-only by default. Updating them affects newly generated docs/sessions/repos; it does not rewrite existing generated outputs. |
-| **Stamped/generated files** | repo `README.md`, copied CI workflows, `.env.example`, STEP plans | Project-owned after creation. Never auto-update; provide advisory diffs only if explicitly requested. |
+| **Stamped/generated files** | a repo `README.md` Throughstone stamped, the `## Role in <project>` section it adds to a README the repo already had, `LICENSE-THROUGHSTONE`, copied CI workflows, `.env.example`, STEP plans | Project-owned after creation. Never auto-update; provide advisory diffs only if explicitly requested. |
 | **Project state** | `overview.md`, `architecture/`, `adr/`, `prompts/STEP-index.md`, `prompts/<phase>/`, application code repos | Never auto-update from upstream Throughstone. Changes happen through the normal method: sessions, ADRs, STEPs, and check-ins. |
 
 `prompts/README.md` is the exception inside `prompts/`: it is scaffold/process guidance for
@@ -319,6 +319,14 @@ edit is required and nothing of yours is rewritten — but a repo registered tha
 contributor clones onto their own machine once, rather than something the setup script fetches for
 them. A `location:` inside the workspace root is unaffected, including one outside the `Code/*`
 shell, and so is a repo already checked out where its `location:` points.
+
+**Three generated docs need pulling, and that is the whole action.**
+`ONBOARDING.md`, the docs hub's own `README.md` and §2's file-bucket table above were each
+written when Throughstone only ever *created* a repo. 1.8 can also take on one that already
+exists, where it writes at most two files: that repo's README and the `LICENSE-THROUGHSTONE`
+notice — never CI, never a license. `ONBOARDING.md` also still described `setup-workspace.sh`
+cloning before it writes the root pointer files, which is the order 1.8 reversed. Review the
+three like the other process docs; nothing of yours is rewritten.
 
 ### 1.7 migration
 

--- a/README.md
+++ b/README.md
@@ -441,12 +441,12 @@ docs, ADRs, scoped STEPs, tests, and a roadmap instead of a mystery pile of gene
 
 ### Can I use this with an existing project?
 
-Increasingly, yes. Throughstone began greenfield-first, and the 1.7 release removed the
-assumptions that got in the way of existing code: planning now scaffolds only repos that
-aren't already registered, plans against what's already built instead of rebuilding from
-scratch, targets the first unfinished phase rather than always Phase 1, and can register a
-repo that already lives outside the workspace. You can also drop your current design docs into
-`inputs/` and have the architecture sessions build on them.
+Increasingly, yes. Throughstone began greenfield-first, and the assumptions that got in the
+way of existing code have been coming out: planning scaffolds only repos that aren't already
+registered, plans against what's already built instead of rebuilding from scratch, targets
+the first unfinished phase rather than always Phase 1, and can register a repo that already
+lives outside the workspace. You can also drop your current design docs into `inputs/` and
+have the architecture sessions build on them.
 
 It is not yet a one-click import — there's no wizard that ingests an existing codebase for you.
 The practical path: run setup, create architecture docs and a roadmap for what you already have


### PR DESCRIPTION
## What this changes

Four passages were written when the method could only ever *create* a repository. It can now
also take on one that already exists, where it writes **at most two files** — that repo's
README and the Throughstone notice — and **never** a CI workflow, **never** a license. Each of
the four described the create path as though it were the only one.

- **Docs hub `README.md`** — the licensing blockquote promised `LICENSE-THROUGHSTONE` and a
  `LICENSING.md` without saying which repos get them. An adopted repo never gets
  `LICENSING.md`. The sentence is **scoped to the repos that get both** rather than qualified
  everywhere, so it stays one sentence.
- **`UPDATING-THROUGHSTONE.md`'s stamped/generated bucket** named "repo `README.md`" as though
  there were one form of it. There are two: the README stamped into a repo that had none, and
  the section added to a README the repo already had — the second being the one where a
  mechanical diff-and-apply against the template would be destructive. The row now names both,
  and adds `LICENSE-THROUGHSTONE`, which was stamped into repos and missing from the bucket
  entirely.
- **`ONBOARDING.md`** had the setup helper cloning sibling repos *before* writing the workspace
  root's pointer files. That order was reversed when a failing clone stopped taking the whole
  workspace down with it — and the ordering is what makes the three files the same passage
  tells you to verify always exist.
- **`ONBOARDING.md`** also gave a missing `remote:` as the only reason a sibling did not arrive.
  There are three now, so it points at the script's own output instead of listing reasons that
  change. The remote-less repo keeps its sentence: **measured**, that is the one case the
  script says nothing about and does not count, because a repo with no remote was never going
  to be cloned and is provided some other way rather than having failed.
- **`README.md`'s existing-project answer** no longer reads as though one release finished the
  job. What it lists is still accurate; the framing around it was what had gone narrow.

A **migration paragraph** tells an existing project to pull the three generated docs. None of
them is named in either enumeration of the 1.8 review-required pull group, and adding them
there would file three independent prose corrections into a group whose stated reason for
existing is that its files reference each other — so the paragraph stands on its own, and both
enumerations plus the template count in prose are unchanged.

## Release notes

**No `CHANGELOG.md` entry, deliberately.** Every one of these passages was correct in v1.7.1:
the method only created repositories then, a failed clone left no workspace rather than a
missing sibling, and the helper really did clone before writing. They go wrong only because of
what ships in this same unreleased release, and they ship corrected in it — so no released
version ever carried a wrong version of any of them.

**The migration half is split in two, which is easy to conflate:** editing
`UPDATING-THROUGHSTONE.md`'s file-bucket row is a *correction to that guide*; the new paragraph
is the *migration entry*. Separate work that happens to land in the same file.

## Type of change
- [x] Documentation / wording

## Verification

| | Result |
|---|---|
| `tests/*.sh` | **14/14 pass** |
| `scripts/links.sh` | 0 fail / 104 links — identical to baseline |
| `scripts/check.sh` | 0 fail / 2 warnings — identical to baseline |
| `init.sh` smoke test | clean `git archive` of this branch → non-interactive init → generated project's doctor **0 fail / 0 warning**, no leftover `{{PROJECT}}`, all four passages correct in the generated output |

**No new tests, and the green suite is not evidence about this change.** This is prose that no
test reads; `links.sh` and `check.sh` are byte-identical to baseline for the same reason.
Saying so explicitly rather than letting a green run stand in for review.

**What was measured rather than read off the source:** the claims about what
`scripts/setup-workspace.sh` reports. Run against a registry carrying all three cases, it named
and counted two of them and stayed silent about the remote-less repo — four rows, three repos
that did not arrive, and a closing line reading "2 repo(s)". That measurement is the reason the
remote-less sentence survives instead of being replaced by the pointer.

**No checks will run on this PR, and that is correct** — `site-publish.yml` is path-filtered to
`docs/`, `brand/site/`, `brand/publish-site.sh`, its own workflow file and `tests/site-publish.sh`,
and this change touches none of them.

## Checklist
- [x] No shell changed
- [x] `check.sh` and the `tests/*.sh` regressions pass
- [x] Ran a throwaway `init.sh` smoke test and confirmed a clean generated project
- [x] Kept the `{{PROJECT}}` placeholder convention intact
- [x] `README.md` updated in the same change; `METHOD.md` needs nothing — it already states the
      create/adopt distinction these passages were missing
