### PR TITLE
Hold the setup wizard to what it tells you it did

### DIFF
--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -458,14 +458,16 @@ if [ "$CHECK_IN" -eq 1 ]; then
         for (i = 1; i <= n; i++) {
           if (locs[i] == "") print "location\t" names[i]
           # Covered by its own remote, or by the remote of a row at "." that contains it.
-          if (rems[i] == "" && !(root && locs[i] != ".")) print "remote\t" names[i]
+          # The location travels with the name: the fix is to push that repo, and a name alone
+          # does not say where it is.
+          if (rems[i] == "" && !(root && locs[i] != ".")) print "remote\t" names[i] "\t" locs[i]
         }
       }
     ' "$REPOS_REGISTRY")"
 
     rows="$(awk '/^[[:space:]]*#/ { next } /^[[:space:]]*-[[:space:]]*name:/ { n++ } END { print n + 0 }' "$REPOS_REGISTRY")"
     no_loc="$(printf '%s\n' "$reg_flat" | awk -F'\t' '$1 == "location" { print $2 }')"
-    no_rem="$(printf '%s\n' "$reg_flat" | awk -F'\t' '$1 == "remote"   { print $2 }')"
+    no_rem="$(printf '%s\n' "$reg_flat" | awk -F'\t' '$1 == "remote"   { print $2 " (" $3 ")" }')"
 
     if [ -n "$no_loc" ]; then
       fail "row(s) with no location: $(printf '%s' "$no_loc" | tr '\n' ' ')"

--- a/init.sh
+++ b/init.sh
@@ -1263,9 +1263,9 @@ EOF
 
 # A remote the user asked for and did not get is a failure, and the exit status has to say so —
 # --non-interactive is documented as being for scripts and CI, and a caller reading exit 0 would
-# be told the backup exists. The closing instructions above are printed first regardless: the
-# project itself is complete, and those instructions are exactly what is needed to finish the job
-# by hand. Both layouts behave identically here.
+# be told the backup exists. The closing instructions above are printed first regardless, because
+# the project itself is complete and usable — this report is about the one thing that is not.
+# Both layouts behave identically here.
 if [ -n "$REMOTE_FAILED_REPOS" ]; then
   cat >&2 <<EOF
 
@@ -1287,7 +1287,9 @@ The remote backup did not complete for:$REMOTE_FAILED_REPOS
       → if it is, does that commit match the one the line above showed?
 
   Then do whichever part is left: create the repository on your host, attach it as origin, or
-  push to it. If the branch is there and the commits match, the backup is done.
+  push to it. Once the branch is there and the commits match, record that URL as remote: on this
+  repo's row in Code/${SLUG}-docs/registries/repos.yml — until it is, every check-in reports this
+  repo as backed up nowhere.
 
 EOF
   exit 1

--- a/init.sh
+++ b/init.sh
@@ -1309,7 +1309,7 @@ if [ -n "$REMOTE_FAILED_REPOS" ]; then
 The remote backup did not complete for:$REMOTE_FAILED_REPOS
 
   Your project is complete and committed locally — nothing is missing from it and you can
-  start work now. Only the backup is outstanding.
+  start work now.
 
   A failed command tells you it did not finish, not how far it got — so find out before you
   retry. The names above are the repositories on your host, not folders here.

--- a/init.sh
+++ b/init.sh
@@ -1045,6 +1045,12 @@ commit_registry_remotes() {
   fi
 }
 
+# REMOTE_FAILED — set when a remote the user explicitly asked for could not be created or
+# pushed. It is reported at the end and decides the exit status. Until this existed the same
+# failure ended the run in one layout and was survivable in the other, purely because of where
+# each call sits relative to errexit; and the exit status told a caller the backup exists.
+REMOTE_FAILED=0
+
 # setup_remote DIR REPONAME MANUAL_URL — create/attach and push a remote.
 # GitHub mode creates a repo with gh. Manual mode attaches an existing remote URL from any Git
 # host and pushes the initialized trunk branch. MADE_REMOTE_URL is a small out-parameter used
@@ -1060,6 +1066,7 @@ setup_remote() {
       return 0
     fi
     echo "  (could not push remote for $2; check that the remote exists, is empty, and accepts your credentials)"
+    REMOTE_FAILED=1
     return 1
   fi
   if [ "$REMOTE_PROVIDER" = "github" ]; then
@@ -1069,9 +1076,11 @@ setup_remote() {
       return 0
     fi
     echo "  (skipped remote for $2)"
+    REMOTE_FAILED=1
     return 1
   fi
   echo "  (skipped remote for $2; unknown provider '$REMOTE_PROVIDER')"
+  REMOTE_FAILED=1
   return 1
 }
 
@@ -1100,6 +1109,7 @@ reuse_root_origin() {
       echo "  pushed: $ROOT_ORIGIN"
     else
       echo "  (could not push existing origin; push manually later)"
+      REMOTE_FAILED=1
     fi
   fi
   return 0
@@ -1110,10 +1120,14 @@ if [ "$LAYOUT" = "2" ]; then
   # Mono-repo: the initialized project is the workspace root. Reuse an empty non-template root
   # origin when safe; otherwise create/use a fresh remote if requested.
   init_repo "."
+  # Both calls are the last command of their construct, so under errexit a failed push would end
+  # the run right here — after the project is generated and committed, and before the closing
+  # instructions that say how to attach a remote later. The failure is not lost: setup_remote
+  # sets REMOTE_FAILED, which is reported below and decides the exit status.
   if [ "$REMOTE_PROVIDER" = "manual" ] && [ -n "$REMOTE_URL" ]; then
-    setup_remote "." "$SLUG" "$REMOTE_URL"
+    setup_remote "." "$SLUG" "$REMOTE_URL" || true
   else
-    reuse_root_origin "." || setup_remote "." "$SLUG" ""
+    reuse_root_origin "." || setup_remote "." "$SLUG" "" || true
   fi
   # The workspace-root row was seeded in step 5c, before this repo had a remote. Record the URL
   # now that one exists, the way multi does for docs and prompts below — otherwise the row stays
@@ -1149,7 +1163,11 @@ else
   REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
   their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."
 fi
-say "Done."
+if [ "$REMOTE_FAILED" = "1" ]; then
+  say "Done — with one problem."
+else
+  say "Done."
+fi
 cat <<EOF
 
 Next step:
@@ -1179,3 +1197,21 @@ Recommended optional backup:
   GitHub CLI (optional; lets Throughstone create GitHub remotes for you):
     https://cli.github.com/
 EOF
+
+# A remote the user asked for and did not get is a failure, and the exit status has to say so —
+# --non-interactive is documented as being for scripts and CI, and a caller reading exit 0 would
+# be told the backup exists. The closing instructions above are printed first regardless: the
+# project itself is complete, and those instructions are exactly what is needed to finish the job
+# by hand. Both layouts behave identically here.
+if [ "$REMOTE_FAILED" = "1" ]; then
+  cat >&2 <<EOF
+
+The remote backup you asked for was NOT set up.
+
+  Your project is complete and committed locally — nothing is missing from it, and you can
+  start work now. Only the backup is outstanding; follow the note above to create an empty
+  repository on your host and push to it.
+
+EOF
+  exit 1
+fi

--- a/init.sh
+++ b/init.sh
@@ -1208,8 +1208,10 @@ if [ "$LAYOUT" = "2" ]; then
   attaching one: an empty origin this folder already had is kept rather than replaced, though
   attaching it can itself fail. So run 'git remote -v' first to see what you actually have, then
   either push the root repo's ${TRUNK_BRANCH} branch to what is there, or create one empty repo on
-  your host and push to that. Leave registries/repos.yml's rows alone — they record your one repo
-  and the folders inside it, not repos to clone."
+  your host and push to that. Then record that URL on the row in registries/repos.yml whose
+  location is \".\", the same as any other repo — until it is there the check-in reports this
+  project as backed up nowhere. The rows below it are folders inside that one repository, not
+  repos to clone."
 else
   REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
   their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."

--- a/init.sh
+++ b/init.sh
@@ -1289,6 +1289,17 @@ EOF
 # the project itself is complete and usable — this report is about the one thing that is not.
 # Both layouts behave identically here.
 if [ -n "$REMOTE_FAILED_REPOS" ]; then
+  # Which names can appear here is decided by the layout, and so is where each one lives. Mono
+  # only ever records the bare slug, and its one repository is the workspace root; prompts/ and
+  # Code/<slug>-docs/ are folders inside it, not repos to stand in. Multi only ever records the
+  # two sibling repos, and its workspace root is not a repository at all. Naming all three in
+  # either layout offers one true mapping and two that send the reader nowhere.
+  if [ "$LAYOUT" = "2" ]; then
+    FAILED_REPO_MAP="Run these from the workspace root, the one repository this project has:"
+  else
+    FAILED_REPO_MAP="Run these from inside the local repo each name backs up — prompts/ for
+  ${SLUG}-prompts, and Code/${SLUG}-docs/ for ${SLUG}-docs:"
+  fi
   cat >&2 <<EOF
 
 The remote backup did not complete for:$REMOTE_FAILED_REPOS
@@ -1297,9 +1308,8 @@ The remote backup did not complete for:$REMOTE_FAILED_REPOS
   start work now. Only the backup is outstanding.
 
   A failed command tells you it did not finish, not how far it got — so find out before you
-  retry. The names above are the repositories on your host, not folders here; run these from
-  inside the local repo each one backs up — the workspace root for ${SLUG}, prompts/ for
-  ${SLUG}-prompts, Code/${SLUG}-docs/ for ${SLUG}-docs:
+  retry. The names above are the repositories on your host, not folders here.
+  ${FAILED_REPO_MAP}
 
     git remote -v
       → is origin attached, and to the URL you meant?

--- a/init.sh
+++ b/init.sh
@@ -1324,8 +1324,8 @@ The remote backup did not complete for:$REMOTE_FAILED_REPOS
 
   Then do whichever part is left: create the repository on your host, attach it as origin, or
   push to it. Once the branch is there and the commits match, record that URL as remote: on this
-  repo's row in Code/${SLUG}-docs/registries/repos.yml — until it is, every check-in reports this
-  repo as backed up nowhere.
+  repo's row in Code/${SLUG}-docs/registries/repos.yml if it is not already there — while that
+  field is missing, every check-in reports this repo as backed up nowhere.
 
 EOF
   exit 1

--- a/init.sh
+++ b/init.sh
@@ -1233,8 +1233,12 @@ if [ "$LAYOUT" = "2" ]; then
   project as backed up nowhere. The rows below it are folders inside that one repository, not
   repos to clone."
 else
-  REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
-  their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."
+  REMOTE_TIP="If you did not set up remotes during init, do this for each of the two repos here,
+  Code/${SLUG}-docs/ and prompts/: create an empty repo on your host, attach it from inside the
+  local one with 'git remote add origin <url>', push the ${TRUNK_BRANCH} branch to it, and only
+  then record that URL as remote: on that repo's row in Code/${SLUG}-docs/registries/repos.yml.
+  Recording last is the point — that row is what tells a teammate where to clone from, so it
+  should never name a remote the branch has not reached."
 fi
 # In mono the workspace root is the project's repository, so init.sh is in its first commit and
 # deleting it is a change like any other. In multi the root is not a repo and the file is simply

--- a/init.sh
+++ b/init.sh
@@ -54,8 +54,11 @@ normalize_license_choice() {
 
 # normalize_layout INPUT — set NORMALIZED_LAYOUT to 1 (multi) or 2 (mono).
 # Same shape and the same reason as normalize_license_choice above: one vocabulary, whichever way
-# the answer arrives. The prompt used to assign its answer raw, so anything that was not exactly
-# "2" — including the word "mono" the menu itself offers — produced a multi project in silence.
+# the answer arrives. The prompt used to assign its answer raw, and downstream is not one test but
+# many: most compare against "2", one compares against "1" and takes its else. So an unrecognised
+# value did not pick the other layout, it picked a hybrid — measured, typing "mono" left prompts/
+# a repository of its own with the scaffold licence notice absent, placed instead at the workspace
+# root, which that layout never clones.
 normalize_layout() {
   case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
     multi|multi-repo|1) NORMALIZED_LAYOUT=1 ;;
@@ -432,7 +435,7 @@ fi
 # question above already works. Both go through normalize_layout, so the two paths cannot drift.
 if [ -n "$LAYOUT_IN" ]; then
   normalize_layout "$LAYOUT_IN" \
-    || { echo "init.sh: invalid --layout '$LAYOUT_IN' (multi | mono)." >&2; exit 2; }
+    || { echo "init.sh: invalid layout '$LAYOUT_IN' (multi | mono) — from --layout or INIT_LAYOUT." >&2; exit 2; }
   LAYOUT="$NORMALIZED_LAYOUT"
 elif [ "$NONINTERACTIVE" = "1" ]; then
   LAYOUT=1
@@ -472,7 +475,7 @@ fi
 # into adr/README.md.
 if [ -n "$COLLAB_IN" ]; then
   normalize_collab "$COLLAB_IN" \
-    || { echo "init.sh: invalid --collab '$COLLAB_IN' (solo | team)." >&2; exit 2; }
+    || { echo "init.sh: invalid collab '$COLLAB_IN' (solo | team) — from --collab or INIT_COLLAB." >&2; exit 2; }
   COLLAB="$NORMALIZED_COLLAB"
 elif [ "$NONINTERACTIVE" = "1" ]; then
   COLLAB=1
@@ -999,10 +1002,16 @@ EOF
 # user no copy, and the multi layout leaves the file on disk too. Keeping both layouts alike is
 # the point.
 #
-# The committed copy has a second use. It is the substituted script, so it records which version
-# of the scaffold generated the project and which answers it was given — and nothing else in a
-# generated project records either. It is inert: the guard in section 0c looks for a marker that
-# section 3 strips, so running this copy inside a finished project refuses and exits.
+# The committed copy has a second, smaller use, and it is worth stating narrowly. It is the
+# generator's own source with this run's answers substituted into it, so it is a snapshot you can
+# diff against another project's copy. It is not a version stamp — nothing in it names a release —
+# and it is not a complete answer log: the licence posture is in .throughstone/project-license, the
+# ADR authority in adr/README.md, the trunk branch in git, the layout in the shape of the tree.
+# Nothing in a generated project records the scaffold version, which is a real gap and a separate
+# question from this one.
+#
+# It is inert: the guard in section 0c looks for a marker that section 3 strips, so running this
+# copy inside a finished project refuses and exits.
 init_repo() {
   write_gitignore "$1"
   stamp_license "$1"
@@ -1057,11 +1066,19 @@ commit_registry_remotes() {
   fi
 }
 
-# REMOTE_FAILED — set when a remote the user explicitly asked for could not be created or
-# pushed. It is reported at the end and decides the exit status. Until this existed the same
-# failure ended the run in one layout and was survivable in the other, purely because of where
-# each call sits relative to errexit; and the exit status told a caller the backup exists.
-REMOTE_FAILED=0
+# REMOTE_FAILED_REPOS — the repos whose remote the user asked for and did not get, accumulated as
+# a space-separated list so the closing report can name them; in the multi layout either repo can
+# fail alone. Every path that gives up on a requested remote records here, including the
+# missing-URL guard in setup_remote, which callers are not supposed to reach. Empty means every
+# requested remote was created and pushed.
+#
+# It exists because the two layouts disagreed about the same failure — one ended the run, the
+# other carried on — purely because of where each call sits relative to errexit, and because the
+# exit status told a caller the backup exists when it did not.
+REMOTE_FAILED_REPOS=""
+
+# note_remote_failure NAME — record a remote we asked for and did not get.
+note_remote_failure() { REMOTE_FAILED_REPOS="$REMOTE_FAILED_REPOS $1"; }
 
 # setup_remote DIR REPONAME MANUAL_URL — create/attach and push a remote.
 # GitHub mode creates a repo with gh. Manual mode attaches an existing remote URL from any Git
@@ -1071,14 +1088,17 @@ setup_remote() {
   MADE_REMOTE_URL=""
   [ "$MK_REMOTES" = "1" ] || return 0
   if [ "$REMOTE_PROVIDER" = "manual" ]; then
-    [ -n "${3:-}" ] || return 1
+    # A caller invariant, not a user error: manual mode is validated to have a URL long before
+    # this. Recorded anyway, so the flag means what its comment says whatever reaches here.
+    [ -n "${3:-}" ] || { note_remote_failure "$2"; return 1; }
     if ( cd "$1" && git remote add origin "$3" && git push -u origin "$TRUNK_BRANCH" >/dev/null ); then
       MADE_REMOTE_URL="$3"
       echo "  remote: $3"
       return 0
     fi
-    echo "  (could not push remote for $2; check that the remote exists, is empty, and accepts your credentials)"
-    REMOTE_FAILED=1
+    echo "  (could not set up the remote for $2: origin may or may not be attached, and nothing"
+    echo "   was pushed. Check that the remote exists, is empty, and accepts your credentials.)"
+    note_remote_failure "$2"
     return 1
   fi
   if [ "$REMOTE_PROVIDER" = "github" ]; then
@@ -1087,12 +1107,14 @@ setup_remote() {
       echo "  remote: $OWNER/$2"
       return 0
     fi
-    echo "  (skipped remote for $2)"
-    REMOTE_FAILED=1
+    # gh creates and pushes in one command, so a failure here says nothing about which half ran.
+    # "skipped" was the old wording and was wrong: the repository may well exist on the host.
+    echo "  (could not create and push $OWNER/$2 — it may have been created; check your host)"
+    note_remote_failure "$2"
     return 1
   fi
-  echo "  (skipped remote for $2; unknown provider '$REMOTE_PROVIDER')"
-  REMOTE_FAILED=1
+  echo "  (no remote for $2; unknown provider '$REMOTE_PROVIDER')"
+  note_remote_failure "$2"
   return 1
 }
 
@@ -1120,8 +1142,8 @@ reuse_root_origin() {
       MADE_REMOTE_URL="$ROOT_ORIGIN"
       echo "  pushed: $ROOT_ORIGIN"
     else
-      echo "  (could not push existing origin; push manually later)"
-      REMOTE_FAILED=1
+      echo "  (origin is attached but nothing was pushed to it; push it yourself later)"
+      note_remote_failure "$SLUG"
     fi
   fi
   return 0
@@ -1132,10 +1154,11 @@ if [ "$LAYOUT" = "2" ]; then
   # Mono-repo: the initialized project is the workspace root. Reuse an empty non-template root
   # origin when safe; otherwise create/use a fresh remote if requested.
   init_repo "."
-  # Both calls are the last command of their construct, so under errexit a failed push would end
-  # the run right here — after the project is generated and committed, and before the closing
-  # instructions that say how to attach a remote later. The failure is not lost: setup_remote
-  # sets REMOTE_FAILED, which is reported below and decides the exit status.
+  # The `|| true` is what keeps the run going. Without it each call is the last command of its
+  # construct, so errexit would end the run right here — after the project is generated and
+  # committed, and before the closing instructions that say how to attach a remote later. Nothing
+  # is swallowed by it: the helpers record the repo in REMOTE_FAILED_REPOS, which is reported at
+  # the end and decides the exit status.
   if [ "$REMOTE_PROVIDER" = "manual" ] && [ -n "$REMOTE_URL" ]; then
     setup_remote "." "$SLUG" "$REMOTE_URL" || true
   else
@@ -1179,15 +1202,16 @@ fi
 # deleting it is a change like any other. In multi the root is not a repo and the file is simply
 # on disk. Say whichever is true rather than one sentence that is only true in one of them.
 if [ "$LAYOUT" = "2" ]; then
-  INIT_SH_TIP="You can delete this init.sh now — it has done its job. It is part of
-your first commit, so removing it is a commit of its own. Keeping it is fine: it is
-inert, and it is the only record of which Throughstone version built this project."
+  INIT_SH_TIP="You can delete this init.sh now — it has done its job. It is in your first
+commit, so deleting the file is a change you would then commit; the copy already in that
+commit stays either way. Keeping it costs nothing: it is inert, and it is a snapshot of the
+generator that built this project."
 else
   INIT_SH_TIP="You can delete this init.sh now — it has done its job. It is not part of any
 repo here, so deleting the file is the whole of it."
 fi
-if [ "$REMOTE_FAILED" = "1" ]; then
-  say "Done — with one problem."
+if [ -n "$REMOTE_FAILED_REPOS" ]; then
+  say "Done — but the backup did not complete."
 else
   say "Done."
 fi
@@ -1226,14 +1250,17 @@ EOF
 # be told the backup exists. The closing instructions above are printed first regardless: the
 # project itself is complete, and those instructions are exactly what is needed to finish the job
 # by hand. Both layouts behave identically here.
-if [ "$REMOTE_FAILED" = "1" ]; then
+if [ -n "$REMOTE_FAILED_REPOS" ]; then
   cat >&2 <<EOF
 
-The remote backup you asked for was NOT set up.
+The remote backup did not complete for:$REMOTE_FAILED_REPOS
 
-  Your project is complete and committed locally — nothing is missing from it, and you can
-  start work now. Only the backup is outstanding; follow the note above to create an empty
-  repository on your host and push to it.
+  Your project is complete and committed locally — nothing is missing from it and you can
+  start work now. Only the backup is outstanding.
+
+  Read the messages further up before retrying. Depending on where it stopped, the remote
+  may already exist and origin may already be attached, so check first and then do whichever
+  part is left: create the repository, attach it as origin, or push to it.
 
 EOF
   exit 1

--- a/init.sh
+++ b/init.sh
@@ -991,6 +991,18 @@ EOF
 # init_repo DIR — create one generated repo with baseline files and an initial trunk commit.
 # Callers decide which directories are durable repos; this helper keeps their initial commit
 # shape consistent.
+# In the mono layout DIR is the workspace root, so `git add -A` takes in init.sh itself. That is
+# deliberate, and it was weighed: excluding it would leave every newly generated project with a
+# dirty working tree, and the next ordinary `git add -A` would commit it anyway. The script does
+# not delete itself either — not because it cannot, since an unlinked script keeps running, but
+# because reading a script while removing it is fragile, a run that failed partway would leave the
+# user no copy, and the multi layout leaves the file on disk too. Keeping both layouts alike is
+# the point.
+#
+# The committed copy has a second use. It is the substituted script, so it records which version
+# of the scaffold generated the project and which answers it was given — and nothing else in a
+# generated project records either. It is inert: the guard in section 0c looks for a marker that
+# section 3 strips, so running this copy inside a finished project refuses and exits.
 init_repo() {
   write_gitignore "$1"
   stamp_license "$1"
@@ -1163,6 +1175,17 @@ else
   REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
   their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."
 fi
+# In mono the workspace root is the project's repository, so init.sh is in its first commit and
+# deleting it is a change like any other. In multi the root is not a repo and the file is simply
+# on disk. Say whichever is true rather than one sentence that is only true in one of them.
+if [ "$LAYOUT" = "2" ]; then
+  INIT_SH_TIP="You can delete this init.sh now — it has done its job. It is part of
+your first commit, so removing it is a commit of its own. Keeping it is fine: it is
+inert, and it is the only record of which Throughstone version built this project."
+else
+  INIT_SH_TIP="You can delete this init.sh now — it has done its job. It is not part of any
+repo here, so deleting the file is the whole of it."
+fi
 if [ "$REMOTE_FAILED" = "1" ]; then
   say "Done — with one problem."
 else
@@ -1182,7 +1205,7 @@ Next step:
   right in the chat. Just describe your idea when it asks.
 
 The agent will interview you, propose a roadmap, and start the architecture STEP.
-You can delete this init.sh now — it has done its job.
+${INIT_SH_TIP}
 
 Recommended optional backup:
   You can start now; your project is saved locally with Git. For backup, sharing,

--- a/init.sh
+++ b/init.sh
@@ -1061,8 +1061,19 @@ commit_registry_remotes() {
   ( cd "$DOCS" && git add registries/repos.yml && git commit -qm "Record bootstrap remotes" )
   echo "  registry: recorded bootstrap remotes"
   if git -C "$DOCS" remote get-url origin >/dev/null 2>&1; then
+    # The repository this commit has to leave is the one that holds the registry: $DOCS in multi,
+    # the workspace root in mono, where $DOCS is a folder inside it and cannot be pushed. A failure
+    # here is a backup that did not complete like any other — the remote is left without the commit
+    # that records the remotes, so its copy of repos.yml lists none of them.
+    local reg_dir reg_name
+    if [ "$LAYOUT" = "2" ]; then
+      reg_dir="the workspace root"; reg_name="$SLUG"
+    else
+      reg_dir="$DOCS"; reg_name="${SLUG}-docs"
+    fi
     ( cd "$DOCS" && git push -q origin "$TRUNK_BRANCH" && echo "  registry: pushed remote updates" ) \
-      || echo "  (could not push registry remote updates; push ${DOCS} manually later)"
+      || { echo "  (could not push the registry commit; it is committed in ${reg_dir} and not yet sent)"
+           note_remote_failure "$reg_name"; }
   fi
 }
 
@@ -1078,8 +1089,16 @@ commit_registry_remotes() {
 # exit status told a caller the backup exists when it did not.
 REMOTE_FAILED_REPOS=""
 
-# note_remote_failure NAME — record a repo whose requested backup did not complete.
-note_remote_failure() { REMOTE_FAILED_REPOS="$REMOTE_FAILED_REPOS $1"; }
+# note_remote_failure NAME — record a repo whose requested backup did not complete. Adding a name
+# twice is possible: a repo whose first push failed keeps its attached origin, so the registry
+# push at the end of the run fails against the same repo. The list is the set of repos to go and
+# look at, so the second mention would only make the report read as though two things broke.
+note_remote_failure() {
+  case " $REMOTE_FAILED_REPOS " in
+    *" $1 "*) return 0 ;;
+  esac
+  REMOTE_FAILED_REPOS="$REMOTE_FAILED_REPOS $1"
+}
 
 # setup_remote DIR REPONAME MANUAL_URL — create/attach and push a remote.
 # GitHub mode creates a repo with gh. Manual mode attaches an existing remote URL from any Git

--- a/init.sh
+++ b/init.sh
@@ -1202,12 +1202,12 @@ fi
 # Mono keeps ONE shared remote for the single root repo. registries/repos.yml records that repo
 # and the folders inside it; no row in it is a repo to clone (runbooks/collaboration.md §9).
 if [ "$LAYOUT" = "2" ]; then
-  REMOTE_TIP="Answering no to remotes skipped creating one and pushing to it — not attaching
-  one: an empty origin this folder already had is kept rather than replaced, though attaching it
-  can itself fail. So run 'git remote -v' first to see what you actually have, then either push
-  the root repo's ${TRUNK_BRANCH} branch to what is there, or create one empty repo on your host
-  and push to that. Leave registries/repos.yml's rows alone — they record your one repo and the
-  folders inside it, not repos to clone."
+  REMOTE_TIP="If you answered no to remotes, that skipped creating one and pushing to it — not
+  attaching one: an empty origin this folder already had is kept rather than replaced, though
+  attaching it can itself fail. So run 'git remote -v' first to see what you actually have, then
+  either push the root repo's ${TRUNK_BRANCH} branch to what is there, or create one empty repo on
+  your host and push to that. Leave registries/repos.yml's rows alone — they record your one repo
+  and the folders inside it, not repos to clone."
 else
   REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
   their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."

--- a/init.sh
+++ b/init.sh
@@ -1275,7 +1275,9 @@ The remote backup did not complete for:$REMOTE_FAILED_REPOS
   start work now. Only the backup is outstanding.
 
   A failed command tells you it did not finish, not how far it got — so find out before you
-  retry, from inside the repo that is listed above:
+  retry. The names above are the repositories on your host, not folders here; run these from
+  inside the local repo each one backs up — the workspace root for ${SLUG}, prompts/ for
+  ${SLUG}-prompts, Code/${SLUG}-docs/ for ${SLUG}-docs:
 
     git remote -v
       → is origin attached, and to the URL you meant?

--- a/init.sh
+++ b/init.sh
@@ -1135,7 +1135,14 @@ reuse_root_origin() {
     fi
     return 1
   }
-  ( cd "$1" && git remote add origin "$ROOT_ORIGIN" )
+  # Checked, not trusted to errexit: this function is called on the left of an ||, which turns
+  # errexit off for its whole body. Without the check a failed attach fell straight through to the
+  # success message below. Returning 1 hands the caller its fallback, which records the failure if
+  # it cannot set up a remote either — so the outcome is reported once, not twice.
+  ( cd "$1" && git remote add origin "$ROOT_ORIGIN" ) || {
+    echo "  note: could not attach the existing origin ($ROOT_ORIGIN)"
+    return 1
+  }
   echo "  remote: reused existing origin ($ROOT_ORIGIN)"
   if [ "$MK_REMOTES" = "1" ]; then
     if ( cd "$1" && git push -u origin "$TRUNK_BRANCH" >/dev/null ); then
@@ -1191,9 +1198,12 @@ fi
 # Mono keeps ONE shared remote for the single root repo. registries/repos.yml records that repo
 # and the folders inside it; no row in it is a repo to clone (runbooks/collaboration.md §9).
 if [ "$LAYOUT" = "2" ]; then
-  REMOTE_TIP="If you did not set up remotes during init, create one empty repo on your host
-  and push the root repo's ${TRUNK_BRANCH} branch to it. Leave registries/repos.yml's rows
-  alone — they record your one repo and the folders inside it, not repos to clone."
+  REMOTE_TIP="Answering no to remotes skipped creating one and pushing to it — not attaching
+  one. If this folder already had an empty origin before you started, it is still attached. So
+  run 'git remote -v' first, then either push the root repo's ${TRUNK_BRANCH} branch to what is
+  already there, or create one empty repo on your host and push to that. Leave
+  registries/repos.yml's rows alone — they record your one repo and the folders inside it, not
+  repos to clone."
 else
   REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
   their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."

--- a/init.sh
+++ b/init.sh
@@ -52,6 +52,29 @@ normalize_license_choice() {
   esac
 }
 
+# normalize_layout INPUT — set NORMALIZED_LAYOUT to 1 (multi) or 2 (mono).
+# Same shape and the same reason as normalize_license_choice above: one vocabulary, whichever way
+# the answer arrives. The prompt used to assign its answer raw, so anything that was not exactly
+# "2" — including the word "mono" the menu itself offers — produced a multi project in silence.
+normalize_layout() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    multi|multi-repo|1) NORMALIZED_LAYOUT=1 ;;
+    mono|mono-repo|2)   NORMALIZED_LAYOUT=2 ;;
+    *)                  return 1 ;;
+  esac
+}
+
+# normalize_collab INPUT — set NORMALIZED_COLLAB to 1 (solo) or 2 (team). See normalize_layout:
+# the same defect was here, and "team" typed at the prompt produced a solo project whose ADR
+# register tells the reader they are the sole authority.
+normalize_collab() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    solo|1) NORMALIZED_COLLAB=1 ;;
+    team|2) NORMALIZED_COLLAB=2 ;;
+    *)      return 1 ;;
+  esac
+}
+
 # validate_trunk_branch NAME — accept ordinary Git branch names, reject empty/pathological
 # values before bootstrap removes the template history.
 validate_trunk_branch() {
@@ -405,19 +428,26 @@ fi
 # Repo layout — multi (default) or mono. Multi-repo turns the root into a per-machine workspace
 # shell with separate durable repos under prompts/ and Code/<project>-docs/. Mono keeps a single
 # repo at the root for projects that are not ready to split yet.
+# An unrecognised flag is fatal; an unrecognised typed answer is re-asked, the way the slug
+# question above already works. Both go through normalize_layout, so the two paths cannot drift.
 if [ -n "$LAYOUT_IN" ]; then
-  case "$(printf '%s' "$LAYOUT_IN" | tr '[:upper:]' '[:lower:]')" in
-    multi|multi-repo|1) LAYOUT=1 ;;
-    mono|mono-repo|2)   LAYOUT=2 ;;
-    *) echo "init.sh: invalid --layout '$LAYOUT_IN' (multi | mono)." >&2; exit 2 ;;
-  esac
+  normalize_layout "$LAYOUT_IN" \
+    || { echo "init.sh: invalid --layout '$LAYOUT_IN' (multi | mono)." >&2; exit 2; }
+  LAYOUT="$NORMALIZED_LAYOUT"
 elif [ "$NONINTERACTIVE" = "1" ]; then
   LAYOUT=1
 else
   echo "Repo layout:"
   echo "  1) multi-repo now  (prompts/ and Code/${SLUG}-docs/ become separate repos)"
   echo "  2) mono-repo for now  (one repo at the workspace root; split later)"
-  LAYOUT="$(ask 'Choose 1 or 2' '1')"
+  LAYOUT=""
+  while [ -z "$LAYOUT" ]; do
+    if normalize_layout "$(ask 'Choose 1 or 2' '1')"; then
+      LAYOUT="$NORMALIZED_LAYOUT"
+    else
+      echo "  -> answer 1 or 2 (the words multi and mono work too)."
+    fi
+  done
 fi
 
 # registries/ always ships, in both layouts. It carries the repo inventory that
@@ -441,18 +471,23 @@ fi
 # answer only affects prompt wording, remote guidance, and the ADR acceptance authority stamped
 # into adr/README.md.
 if [ -n "$COLLAB_IN" ]; then
-  case "$(printf '%s' "$COLLAB_IN" | tr '[:upper:]' '[:lower:]')" in
-    solo|1) COLLAB=1 ;;
-    team|2) COLLAB=2 ;;
-    *) echo "init.sh: invalid --collab '$COLLAB_IN' (solo | team)." >&2; exit 2 ;;
-  esac
+  normalize_collab "$COLLAB_IN" \
+    || { echo "init.sh: invalid --collab '$COLLAB_IN' (solo | team)." >&2; exit 2; }
+  COLLAB="$NORMALIZED_COLLAB"
 elif [ "$NONINTERACTIVE" = "1" ]; then
   COLLAB=1
 else
   echo "Working solo for now, or collaborating with others from day one?"
   echo "  1) Solo for now  (team conventions switch on later; nothing here locks you in)"
   echo "  2) Team from day one"
-  COLLAB="$(ask 'Choose 1 or 2' '1')"
+  COLLAB=""
+  while [ -z "$COLLAB" ]; do
+    if normalize_collab "$(ask 'Choose 1 or 2' '1')"; then
+      COLLAB="$NORMALIZED_COLLAB"
+    else
+      echo "  -> answer 1 or 2 (the words solo and team work too)."
+    fi
+  done
 fi
 ADR_AUTHORITY=""
 if [ "$COLLAB" = "2" ]; then

--- a/init.sh
+++ b/init.sh
@@ -1083,8 +1083,9 @@ note_remote_failure() { REMOTE_FAILED_REPOS="$REMOTE_FAILED_REPOS $1"; }
 
 # setup_remote DIR REPONAME MANUAL_URL — create/attach and push a remote.
 # GitHub mode creates a repo with gh. Manual mode attaches an existing remote URL from any Git
-# host and pushes the initialized trunk branch. MADE_REMOTE_URL is a small out-parameter used
-# only by the multi-repo registry recorder.
+# host and pushes the initialized trunk branch. Either way MADE_REMOTE_URL is set only inside the
+# success arm of the command that pushes, so a caller reading it is reading a URL the branch has
+# reached.
 setup_remote() {
   MADE_REMOTE_URL=""
   [ "$MK_REMOTES" = "1" ] || return 0

--- a/init.sh
+++ b/init.sh
@@ -1066,18 +1066,19 @@ commit_registry_remotes() {
   fi
 }
 
-# REMOTE_FAILED_REPOS — the repos whose remote the user asked for and did not get, accumulated as
-# a space-separated list so the closing report can name them; in the multi layout either repo can
-# fail alone. Every path that gives up on a requested remote records here, including the
-# missing-URL guard in setup_remote, which callers are not supposed to reach. Empty means every
-# requested remote was created and pushed.
+# REMOTE_FAILED_REPOS — the repos whose requested backup did not complete, accumulated as a
+# space-separated list so the closing report can name them; in the multi layout either repo can
+# fail alone. Read it exactly that way: a listed repo may still have an origin attached — what the
+# list says is that the branch was not confirmed to be on it. Empty means every requested backup
+# completed; it does not mean the wizard created every remote, since reuse_root_origin pushes to
+# one that was already there.
 #
 # It exists because the two layouts disagreed about the same failure — one ended the run, the
 # other carried on — purely because of where each call sits relative to errexit, and because the
 # exit status told a caller the backup exists when it did not.
 REMOTE_FAILED_REPOS=""
 
-# note_remote_failure NAME — record a remote we asked for and did not get.
+# note_remote_failure NAME — record a repo whose requested backup did not complete.
 note_remote_failure() { REMOTE_FAILED_REPOS="$REMOTE_FAILED_REPOS $1"; }
 
 # setup_remote DIR REPONAME MANUAL_URL — create/attach and push a remote.
@@ -1088,16 +1089,19 @@ setup_remote() {
   MADE_REMOTE_URL=""
   [ "$MK_REMOTES" = "1" ] || return 0
   if [ "$REMOTE_PROVIDER" = "manual" ]; then
-    # A caller invariant, not a user error: manual mode is validated to have a URL long before
-    # this. Recorded anyway, so the flag means what its comment says whatever reaches here.
+    # Not a caller error: the mono fallback calls this with no URL on purpose. Validation only
+    # demands --remote-url when the root origin cannot be reused, so a run that expected to reuse
+    # one and then could not attach it arrives here with nothing to fall back to. That is a
+    # requested backup that did not happen, so it is recorded like any other.
     [ -n "${3:-}" ] || { note_remote_failure "$2"; return 1; }
     if ( cd "$1" && git remote add origin "$3" && git push -u origin "$TRUNK_BRANCH" >/dev/null ); then
       MADE_REMOTE_URL="$3"
       echo "  remote: $3"
       return 0
     fi
-    echo "  (could not set up the remote for $2: origin may or may not be attached, and nothing"
-    echo "   was pushed. Check that the remote exists, is empty, and accepts your credentials.)"
+    echo "  (could not complete the remote for $2 — the command stopped partway, so whether"
+    echo "   origin is attached and whether the branch reached it are both unconfirmed. Check that"
+    echo "   the remote exists, is empty, and accepts your credentials.)"
     note_remote_failure "$2"
     return 1
   fi
@@ -1149,7 +1153,7 @@ reuse_root_origin() {
       MADE_REMOTE_URL="$ROOT_ORIGIN"
       echo "  pushed: $ROOT_ORIGIN"
     else
-      echo "  (origin is attached but nothing was pushed to it; push it yourself later)"
+      echo "  (origin is attached, but the push did not complete; check it and push later)"
       note_remote_failure "$SLUG"
     fi
   fi
@@ -1199,11 +1203,11 @@ fi
 # and the folders inside it; no row in it is a repo to clone (runbooks/collaboration.md §9).
 if [ "$LAYOUT" = "2" ]; then
   REMOTE_TIP="Answering no to remotes skipped creating one and pushing to it — not attaching
-  one. If this folder already had an empty origin before you started, it is still attached. So
-  run 'git remote -v' first, then either push the root repo's ${TRUNK_BRANCH} branch to what is
-  already there, or create one empty repo on your host and push to that. Leave
-  registries/repos.yml's rows alone — they record your one repo and the folders inside it, not
-  repos to clone."
+  one: an empty origin this folder already had is kept rather than replaced, though attaching it
+  can itself fail. So run 'git remote -v' first to see what you actually have, then either push
+  the root repo's ${TRUNK_BRANCH} branch to what is there, or create one empty repo on your host
+  and push to that. Leave registries/repos.yml's rows alone — they record your one repo and the
+  folders inside it, not repos to clone."
 else
   REMOTE_TIP="If you did not set up remotes during init, create empty repos on your host, add
   their URLs to registries/repos.yml, and push each local repo's ${TRUNK_BRANCH} branch."
@@ -1268,9 +1272,18 @@ The remote backup did not complete for:$REMOTE_FAILED_REPOS
   Your project is complete and committed locally — nothing is missing from it and you can
   start work now. Only the backup is outstanding.
 
-  Read the messages further up before retrying. Depending on where it stopped, the remote
-  may already exist and origin may already be attached, so check first and then do whichever
-  part is left: create the repository, attach it as origin, or push to it.
+  A failed command tells you it did not finish, not how far it got — so find out before you
+  retry, from inside the repo that is listed above:
+
+    git remote -v
+      → is origin attached, and to the URL you meant?
+    git ls-remote <that-url> ${TRUNK_BRANCH}
+      → is the branch on the remote at all?
+    git rev-parse ${TRUNK_BRANCH}
+      → if it is, does that commit match the one the line above showed?
+
+  Then do whichever part is left: create the repository on your host, attach it as origin, or
+  push to it. If the branch is there and the commits match, the backup is done.
 
 EOF
   exit 1

--- a/init.sh
+++ b/init.sh
@@ -1165,8 +1165,10 @@ if [ "$LAYOUT" = "2" ]; then
   # Mono-repo: the initialized project is the workspace root. Reuse an empty non-template root
   # origin when safe; otherwise create/use a fresh remote if requested.
   init_repo "."
-  # The `|| true` is what keeps the run going. Without it each call is the last command of its
-  # construct, so errexit would end the run right here — after the project is generated and
+  # The `|| true` is what keeps the run going, and each branch needs it for its own reason. In the
+  # first, setup_remote is a plain command in an if-body, which errexit acts on wherever it sits.
+  # In the second it is the final command of an `||` list, the one position in such a list errexit
+  # still watches. Either way the run would end right here — after the project is generated and
   # committed, and before the closing instructions that say how to attach a remote later. Nothing
   # is swallowed by it: the helpers record the repo in REMOTE_FAILED_REPOS, which is reported at
   # the end and decides the exit status.

--- a/tests/check-repo-registry.sh
+++ b/tests/check-repo-registry.sh
@@ -146,14 +146,16 @@ drop_field() {
 
 # --- 1. Greenfield, both layouts ----------------------------------------------
 # A project the method just created has no remotes when init.sh is told to make none, so its
-# first check-in warns — and names exactly the repos whose contents nothing else backs up.
+# first check-in warns — and names exactly the repos whose contents nothing else backs up. Each
+# is named with its location, because the fix is to go and push that repo and a name on its own
+# does not say where it is; the assertions below carry both, so dropping the location fails them.
 multi="$(bootstrap "registry-multi" multi apache-2.0)" || exit 1
 mono="$(bootstrap "registry-mono" mono bsd-3)"         || exit 1
 
 # Multi has no workspace-root row, so each repo stands alone and both are named.
 doctor "$multi" --check-in
 note "multi greenfield: $(printf '%s\n' "$SEC" | grep -E '^  \[' | head -1)"
-expect "[WARN] repo(s) with no remote: registry-multi-docs prompts" "multi greenfield"
+expect "[WARN] repo(s) with no remote: registry-multi-docs (Code/registry-multi-docs/) prompts (prompts/)" "multi greenfield"
 expect "Push it somewhere and record the URL in remote:" "multi greenfield hint"
 refute "[FAIL]" "multi greenfield"
 result OK "multi greenfield"
@@ -166,7 +168,7 @@ result OK "multi greenfield"
 # root itself is covered by nothing else, so it is flagged like any other repo.
 doctor "$mono" --check-in
 note "mono greenfield: $(printf '%s\n' "$SEC" | grep -E '^  \[' | head -1)"
-expect "[WARN] repo(s) with no remote: registry-mono" "mono greenfield"
+expect "[WARN] repo(s) with no remote: registry-mono (.)" "mono greenfield"
 refute "registry-mono-docs" "mono root covers the folders below it"
 refute "prompts" "mono root covers prompts/ as well"
 [ "$DOC_STATUS" -eq 0 ] || bad "mono greenfield — expected exit 0, got $DOC_STATUS"
@@ -185,14 +187,14 @@ clean "mono root remote"
 
 set_field "$multi" "prompts" remote "git@example.com:TEAM/registry-multi-prompts.git"
 doctor "$multi" --check-in
-expect "[WARN] repo(s) with no remote: registry-multi-docs" "a sibling's remote covers only itself"
+expect "[WARN] repo(s) with no remote: registry-multi-docs (Code/registry-multi-docs/)" "a sibling's remote covers only itself"
 refute "prompts" "the row that has a remote is not named"
 
 # An empty remote: is not a remote. runbooks/check-in.md tells the operator to fill in a field
 # that is "absent or empty"; the doctor has to agree with it about the second half.
 set_field "$multi" "registry-multi-docs" remote ""
 doctor "$multi" --check-in
-expect "[WARN] repo(s) with no remote: registry-multi-docs" "an empty remote reads as absent"
+expect "[WARN] repo(s) with no remote: registry-multi-docs (Code/registry-multi-docs/)" "an empty remote reads as absent"
 
 # --- 3. A row with no location: is a hard failure -------------------------------
 # location: is what setup-workspace.sh clones into and what the STEP process reads, so a row
@@ -202,7 +204,7 @@ drop_field "$multi" "prompts" location
 doctor "$multi" --check-in
 expect "[FAIL] row(s) with no location: prompts" "missing location fails"
 expect "give every row a location:" "missing location hint"
-expect "[WARN] repo(s) with no remote: registry-multi-docs" "the remote warning still speaks"
+expect "[WARN] repo(s) with no remote: registry-multi-docs (Code/registry-multi-docs/)" "the remote warning still speaks"
 result FAIL "missing location"
 [ "$DOC_STATUS" -eq 1 ] || bad "missing location — expected exit 1, got $DOC_STATUS"
 

--- a/tests/fixtures/gh-stub.sh
+++ b/tests/fixtures/gh-stub.sh
@@ -10,8 +10,15 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "$GH_LOG"
 
-# Only `gh repo create OWNER/NAME ...` is modeled. The stub creates a local bare repository
-# and adds it as origin in the current checkout, matching the init.sh side effects under test.
+# Only `gh repo create OWNER/NAME ...` is modeled. The stub creates a local bare repository,
+# adds it as origin in the current checkout, and pushes -- matching the init.sh side effects
+# under test.
+#
+# The push is the point, not a detail. init.sh invokes this with --push and treats a zero exit
+# as proof that the branch is on the remote: on that basis it records the remote's URL in
+# registries/repos.yml. A stub that created the repository and stopped reported success for an
+# upload that had not happened, so the tests modelled init.sh recording a remote for a provably
+# empty repository -- the one thing the registry is supposed never to claim.
 if [ "${1:-}" != "repo" ] || [ "${2:-}" != "create" ] || [ -z "${3:-}" ]; then
   echo "gh-stub.sh: unsupported command: $*" >&2
   exit 2
@@ -21,3 +28,9 @@ repo_name="${3##*/}"
 remote="$GH_REMOTE_ROOT/$repo_name.git"
 git init --bare -q "$remote"
 git remote add origin "$remote"
+branch="$(git symbolic-ref --short HEAD)"
+git push -q -u origin "$branch"
+# A real host leaves the created repository pointing at the branch it received. Without this the
+# bare repo's HEAD names the branch `git init` defaulted to, which never arrives, and a later
+# clone of it checks nothing out.
+git --git-dir="$remote" symbolic-ref HEAD "refs/heads/$branch"

--- a/tests/fixtures/gh-stub.sh
+++ b/tests/fixtures/gh-stub.sh
@@ -24,13 +24,31 @@ if [ "${1:-}" != "repo" ] || [ "${2:-}" != "create" ] || [ -z "${3:-}" ]; then
   exit 2
 fi
 
+# The side effects are driven by the options, not assumed. `gh repo create` only attaches a
+# remote when told which local checkout to use and what to call it, and only uploads when told to
+# -- so a stub that always did both would keep reporting success after those options were dropped
+# from init.sh, and the tests would not notice. Model the contract; do not stand in for it.
+want_source=0; want_remote=""; want_push=0
+for arg in "$@"; do
+  case "$arg" in
+    --source=.)   want_source=1 ;;
+    --remote=*)   want_remote="${arg#--remote=}" ;;
+    --push)       want_push=1 ;;
+  esac
+done
+
 repo_name="${3##*/}"
 remote="$GH_REMOTE_ROOT/$repo_name.git"
 git init --bare -q "$remote"
-git remote add origin "$remote"
-branch="$(git symbolic-ref --short HEAD)"
-git push -q -u origin "$branch"
-# A real host leaves the created repository pointing at the branch it received. Without this the
-# bare repo's HEAD names the branch `git init` defaulted to, which never arrives, and a later
-# clone of it checks nothing out.
-git --git-dir="$remote" symbolic-ref HEAD "refs/heads/$branch"
+
+# --source tells gh which checkout to attach; without it there is nothing to attach or upload.
+[ "$want_source" = "1" ] || exit 0
+[ -n "$want_remote" ] && git remote add "$want_remote" "$remote"
+if [ "$want_push" = "1" ] && [ -n "$want_remote" ]; then
+  branch="$(git symbolic-ref --short HEAD)"
+  git push -q -u "$want_remote" "$branch"
+  # A real host leaves the created repository pointing at the branch it received. Without this the
+  # bare repo's HEAD names the branch `git init` defaulted to, which never arrives, and a later
+  # clone of it checks nothing out.
+  git --git-dir="$remote" symbolic-ref HEAD "refs/heads/$branch"
+fi

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -388,6 +388,140 @@ run_registry_multi_case() {
   assert_maintainer_tests_removed "$name" "$work"
 }
 
+# refusing_remote PATH — a bare repo that accepts no push. `git ls-remote` still answers, so
+# init.sh's pre-boundary reachability check passes and the failure lands where these cases need
+# it: after the project is generated and committed, which is the only place the two layouts ever
+# disagreed about what to do next.
+refusing_remote() {
+  git init --bare -q "$1"
+  printf '#!/bin/sh\nexit 1\n' >"$1/hooks/pre-receive"
+  chmod +x "$1/hooks/pre-receive"
+}
+
+# run_remote_failure_multi_case — a backup the user asked for and did not get must not read as
+# success. The prompts remote refuses every push and the docs remote works, so this also pins
+# that only the repo that failed is named: sending someone to a repo that is fine is its own
+# defect. Multi used to exit 0 here, which told a caller -- --non-interactive is documented as
+# being for scripts and CI -- that the backup exists.
+run_remote_failure_multi_case() {
+  local name="remote-failure-multi"
+  local work="$TMP_ROOT/$name"
+  local docs_remote="$TMP_ROOT/$name-docs.git"
+  local prompts_remote="$TMP_ROOT/$name-prompts.git"
+  local status
+
+  copy_template "$work"
+  git init --bare -q "$docs_remote"
+  refusing_remote "$prompts_remote"
+  set +e
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Remote failure test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=yes \
+      --remote-provider=manual \
+      --docs-remote="$docs_remote" \
+      --prompts-remote="$prompts_remote"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+  status=$?
+  set -e
+
+  [ "$status" -ne 0 ] || {
+    echo "FAIL: $name exited 0 with a backup that did not complete" >&2
+    return 1
+  }
+  # The project is finished, so the instructions for attaching a remote by hand are exactly what
+  # the reader needs now and must survive the failure.
+  grep -Fq "Next step:" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name suppressed the closing instructions" >&2
+    return 1
+  }
+  grep -Fq "The remote backup did not complete for: $name-prompts" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not name the repo whose backup failed" >&2
+    grep -F "did not complete for" "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  if grep -F "did not complete for" "$TMP_ROOT/$name.out" | grep -Fq "$name-docs"; then
+    echo "FAIL: $name named the docs repo, whose push succeeded" >&2
+    return 1
+  fi
+  # The registry is the half that must never overstate: the repo that pushed is recorded, the
+  # one that did not is left with no remote for the check-in to flag.
+  grep -Fq "remote: \"$docs_remote\"" "$work/Code/$name-docs/registries/repos.yml" || {
+    echo "FAIL: $name did not record the remote that succeeded" >&2
+    return 1
+  }
+  if grep -Fq "$prompts_remote" "$work/Code/$name-docs/registries/repos.yml"; then
+    echo "FAIL: $name recorded a remote its branch never reached" >&2
+    return 1
+  fi
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
+# run_remote_failure_mono_case — the same failure through the other layout's code. Mono reaches
+# it by reusing an origin the folder already had, so the push is inside reuse_root_origin rather
+# than setup_remote, and it used to end the run outright: the project was generated and committed
+# and the closing instructions never printed. The origin stays attached here, which is why the
+# report is careful to say the push did not complete rather than that there is no remote.
+run_remote_failure_mono_case() {
+  local name="remote-failure-mono"
+  local work="$TMP_ROOT/$name"
+  local remote="$TMP_ROOT/$name-origin.git"
+  local status root_row
+
+  copy_template "$work"
+  refusing_remote "$remote"
+  set +e
+  (
+    cd "$work"
+    git init -q
+    git remote add origin "$remote"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Remote failure test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=mono \
+      --collab=solo \
+      --remotes=yes
+  ) >"$TMP_ROOT/$name.out" 2>&1
+  status=$?
+  set -e
+
+  [ "$status" -ne 0 ] || {
+    echo "FAIL: $name exited 0 with a backup that did not complete" >&2
+    return 1
+  }
+  grep -Fq "Next step:" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name suppressed the closing instructions" >&2
+    return 1
+  }
+  grep -Fq "The remote backup did not complete for: $name" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not name the repo whose backup failed" >&2
+    grep -F "did not complete for" "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Reused, so it is still attached -- the failure is the push, not the remote.
+  [ "$(git -C "$work" remote get-url origin)" = "$remote" ] || {
+    echo "FAIL: $name did not keep the origin it reused" >&2
+    return 1
+  }
+  root_row="$(first_registry_row "$work/Code/$name-docs/registries/repos.yml")"
+  if printf '%s\n' "$root_row" | grep -Fq 'remote:'; then
+    echo "FAIL: $name recorded a remote its branch never reached" >&2
+    printf '%s\n' "$root_row" >&2
+    return 1
+  fi
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
 # run_visibility_case NAME VISIBILITY — verify GitHub repo creation receives the requested
 # visibility flag for both generated multi-repo remotes.
 run_visibility_case() {
@@ -769,6 +903,12 @@ run_public_proprietary_case
 # --- Remote setup and missing canonical license behavior -----------------------
 run_invalid_visibility_case
 run_manual_multi_remote_case
+
+# --- A remote the user asked for and did not get -------------------------------
+# Both layouts must finish the project, print the closing instructions, name only what failed,
+# record nothing they cannot back up, and exit non-zero.
+run_remote_failure_multi_case
+run_remote_failure_mono_case
 run_missing_canonical_license_case
 
 # --- Invalid inputs fail before destructive bootstrap work ---------------------

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -431,6 +431,19 @@ run_visibility_case() {
       return 1
     fi
   fi
+
+  # The recorded remote must be one something was actually pushed to. init.sh only records a URL
+  # after gh reports success, so this is the assertion that gives that guarantee teeth: it fails
+  # if the stub ever stops pushing, and a check that repos.yml merely holds an address would not.
+  local recorded url
+  while IFS= read -r recorded; do
+    url="${recorded#*remote: \"}"; url="${url%\"}"
+    if [ -z "$(git --git-dir="$url" for-each-ref --count=1 refs/heads 2>/dev/null)" ]; then
+      echo "FAIL: $name recorded a remote nothing was pushed to: $url" >&2
+      return 1
+    fi
+  done < <(grep '^    remote: ' "$work/Code/$name-docs/registries/repos.yml")
+
   assert_maintainer_tests_removed "$name" "$work"
 }
 

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -514,6 +514,17 @@ run_remote_failure_multi_case() {
     echo "FAIL: $name named the docs repo, whose push succeeded" >&2
     return 1
   fi
+  # Where to stand is layout-decided. Multi can only ever list the two sibling repos, and its
+  # workspace root is not a repository, so offering it sends the reader somewhere they cannot run
+  # the commands below the sentence.
+  grep -Fq "Code/$name-docs/ for $name-docs" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not say which folder each named repo backs up" >&2
+    return 1
+  }
+  if grep -Fq "workspace root, the one repository" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name offered the workspace root, which is not a repository in this layout" >&2
+    return 1
+  fi
   # The registry is the half that must never overstate: the repo that pushed is recorded, the
   # one that did not is left with no remote for the check-in to flag.
   grep -Fq "remote: \"$docs_remote\"" "$work/Code/$name-docs/registries/repos.yml" || {
@@ -571,6 +582,16 @@ run_remote_failure_mono_case() {
     grep -F "did not complete for" "$TMP_ROOT/$name.out" >&2
     return 1
   }
+  # The mirror of the multi case: mono only ever lists the bare slug, and prompts/ and
+  # Code/<slug>-docs/ are folders inside the one repository rather than repos to stand in.
+  grep -Fq "Run these from the workspace root" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not point the reader at the workspace root" >&2
+    return 1
+  }
+  if grep -Fq "Code/$name-docs/ for" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name offered a folder inside the root repo as somewhere to stand" >&2
+    return 1
+  fi
   # Reused, so it is still attached -- the failure is the push, not the remote.
   [ "$(git -C "$work" remote get-url origin)" = "$remote" ] || {
     echo "FAIL: $name did not keep the origin it reused" >&2

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -388,6 +388,69 @@ run_registry_multi_case() {
   assert_maintainer_tests_removed "$name" "$work"
 }
 
+# run_typed_layout_collab_case — the layout and collaboration answers typed at the prompt, in the
+# vocabulary the menus offer. Both questions used to assign their answer raw while everything
+# downstream compared against "1" or "2", so a typed word was neither: typing "mono" built a
+# hybrid, and typing "team" built a solo project. Both now go through the same normaliser the
+# flags use, and this is the only case that enters that branch at all — every other invocation in
+# the suite passes --layout and --collab, which is the path that already normalised.
+#
+# The re-prompts are the cheap half. The assertions that matter are about the project that came
+# out: a hybrid answers the hints identically.
+run_typed_layout_collab_case() {
+  local name="typed-layout-collab"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    printf 'bogus\nmono\nnope\nteam\n' | ./init.sh \
+      --slug="$name" \
+      --desc="Typed answer test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --adr-authority="tech lead" \
+      --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  grep -Fq "answer 1 or 2 (the words multi and mono work too)" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not re-ask the layout question after an unrecognised answer" >&2
+    return 1
+  }
+  grep -Fq "answer 1 or 2 (the words solo and team work too)" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name did not re-ask the collaboration question after an unrecognised answer" >&2
+    return 1
+  }
+
+  # "mono" has to mean the mono layout, not most of it. The hybrid's signature was prompts/ left
+  # as a repository of its own while every other decision went the mono way, so these two
+  # assertions together are what separates the layouts -- neither alone does.
+  [ -d "$work/.git" ] || {
+    echo "FAIL: $name did not make the workspace root a repository" >&2
+    return 1
+  }
+  [ ! -d "$work/prompts/.git" ] || {
+    echo "FAIL: $name left prompts/ a repository of its own — the hybrid build" >&2
+    return 1
+  }
+  grep -Fq 'location: "."' "$work/Code/$name-docs/registries/repos.yml" || {
+    echo "FAIL: $name did not seed the workspace-root registry row" >&2
+    return 1
+  }
+
+  # "team" has to reach the one thing the answer decides. Solo stamps "_solo author_" on this
+  # field; the flag's value only lands there if the typed answer was read as team. Match the
+  # field and its value together: the line below it is a template comment offering "tech lead"
+  # as an example, so a bare grep for the value passes in a solo project too — measured.
+  grep -Fq '**Who accepts an ADR in this project:** tech lead' \
+    "$work/Code/$name-docs/adr/README.md" || {
+    echo "FAIL: $name did not record the ADR acceptance authority — typed 'team' read as solo" >&2
+    grep -F 'Who accepts an ADR in this project' "$work/Code/$name-docs/adr/README.md" >&2
+    return 1
+  }
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
 # refusing_remote PATH — a bare repo that accepts no push. `git ls-remote` still answers, so
 # init.sh's pre-boundary reachability check passes and the failure lands where these cases need
 # it: after the project is generated and committed, which is the only place the two layouts ever
@@ -909,6 +972,9 @@ run_manual_multi_remote_case
 # record nothing they cannot back up, and exit non-zero.
 run_remote_failure_multi_case
 run_remote_failure_mono_case
+
+# --- Typed answers, not just flags --------------------------------------------
+run_typed_layout_collab_case
 run_missing_canonical_license_case
 
 # --- Invalid inputs fail before destructive bootstrap work ---------------------

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -432,17 +432,35 @@ run_visibility_case() {
     fi
   fi
 
-  # The recorded remote must be one something was actually pushed to. init.sh only records a URL
-  # after gh reports success, so this is the assertion that gives that guarantee teeth: it fails
-  # if the stub ever stops pushing, and a check that repos.yml merely holds an address would not.
-  local recorded url
+  # Every recorded remote must hold this project's trunk, at this project's commit. init.sh only
+  # records a URL after gh reports success, and this is what gives that guarantee teeth: an
+  # address in repos.yml proves nothing, and neither does an arbitrary branch on the far end.
+  #
+  # The count is asserted first and deliberately. A loop fed by grep runs zero times when the file
+  # holds no rows, and passes -- so without this the whole check could succeed having examined
+  # nothing at all.
+  local recorded url rowname local_repo want_sha got_sha n=0
   while IFS= read -r recorded; do
+    n=$((n + 1))
     url="${recorded#*remote: \"}"; url="${url%\"}"
-    if [ -z "$(git --git-dir="$url" for-each-ref --count=1 refs/heads 2>/dev/null)" ]; then
-      echo "FAIL: $name recorded a remote nothing was pushed to: $url" >&2
+    rowname="$(basename "${url%.git}")"
+    case "$rowname" in
+      "$name-docs") local_repo="$work/Code/$name-docs" ;;
+      "$name-prompts") local_repo="$work/prompts" ;;
+      *) echo "FAIL: $name recorded a remote for an unexpected repo: $url" >&2; return 1 ;;
+    esac
+    want_sha="$(git -C "$local_repo" rev-parse HEAD)"
+    got_sha="$(git --git-dir="$url" rev-parse "refs/heads/$(git -C "$local_repo" symbolic-ref --short HEAD)" 2>/dev/null || true)"
+    if [ "$got_sha" != "$want_sha" ]; then
+      echo "FAIL: $name's remote $url does not hold $local_repo's trunk" >&2
+      echo "      local $want_sha / remote ${got_sha:-<no such branch>}" >&2
       return 1
     fi
   done < <(grep '^    remote: ' "$work/Code/$name-docs/registries/repos.yml")
+  if [ "$n" -ne 2 ]; then
+    echo "FAIL: $name recorded $n remote(s) in repos.yml; expected 2 (docs and prompts)" >&2
+    return 1
+  fi
 
   assert_maintainer_tests_removed "$name" "$work"
 }

--- a/tests/init-mono-origin-reuse.sh
+++ b/tests/init-mono-origin-reuse.sh
@@ -105,6 +105,7 @@ run_empty_origin_push_without_gh_case() {
   local name="mono-empty-origin-push"
   local work="$TMP_ROOT/$name"
   local remote="$TMP_ROOT/$name-origin.git"
+  local root_row
 
   copy_template "$work"
   git init --bare -q "$remote"
@@ -126,6 +127,32 @@ run_empty_origin_push_without_gh_case() {
   git --git-dir="$remote" rev-parse --verify refs/heads/main >/dev/null
   grep -Fq "remote: reused existing origin ($remote)" "$TMP_ROOT/$name.out"
   grep -Fq "pushed: $remote" "$TMP_ROOT/$name.out"
+
+  # A mono project records its one repository's remote on the row whose location is ".", and the
+  # check-in flags that row until it does. Nothing else in the suite reads a remote back out of a
+  # mono registry -- the multi read-back lives in tests/init-license-validation.sh -- so deleting
+  # the write left every case green while every generated mono project reported its own repo as
+  # backed up nowhere.
+  root_row="$(awk '/^[[:space:]]*-[[:space:]]*name:/ { n++ } n == 1' \
+    "$work/Code/$name-docs/registries/repos.yml")"
+  printf '%s\n' "$root_row" | grep -Fq 'location: "."' || {
+    echo "FAIL: the first registry row is not the workspace root" >&2
+    printf '%s\n' "$root_row" >&2
+    return 1
+  }
+  printf '%s\n' "$root_row" | grep -Fq "remote: \"$remote\"" || {
+    echo "FAIL: the workspace-root row did not record the remote it pushed to" >&2
+    printf '%s\n' "$root_row" >&2
+    return 1
+  }
+  # The recorded URL has to be one the branch reached, and reached at this commit. Asserting the
+  # ref exists is not enough: recording happens before the second commit that carries it, so a
+  # remote left behind at the initial commit still has a main to find.
+  [ "$(git --git-dir="$remote" rev-parse refs/heads/main)" = "$(git -C "$work" rev-parse HEAD)" ] || {
+    echo "FAIL: the recorded remote does not hold the local trunk" >&2
+    echo "      local $(git -C "$work" rev-parse HEAD) / remote $(git --git-dir="$remote" rev-parse refs/heads/main)" >&2
+    return 1
+  }
 }
 
 run_non_empty_origin_case

--- a/tests/init-trunk-branch.sh
+++ b/tests/init-trunk-branch.sh
@@ -95,7 +95,10 @@ run_manual_remote_custom_case() {
     | grep -Fq "remote: \"$docs_remote\""
   grep -Fq '**shared trunk** (`master`)' \
     "$work/Code/$name-docs/runbooks/collaboration.md"
-  grep -Fq "push each local repo's master branch" "$TMP_ROOT/$name.out"
+  # The chosen trunk name has to reach the closing text, which is the only instruction most
+  # users get about backups. Match the whole clause rather than the bare word: "master" appears
+  # elsewhere in that output for other reasons.
+  grep -Fq "push the master branch to it" "$TMP_ROOT/$name.out"
 }
 
 run_mono_reused_origin_custom_case() {


### PR DESCRIPTION
## What this changes

Four defects in the setup wizard, found while verifying an unrelated change and all pre-dating it.
Each is on the once-per-project path; none touches the registry work.

**Typed answers now share the flags' vocabulary.** The layout and collaboration questions accepted
the friendly word from a flag and rejected it from a prompt, then compared the raw answer against
`"1"` / `"2"` downstream. Typing `mono` did not build the other layout — it built a hybrid, because
most branches compare against `"2"` and one compares against `"1"` and takes its else, so `prompts/`
became a shared repository with the scaffold licence notice absent, placed instead at a workspace
root that layout never clones. Typing `team` produced a project whose ADR register never records
who accepts an ADR. Both now run through one normaliser each, the shape `normalize_license_choice`
already uses; a bad flag stays fatal, a bad typed answer is re-asked like the slug question above.

**A failed remote finishes the run and reports itself.** The same push failure ended the run in the
mono layout and was survivable in multi — not by decision, but because of where each call sits
relative to errexit. Multi also exited 0, telling a caller the backup exists; `--non-interactive`
is documented as being for scripts and CI. Both layouts now print the closing instructions, name
the repos whose backup did not complete, and exit non-zero.

**The gh stand-in does what it stands for.** It created a repository, attached origin and exited 0
without pushing, so the tests modelled `init.sh` recording a remote for a provably empty repository
— the one thing that registry must never claim. It now reads its options and performs only the side
effects they request, and the assertion beside it compares each recorded remote's trunk against the
commit the local repository holds.

**The closing note says what deleting `init.sh` costs.** In multi the root is not a repository and
deleting the file is the whole of it; in mono it is in the first commit. Behaviour is unchanged and
deliberate: excluding it would leave every new project with a dirty tree, and the next `git add -A`
would commit it anyway.

Three of the eight commits are corrections from review rounds, kept separate rather than folded in.

## Rebased onto `repo-record`

This branch was written against `main` and now targets the `repo-record` integration branch, which
had moved `init.sh` underneath it: mono seeds its workspace-root row and records that repo's remote
on it, `reuse_root_origin` reports the URL in `MADE_REMOTE_URL` and only after a successful push,
`commit_registry_remotes` lost its multi-only guard, and the deleted `provides:` / `control:` fields
took their assertions out of `tests/init-license-validation.sh`.

Three commits conflicted, all on the same six lines — the push inside `reuse_root_origin`, which
each side had rewritten. `repo-record` turned it into an `if` / `then` that sets `MADE_REMOTE_URL`
on success; this branch turned it into an `||` list that calls `note_remote_failure`. Resolved by
keeping `repo-record`'s shape and putting `note_remote_failure` in its `else`. Nothing else moved:
the added and removed line sets of the pre-rebase and post-rebase net diffs are identical apart
from exactly those lines.

## Then reviewed on the new base

Eleven findings, all reproduced by running them, all fixed here — one commit each. Four were this
branch's own: the mono closing tip asserting the reader answered no to remotes, on every mono run
including one that had just created and pushed a remote; the `|| true` comment giving a reason
bash does not support; the failure report naming host repositories as places to stand; and that
report walking the reader through finishing the backup without the step that clears the warning
they will otherwise get at every check-in.

Three were already on `repo-record` and sat inside what this branch rewrote: `init.sh` telling a
mono project to leave `registries/repos.yml` alone, which the runbook, the doctor and `init.sh`
itself now contradict; `setup_remote`'s header naming who reads its out-parameter, which stopped
being true when mono started reading it; and a refused registry push returning success, so the run
said `Done.` and exited 0 with the remote a commit behind and its copy of `repos.yml` listing no
remotes at all.

Three were coverage, and the first is the one that mattered: **nothing tested the failure this
branch exists to handle.** Replacing the accumulator with `note_remote_failure() { :; }` — which
reverts the change outright — left the suite green. Neither did anything answer the layout or
collaboration question at the prompt, which is the branch the other change rewrote, nor read a
`remote:` back out of a mono registry. The last is the path the rebase had to merge by hand.

The eleventh came from sweeping for the same defects elsewhere: the doctor names a repo with no
remote but not where it is.

`runbooks/splitting-repos.md:98` states the same retired rule as the mono tip and is deliberately
left alone — another runbook, and the clause is load-bearing in its Part 1 / Part 2 routing
argument, which needs its own read.

## Then read cold, as the text a generated project prints

The closing output of four real runs was handed to an outside fresh reader, with the code behind
it stated as fact and no diff. It found three more, and one of them is the sharpest thing in this
branch: **the folder mapping added above was wrong in both layouts.** It printed all three
mappings unconditionally, and which repository names can appear is layout-decided — so mono was
offered `prompts/` and `Code/<slug>-docs/`, which are folders inside its one repository, and multi
was offered "the workspace root", which in that layout is not a repository at all. Each layout got
one true mapping and two that send the reader somewhere they cannot run the commands underneath.
That is a correction introducing the fault it was written to fix, and it is now layout-aware, with
both failure cases asserting the mapping they should get and the absence of the other's.

It also landed, independently, the one open item deliberately withheld from it: the multi backup
tip told the reader to record a URL before pushing, which is the order `collaboration.md` §9
spells out the other way round and gives the reason for. Reading it cold turned up two more faults
in the same sentence — there is no `registries/` at a multi workspace root, and nothing said to
attach the remote at all, so following it literally leaves nothing pushed. It now reads create,
attach, push, record, with the real path.

A deletion pass over the same text named three candidates and one was taken: a line the failure
report already made twice. The other two answer a question the reader is actually being asked, and
a deletion-framed review ratchets downward as mechanically as a review-framed one ratchets up.

A second cold read, hardened — the current text, a list of what the first round already fixed so it
could not be re-reported, and quote-verbatim-or-drop — graded those fixes correct and found one
more. Two different failures print the closing report, and its last sentence was written for one of
them: when a repo's own push is refused the row carries no `remote:` and the sentence holds, but
when the pushes succeed and the *registry commit's* push is refused, the URL was recorded before
that commit and the check-in answers `[PASS]`. That second path is one this branch created. The
sentence is qualified rather than branched, since which failure occurred is not carried anywhere
and threading it through would buy precision over an uncommon failure at the cost of real plumbing.

## Related issue

None.

## Type of change
- [x] Bug fix
- [x] Documentation / wording

## Checklist
- [x] If I changed shell: `bash -n` and `shellcheck` pass for the affected scripts
- [x] `Code/{{PROJECT}}-docs/scripts/check.sh` and the relevant `tests/*.sh` regressions pass — suite 14/14
- [x] If I changed the wizard or templates, I ran a throwaway `init.sh` smoke test and confirmed a clean generated project
- [x] Kept the `{{PROJECT}}` placeholder convention intact
- [x] Updated `METHOD.md` / `README.md` / `prompts/` for consistency where the change affects them — n/a

## Verification

Re-run against the new base, not carried over from the `main`-based branch.

Suite **14/14** here and **14/14** on a plain `repo-record` worktree — the same fourteen files, so
these commits add no failure. `bash -n` and `shellcheck` clean on all six changed files.

Four projects generated (mono/multi × with/without remotes): the generated tree, the registry, the
git remotes and both doctor runs per project are **identical** to the same four generated from
plain `repo-record`, except for the two intended changes — the wizard's closing text and check 11
now naming each flagged repo with its location. Doctor exit 0 on all eight runs.

The gh stand-in fix shows up in the artifacts rather than only in the assertion: generated from
`repo-record`, the prompts repo's bare remote ends up with **no branches at all** while
`repos.yml` records its URL. Generated from this branch, all three bare remotes hold the trunk at
the local repo's HEAD, with `HEAD` pointing at it.

Remote failures are forced with a bare repo whose `pre-receive` hook refuses — `git ls-remote`
still answers, so the pre-boundary reachability check passes and the failure lands after the
project is committed, which is the only place the layouts ever differed. Every such path was run:
a manual URL, a reused root origin, multi with only prompts failing, and a host that accepts the
first push and refuses the registry commit. Each finishes the project, prints the closing
instructions, names only what failed, records no remote it cannot back up, and exits 1.

**Everything added or changed here was mutation-tested**, each mutation asserting its own
substitution count before its result was read. Sixteen mutations, sixteen caught: the accumulator
gutted, `reuse_root_origin` no longer recording its failed push, the exit status forced back to 0,
a remote recorded although the push failed, multi's failure made fatal again, both prompts
assigning raw, both normalisers mapping to the wrong layout and collaboration mode, the layout
re-ask hint alone, mono no longer calling `record_registry_remote`, `record_registry_remote`
inserting nothing, the registry commit never pushed, and the location dropped from check 11 at
either end.

Two of those first came back uncaught and both were the harness, not the code: `set -e` aborts a
test file at an earlier case, so a case near the end never ran; and one assertion matched a
template comment offering the same value as an example. Both are recorded in the commits that fixed
them.

One commit went out with the suite red. `tests/init-trunk-branch.sh` asserts that a chosen
`--trunk-branch` reaches the closing text, matching the exact clause the multi tip rewrite deleted;
the assertion was right and now matches its replacement, confirmed still to test the substitution
rather than the sentence. The suite is green from the commit after it.

## Deliberately not fixed here

Found in the same review, all pre-existing, all left as recorded findings rather than folded in:

1. Mono + "create GitHub remotes" + an existing empty origin silently reuses that origin, ignoring
   `--owner` and `--visibility`.
2. The public/proprietary warning is not guaranteed: a public *manual* remote takes proprietary
   source unwarned.
3. The same URL given for both multi repos passes validation and fails after the destructive
   boundary.
4. `gh` authentication is only exercised after the destructive boundary.
5. Layout-incompatible URL flags are accepted and ignored.
6. A blank interactive answer ships `Copyright (c) <year> ` with no holder; the same input as a
   flag exits 2.
7. `yesno` accepts `y|Y|yes` but not `Yes`/`YES`, at three prompts including the backup question.
8. Nothing in a generated project records which Throughstone version built it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
