### PR TITLE
Keep every registered repo inside the workspace

### DIFF
--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -483,24 +483,22 @@ adds an `ARCHITECTURE.md` at its root for its internal design. **Licensing follo
 `.throughstone/project-license` and applied per repo by `scripts/apply-project-license.sh` when the
 repo is brought in.
 
-**Where a repo lives — created as a sibling, or registered in place.** By default a repo is
-**created as a `Code/*` sibling** under the workspace root, and its `registries/repos.yml`
-`location:` is that workspace-relative sibling path — the layout `init.sh` and the scaffolding
-above assume. A repo may instead be **registered in place by its `location:`** — a path
-*outside* the `Code/*` shell (an absolute path, or any other arbitrary path) — in addition to that
-created-as-sibling default, so a repo that lives elsewhere is referenced where it sits rather than
-created under `Code/`. `location:` records wherever the repo actually is; the optional `remote:` is
-unchanged (a cloneable URL when the repo has one).
-`scripts/setup-workspace.sh` honors `location:` verbatim, but it only ever *clones* into a path
-the workspace owns: a location inside the workspace root is cloned from `remote:` when a remote is
-set and nothing is there yet, and a location **outside** it — absolute, or reaching out with
-`..` — is reported and skipped rather than cloned into, because placing a repository outside the
-workspace is not that script's business even when the path happens to be writable. A repo already
-checked out at its `location:` is left alone either way, so an in-place repo outside the root is
-one each contributor clones onto their own machine once.
-Branch-per-STEP and the overlap warning (`runbooks/collaboration.md`) key on repo
-**identity** — its `repos.yml` entry, not where it lives — so an in-place repo participates in
-them exactly like a sibling. The `Code/*` sibling layout stays the default.
+**Where a repo lives — always inside the workspace.** A repo's `registries/repos.yml`
+`location:` is **a path relative to the workspace root, identical on every machine; it never
+begins with `/` or `~`, and no segment of it is `..`.** Usually that is a `Code/*`
+sibling — the layout `init.sh` and the scaffolding above assume — but any contained path works.
+The point is reproducibility: a contributor clones the docs hub, runs
+`scripts/setup-workspace.sh`, and assembles the whole workspace from the registry alone.
+`location:` says where the repo is; the optional `remote:` says where to clone it from.
+**No repo's code is rewritten, and none is forced to move.** A repo that already exists is
+adopted either by moving into the workspace or, when it genuinely cannot move, by staying
+exactly where it is with a **symlink** at its registered location pointing at the real
+checkout — the row stays portable and the repo's contents are untouched
+(`runbooks/register-repo.md`).
+`scripts/setup-workspace.sh` clones each row that has a `remote:` into its `location:`, leaves a
+location that already holds a checkout alone (including one reached through a symlink), and
+reports and skips any location breaking that shape rather than cloning into it — an absolute path
+from someone else's machine must not be written to here even when it happens to be writable.
 
 **What a row records, and what it does not.** A row is an inventory entry, never a status board;
 `registries/repos.yml` documents its fields. Two of them are **stamps for a reader** — `added_as`

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -10,15 +10,19 @@
 # repos yet, and for those this inventory describes the post-split target. When you do split them
 # apart, follow `runbooks/splitting-repos.md`, and delete this note once the repos are real.
 #
-# `location:` — where the repo lives. By default a `Code/*` sibling under the workspace root,
-# written workspace-root-relative (e.g. Code/{{PROJECT}}-api/). It MAY point OUTSIDE that shell —
-# an absolute path, or any other path — for a repo referenced in place rather than created as a
-# sibling. scripts/setup-workspace.sh uses `location` verbatim but only ever CLONES into a path
-# the workspace owns: a location outside the workspace root is reported and skipped, so an
-# in-place repo there is one each contributor clones onto their own machine — a path outside the
-# workspace describes one person's machine, so on a shared project keep `location` inside it where
-# you can. Keep `location` and `remote` distinct — a clone URL goes in `remote`, never folded into
-# `location`.
+# `location:` — where the repo lives, and it is always inside the workspace: **a path relative
+# to the workspace root, identical on every machine; never begins with `/` or `~`, and no
+# segment of it is `..`.** Usually a `Code/*` sibling (e.g. Code/{{PROJECT}}-api/), but any
+# contained path is fine. That shape is what makes this file reproducible: a teammate clones the
+# docs repo, runs scripts/setup-workspace.sh, and gets the whole workspace. That script reports
+# and skips any location breaking that shape rather than cloning into it — most often an absolute
+# path left over from one person's machine, which every other contributor then sets up by hand.
+# The value is passed literally: no shell expansion and no YAML interpretation happen, so `~/lib`
+# and `$HOME/lib` are directory names, not paths to a home directory.
+# A repo that genuinely cannot move stays where it is: put a symlink at its workspace-relative
+# location pointing at the real checkout, and register the symlink's path — see
+# runbooks/register-repo.md. Keep `location` and `remote` distinct — a clone URL goes in
+# `remote`, never folded into `location`.
 #
 # `remote:` — any cloneable git URL, **recorded** if the repo has one; never created, never
 # repointed. scripts/setup-workspace.sh clones from it. A repo with no remote yet is fine: a
@@ -41,14 +45,18 @@
 # split (`runbooks/splitting-repos.md`), and nothing maintains it afterwards. Shape in the
 # example row below. `from:` is a historical name and may have no row of its own.
 #
-# Two rules for anything that reads or rewrites this file, because the scripts that read it match
-# line prefixes rather than parsing YAML:
+# Three rules for anything that reads or rewrites this file, because the scripts that read it
+# match line prefixes rather than parsing YAML:
 #
 # 1. **Every value is a single-line scalar.** Nothing spans lines.
 # 2. **Anything that rewrites a row anchors on the row block** — from a `- name:` to the next
 #    `- name:`, respecting indentation — never on a bare line prefix.
-#
-# Comment lines are skipped, which is why the example row below can sit here fully formed.
+# 3. **A `#` on a value line is part of the value, not a comment.** These readers skip only a line
+#    whose first non-blank character is `#`, so the fields they actually read — `- name:`,
+#    `location:` and `remote:` — must carry nothing after the value. (`type:` below carries an
+#    annotation; nothing reads that field.) The annotations in the example block are safe only
+#    because the whole block is commented out; move them off the value lines before uncommenting
+#    a row.
 
 repos:
   - name: "{{PROJECT}}-docs"
@@ -63,9 +71,10 @@ repos:
     added_as: created
     description: "prompts/STEP-index.md roadmap plus archived STEP plans and substep prompts; the build record."
 
-  # Service / app / library repos get added here as the architecture names them — created here and
-  # stamped from templates/repo-readme-template.md, or adopted, in which case the repo's own
-  # README gets a `## Role in <project>` section instead. See runbooks/register-repo.md. Example:
+  # Service / app / library repos get added here as the architecture names them, whether created
+  # here or adopted. A repo with no README is stamped from templates/repo-readme-template.md; one
+  # that already has a README keeps it and gains a `## Role in <project>` section instead — what
+  # is in the repo decides, not how it arrived. See runbooks/register-repo.md. Example:
   # - name: "{{PROJECT}}-api"
   #   location: "Code/{{PROJECT}}-api/"
   #   type: service

--- a/Code/{{PROJECT}}-docs/runbooks/register-repo.md
+++ b/Code/{{PROJECT}}-docs/runbooks/register-repo.md
@@ -26,8 +26,16 @@ The goal is that the **result** is the same however a repo arrived.
      type: service
      description: "..."
      added_as: adopted                     # created | adopted — written once, never changes
-     remote: "git@example.com:TEAM/api.git"    # recorded if it has one; never created, never repointed
+     remote: "git@example.com:TEAM/api.git"
    ```
+
+   **`location:` is always inside the workspace** — a path relative to the workspace root, so a
+   teammate reproduces the whole workspace from this file; a repo that genuinely cannot move stays
+   where it is, with a symlink at that workspace-relative path pointing at the real checkout.
+
+   **`remote:` is recorded if the repo has one** — never created, never repointed. Put nothing
+   after a `- name:`, `location:` or `remote:` value: the readers take the rest of the line as part
+   of it, so a trailing `# note` ends up inside the name, the path or the clone URL.
 
    **A repo split out of another is `added_as: created`** — the method made it — with the split
    history in its `provenance:` block, written by
@@ -107,7 +115,7 @@ acme-billing
   → repo commit: blocked by the same dirty tree; the notice is written but uncommitted.
 
 internal-tooling
-  SKIPPED — location is on another machine and the repo is not cloned here.
+  SKIPPED — nothing is checked out at Code/internal-tooling/ on this machine.
 ```
 
 `licence ✓` means every artifact that repo's posture requires landed: for one we created,

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -471,7 +471,7 @@ if [ "$CHECK_IN" -eq 1 ]; then
 
     if [ -n "$no_loc" ]; then
       fail "row(s) with no location: $(printf '%s' "$no_loc" | tr '\n' ' ')"
-      hint "give every row a location: — it is what setup-workspace.sh clones into and what the STEP process reads."
+      hint "give every row a location: — the workspace-relative path the repo lives at; without one, nothing can find the repo."
     fi
     if [ -n "$no_rem" ]; then
       warn "repo(s) with no remote: $(printf '%s' "$no_rem" | tr '\n' ' ')"

--- a/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
+++ b/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
@@ -89,24 +89,33 @@ if [ -f "$REG" ]; then
   # and the loop body runs in this shell rather than a subshell, so the count below survives it.
   while IFS='|' read -r loc rem; do
     [ -n "${rem:-}" ] || continue
-    # Clone side effect: create a missing sibling repo at its registry location. Existing git
-    # checkouts are left untouched so rerunning setup is safe for already-cloned repos. This
-    # is also what leaves a repo registered in place alone: it is already where it belongs.
-    [ -d "$loc/.git" ] && { echo "  exists: $loc"; continue; }
-    # A location this workspace cannot own is referenced where it sits, never cloned into.
-    # Cloning would put the repository outside the workspace this script is assembling —
-    # silently, when the path happens to be writable. The test is textual on purpose: an
-    # absolute path from the first developer's machine must be skipped whether or not it
-    # resolves to anything here.
+    # A location is meant to be a path relative to the workspace root, and one that is not never
+    # gets cloned into. An absolute or `..` path can put the repository outside the workspace this
+    # script is assembling, silently, whenever that path happens to be writable. The test is
+    # textual on purpose: an absolute path from the first developer's machine is skipped whether
+    # or not it resolves to anything here. `~` fails differently and needs its own arm — this loop
+    # reads the path out of a variable, where no tilde expansion happens, so cloning it builds a
+    # literal `~` directory here. The arm is quoted so the pattern matches a literal tilde.
+    #
+    # This runs before the existing-checkout test below, and the order is the point: on a machine
+    # where a bad location does resolve — usually the one whose paths it was written from — that
+    # test matches and reports the repo as already present, saying nothing about the location. The
+    # machine best placed to fix the row is the one that would otherwise never hear about it.
     case "$loc" in
-      /* | .. | ../* | */../* | */..)
-        echo "  skipped: $loc — outside the workspace root; this script never clones there"
+      /* | '~'* | .. | ../* | */../* | */..)
+        echo "  skipped: $loc — a location must be a path relative to the workspace root, and this is not"
         missing=$((missing + 1))
         continue
         ;;
     esac
+    # Clone side effect: create a missing sibling repo at its registry location. Existing git
+    # checkouts are left untouched so rerunning setup is safe for already-cloned repos. That
+    # also covers a location that is a symlink to a checkout elsewhere: -d follows the link,
+    # so the repo behind it is reported and left alone rather than cloned over.
+    [ -d "$loc/.git" ] && { echo "  exists: $loc"; continue; }
     echo "  cloning $rem -> $loc"
-    git clone -q "$rem" "$loc" || {
+    # `--` so a value beginning with `-` reaches git as a path rather than as an option.
+    git clone -q -- "$rem" "$loc" || {
       echo "  warning: could not clone $rem -> $loc — continuing without it"
       missing=$((missing + 1))
     }

--- a/tests/check-repo-registry.sh
+++ b/tests/check-repo-registry.sh
@@ -197,9 +197,9 @@ doctor "$multi" --check-in
 expect "[WARN] repo(s) with no remote: registry-multi-docs (Code/registry-multi-docs/)" "an empty remote reads as absent"
 
 # --- 3. A row with no location: is a hard failure -------------------------------
-# location: is what setup-workspace.sh clones into and what the STEP process reads, so a row
-# without one is unusable — unlike a missing remote, which is a risk someone may have accepted
-# on purpose. The two findings are independent, and both speak in the same run.
+# location: is the workspace-relative path the repo lives at, so a row without one is unusable —
+# unlike a missing remote, which is a risk someone may have accepted on purpose. The two findings
+# are independent, and both speak in the same run.
 drop_field "$multi" "prompts" location
 doctor "$multi" --check-in
 expect "[FAIL] row(s) with no location: prompts" "missing location fails"

--- a/tests/setup-workspace-resilience.sh
+++ b/tests/setup-workspace-resilience.sh
@@ -9,11 +9,13 @@
 # over a repository they may not even need. So every case below asserts the same two things:
 # the run exits 0, and the three workspace files are there.
 #
-# The second half is about where a clone is allowed to land. A location the workspace does not
-# own — an absolute path from the first developer's machine, or one reaching out with `..` —
-# used to be cloned into verbatim, which put a repository outside the workspace silently
-# whenever the path happened to be writable. Those cases assert the absence of a clone, not
-# just the presence of a message.
+# The second half is about where a clone is allowed to land. A registered location is always a
+# path relative to the workspace root, and one that breaks that shape used to be cloned into
+# verbatim, putting a repository outside the workspace — or, for a tilde, into a literal `~`
+# directory — whenever the path happened to be writable. Those cases
+# assert the absence of a clone, not just the presence of a message. One case is the other side
+# of the same rule: a repo that cannot move is reached through a symlink at a workspace-relative
+# location, and that must still be left alone.
 #
 # Assertions read the output as well as the exit status: after this change almost everything
 # exits 0, so a test that only looked at $? could not tell a clone from a refusal.
@@ -220,7 +222,7 @@ run_setup "$tw"
 assert_assembled "no registries/" "$tw"
 assert_out "no registries/" "skipping clone step"
 
-# --- Part 2. A clone only ever lands where the workspace can own it -------------------------
+# --- Part 2. A clone only ever lands at a path relative to the workspace root ---------------
 
 echo "An absolute location left over from the first developer's machine ..."
 tw="$(teammate absolute "$MULTI_DOCS")"
@@ -237,10 +239,58 @@ add_row "$tw" <<EOF
 EOF
 run_setup "$tw"
 assert_assembled "absolute location" "$tw"
-assert_out "absolute location" "outside the workspace root"
+assert_out "absolute location" "a location must be a path relative to the workspace root"
 assert_not_out "absolute location" "cloning $REACHABLE -> $outside"
 assert_out "absolute location" "did not arrive"
 assert_not_cloned "absolute location" "$outside"
+
+# The same shape, but with a real checkout sitting at it — what a bad row looks like on the one
+# machine it was written from. The existing-checkout test matches there and would report the row
+# as fine, so the shape guard has to run first or that machine, the one best placed to fix the
+# row, is told nothing at all. Nothing is written either way: assert the checkout is undisturbed.
+echo "A prohibited location that already holds a checkout on this machine ..."
+tw="$(teammate authored "$MULTI_DOCS")"
+authored="$TMP_ROOT/authored-elsewhere"
+rm -rf "$authored"
+git clone -q "$REACHABLE" "$authored" >/dev/null 2>&1
+printf 'local work\n' > "$authored/uncommitted.txt"
+add_row "$tw" <<EOF
+
+  - name: "partner-billing"
+    location: "$authored"
+    type: service
+    added_as: adopted
+    remote: "$REACHABLE"
+    description: "An absolute path that really does resolve on this machine."
+EOF
+run_setup "$tw"
+assert_assembled "authored-here location" "$tw"
+assert_out "authored-here location" "a location must be a path relative to the workspace root"
+assert_out "authored-here location" "did not arrive"
+assert_not_out "authored-here location" "exists: $authored"
+[ -f "$authored/uncommitted.txt" ] || bad "authored-here location: the checkout there was disturbed"
+
+# A tilde is not an absolute path and does not reach out with `..`, and it is the one shape the
+# workspace does not own that a run could complete "successfully": this loop reads the location
+# out of a variable, where the shell performs no tilde expansion, so an unskipped tilde location
+# is cloned into a literal `~` directory under the workspace root and counted as a clone that
+# worked. Assert the directory is absent, not just the message.
+echo "A location that starts with a tilde ..."
+tw="$(teammate tilde "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "home-lib"
+    location: "~/tw-tilde-lib/"
+    type: library
+    added_as: adopted
+    remote: "$REACHABLE"
+    description: "A home-relative path from the first developer's machine."
+EOF
+run_setup "$tw"
+assert_assembled "tilde location" "$tw"
+assert_out "tilde location" "a location must be a path relative to the workspace root"
+assert_out "tilde location" "did not arrive"
+assert_not_cloned "tilde location" "$tw/~"
 
 echo "A location reaching out of the workspace with .. ..."
 tw="$(teammate dotdot "$MULTI_DOCS")"
@@ -257,35 +307,62 @@ add_row "$tw" <<EOF
 EOF
 run_setup "$tw"
 assert_assembled "dotdot location" "$tw"
-assert_out "dotdot location" "outside the workspace root"
+assert_out "dotdot location" "a location must be a path relative to the workspace root"
 assert_out "dotdot location" "did not arrive"
 assert_not_cloned "dotdot location" "$escaped"
 
-echo "A repo already checked out at an absolute location is left alone, not reported missing ..."
-tw="$(teammate inplace "$MULTI_DOCS")"
-inplace="$TMP_ROOT/in-place-repo"
-rm -rf "$inplace"
-git clone -q "$REACHABLE" "$inplace" >/dev/null 2>&1
-# Uncommitted local work, so the failure that matters — the directory replaced or cleared, the
+# The escape hatch for a repo that genuinely cannot move: it stays where it is and a symlink at
+# a workspace-relative location points at it, so the row is the same on every machine. Two
+# mechanics carry it — the location is contained, so it passes the shape guard on its text, and
+# the existing-checkout branch reaches `.git` through the link because `-d` follows symlinks.
+# The second is what this case holds: make a symlinked location stop counting as an existing
+# checkout and the run tries to clone over the link instead.
+# Uncommitted local work, so the failure that matters — the checkout replaced or cleared, the
 # contributor's own work gone with it — is caught as state. The `exists:` line below is printed
 # by the branch that skips the clone, but a maintainer who restructures that loop could print it
 # and still re-clone or clear the directory.
-printf 'local work\n' > "$inplace/uncommitted.txt"
+echo "A repo that cannot move, reached through a symlink at a workspace-relative location ..."
+tw="$(teammate symlink "$MULTI_DOCS")"
+immovable="$TMP_ROOT/immovable-lib"
+rm -rf "$immovable"
+git clone -q "$REACHABLE" "$immovable" >/dev/null 2>&1
+printf 'local work\n' > "$immovable/uncommitted.txt"
+ln -s "$immovable" "$tw/Code/immovable-lib"
 add_row "$tw" <<EOF
 
-  - name: "partner-billing"
-    location: "$inplace"
-    type: service
+  - name: "immovable-lib"
+    location: "Code/immovable-lib/"
+    type: library
     added_as: adopted
     remote: "$REACHABLE"
-    description: "Registered in place, and really there."
+    description: "A repo that cannot move, linked at a workspace-relative location."
 EOF
 run_setup "$tw"
-assert_assembled "in-place repo" "$tw"
-assert_out "in-place repo" "exists: $inplace"
-[ -f "$inplace/uncommitted.txt" ] || bad "in-place repo: uncommitted work in the checkout is gone"
-assert_not_out "in-place repo" "outside the workspace root"
-assert_not_out "in-place repo" "did not arrive"
+assert_assembled "symlinked location" "$tw"
+assert_out "symlinked location" "exists: Code/immovable-lib/"
+[ -L "$tw/Code/immovable-lib" ] || bad "symlinked location: the link is gone or was replaced"
+[ -f "$immovable/uncommitted.txt" ] || bad "symlinked location: uncommitted work in the real checkout is gone"
+assert_not_out "symlinked location" "a location must be a path relative to the workspace root"
+assert_not_out "symlinked location" "did not arrive"
+
+# git reads a leading `-` as an option, so without the `--` in the clone the run dies with
+# `unknown switch` and the repo does not arrive. Nothing else in the suite passes git a value it
+# could mistake for a flag, so deleting the `--` is invisible without this case.
+echo "A location that begins with a dash ..."
+tw="$(teammate dash "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "dash-lib"
+    location: "-dash-lib/"
+    type: library
+    added_as: adopted
+    remote: "$REACHABLE"
+    description: "A location whose first character git could read as an option."
+EOF
+run_setup "$tw"
+assert_assembled "dash location" "$tw"
+assert_cloned "dash location" "$tw/-dash-lib"
+assert_not_out "dash location" "did not arrive"
 
 echo "A location outside Code/ but inside the workspace is still cloned ..."
 tw="$(teammate vendored "$MULTI_DOCS")"


### PR DESCRIPTION
## What

A repository's `location:` in `registries/repos.yml` is now always a path inside the workspace:
*a path relative to the workspace root, identical on every machine; it never begins with `/` or
`~`, and no segment of it is `..`.*

That is what lets a teammate clone the docs hub, run `scripts/setup-workspace.sh`, and get the
whole workspace from the registry alone. A location pointing at one person's machine could not be
cloned by anyone else — and the run that skipped it still printed "The workspace itself is
complete."

The wording was checked against the guard over 1,100 generated paths and disagrees with it on
none.

## No repo is forced to move, and no code is rewritten

A repo that genuinely cannot move — a linked worktree, tooling with baked absolute paths — stays
exactly where it is, behind a symlink at its registered location. Verified: that reads as
contained by the textual guard, and the existing-checkout branch leaves it alone because `-d`
follows the link. One sentence in the adoption runbook; no new field, no status, no code path.

## Two gaps in the guard

- A `~` location cloned **successfully** into a literal `./~/work/lib` under the workspace root:
  exit 0, printed as an ordinary clone, not even counted as missing. The loop reads the path out
  of a variable, where no tilde expansion happens. It now has its own arm, and the field note
  explains the whole class — the value is passed literally, so `~/lib` and `$HOME/lib` are
  directory names, not paths to a home directory.
- The existing-checkout test ran *before* the shape guard, so on the one machine where a bad
  absolute location does resolve — the machine best placed to fix the row — the run reported the
  repo as present and said nothing about the location. The guard now runs first.

The clone also gained `--`, so a location beginning with `-` reaches git as a path rather than as
an option.

## Corrections to things that had stopped being true

- `check.sh`'s hint said `location:` "is what setup-workspace.sh clones into" — false for every
  shape that script skips.
- `repos.yml`'s example lead-in still said a created repo gets the template README and an adopted
  one gets a `## Role in <project>` section. `METHOD.md` and `runbooks/register-repo.md` both say
  the opposite, and are right: what is in the repo decides, not how it arrived.
- The copyable row in `runbooks/register-repo.md` put a comment after the `remote:` value. The
  readers strip a quote only at end of line, so a row copied verbatim yielded the clone URL
  ``git@example.com:TEAM/api.git"`` followed by the comment text. The clone failed loudly, but the
  doctor saw a non-empty remote and reported the row as covered. Reproduced, fixed, and written
  down as a third rule for anything that reads or rewrites the file.

## Verification

Suite 14/14. Eight deliberate breakings of the changed behaviour, run against the tests: drop the
`~` arm; make it match a bare `~` only; stop a symlinked location counting as an existing
checkout; stop counting a skipped row as missing; delete the guard entirely; break the doctor
hint's anchor; restore the old ordering; drop the `--`. All eight caught, each confirmed applied
before its result counted.

The resilience suite's in-place case had stopped testing a supported shape and started testing a
rejected one. It is now the symlink case, beside new cases for a tilde location, a prohibited
location that already holds a checkout on this machine, and a location beginning with a dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
