### PR TITLE
Stop two documents describing a registry model that changed underneath them

### DIFF
--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -280,10 +280,13 @@ flow (§6). The transition is mostly mechanical:
 
    **Mono-repo-for-now** (`METHOD.md` §7) has one repo, the workspace root, so this is one
    remote rather than several: create it, push the root repo's existing history to it, and have
-   each new contributor clone that single repo. Don't add `remote:` fields to
-   `registries/repos.yml` and **don't run `scripts/setup-workspace.sh`** — no row in that file is
-   a repo to clone (one *is* the repository you already have; the rest are folders inside it),
-   and the script is for multi-repo workspaces: run in a mono clone it overwrites the committed
+   each new contributor clone that single repo. Record it on the row whose `location` is `.`, the
+   same as any other repo — `init.sh` writes it when it made the remote itself, and until a row
+   has one the check-in flags it, because work with no remote lives on one laptop. A mono project
+   may sit without a remote for a while; that warning is the reminder, not an error. But **don't
+   run `scripts/setup-workspace.sh`** — no row in that file is a repo to clone (one *is* the
+   repository you already have; the rest are folders inside it), and the script is for multi-repo
+   workspaces: run in a mono clone it overwrites the committed
    root `CLAUDE.md`, `AGENTS.md` and `doctor.sh` with per-machine pointers asserting the root is
    not a repo. Everything else is the same, including number reservation, which needs a shared
    remote and not a particular number of them. Whether to split is a separate question, answered

--- a/init.sh
+++ b/init.sh
@@ -967,7 +967,10 @@ init_repo() {
 
 # record_registry_remote REPO_NAME REMOTE_URL — update registries/repos.yml after a remote is
 # attached and pushed. Both layouts use it: multi for the docs and prompts repos, mono for the
-# workspace-root row. It matches the row by name, so a pruned registry safely no-ops.
+# workspace-root row. It matches the row by name, so a pruned registry safely no-ops. Where the
+# row carries no `remote:` yet, the line goes in after `location:` — the one field a row cannot
+# lack, since the check-in fails a row without one — never after an optional field a reader is
+# told is safe to drop.
 record_registry_remote() {
   local repo="$1" remote="$2" reg="$DOCS/registries/repos.yml"
   [ -f "$reg" ] || return 0
@@ -983,7 +986,7 @@ record_registry_remote() {
        $block;
      }ems
     or
-    s{(^[ \t]*-[ \t]*name:[ \t]*"\Q$ENV{REPO}\E"[^\n]*\n(?:(?!^[ \t]*-[ \t]*name:).)*?^[ \t]*type:[^\n]*\n)}
+    s{(^[ \t]*-[ \t]*name:[ \t]*"\Q$ENV{REPO}\E"[^\n]*\n(?:(?!^[ \t]*-[ \t]*name:).)*?^[ \t]*location:[^\n]*\n)}
      {$1 . qq{    remote: "$qremote"\n}}ems;
   ' "$reg"
 }


### PR DESCRIPTION
## What this changes

Two places where shipped documentation or code still described the old registry model.

**`runbooks/collaboration.md` §9** told a mono project not to add `remote:` fields to its registry
rows. That was reversed earlier in this line of work: the row whose `location` is `.` records its
remote like any other row, and a project may sit without one while the periodic check-in reminds
it. The same paragraph tells a solo project to push before branching, so the two halves
contradicted each other.

**`init.sh`'s `record_registry_remote`** anchored its fallback insertion on `type:` — the field
`registries/repos.yml` explicitly tells the reader nothing reads and is safe to drop. Deleting
`type:` on that advice made the insertion silently no-op: both regexes fail, `perl -0pi` leaves the
file unchanged, the row keeps no remote, and nothing says why. It now anchors on `location:`, the
one field a row cannot lack — the check-in fails a row without one.

## Related issue

None — part of the repo-record line of work.

## Type of change
- [x] Bug fix
- [x] Documentation / wording

## Checklist
- [x] If I changed shell: `bash -n` and `shellcheck` pass for the affected scripts
- [x] `Code/{{PROJECT}}-docs/scripts/check.sh` and the relevant `tests/*.sh` regressions pass — suite 14/14
- [x] If I changed the wizard or templates, I ran a throwaway `init.sh` smoke test and confirmed a clean generated project
- [x] Kept the `{{PROJECT}}` placeholder convention intact
- [x] Updated `METHOD.md` / `README.md` / `prompts/` for consistency where the change affects them

## Verification

Mutation-verified: point the fallback anchor at a key no row carries and `tests/init-trunk-branch.sh`
goes red — it is the only test that reads the recorded URL back out of the pushed registry, the
other two remote-enabled tests assert on stdout alone.

Re-verified as part of the step-F acceptance gate: four generated projects pass 201 acceptance
checks, and 17 deliberate breakings of the project-creation path are all caught — including this
one, where mutating the anchor turns the mono remote assertion red.

## Note on the base branch

Stacked on #188. GitHub will retarget this to `repo-record` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
