### PR TITLE
Write a path from where the reader is standing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,38 @@ any project built with it.
   is today.
 
 ### Fixed
+- **Instructions in the docs now work from the directory they tell you to stand in.** Six of them
+  did not. The first line of the periodic check-in told you to run `scripts/check.sh --check-in`,
+  which fails from the workspace root where you actually are — and that one is on the path anyone
+  walks regularly. So did the setup a new contributor is told to run, two of the split's pre-swap
+  checks, its teammate-clone verification, and the sentence the split copies into a README handed
+  to people still holding a clone of the old repo. Each now names the script the way
+  `scripts/setup-workspace.sh`'s own usage header always has: from the workspace root, in full.
+  Two warnings that name a script you must *not* run got the same treatment, because a warning has
+  to identify the program unambiguously too.
+
+  Behind them, the path convention in `METHOD.md` §7 sorted documents into two piles and put
+  `runbooks/` in neither — which is where most of the unfollowable instructions lived. It now turns
+  on what a path is *for*. A shell command is written from where the text stands you, the workspace
+  root unless the text says otherwise; everything else follows the file it is written in, which
+  inside the docs hub means relative to the hub. It also settles what "relative to the hub" is
+  measured from, what a bare `status.sh` or `architecture/` means, and that a Markdown link target
+  follows Markdown rather than either convention — so a sweep cannot quietly break your links.
+  `AGENTS.md` had copied the old wording into its own header and drifted from it; it now states
+  where its paths are relative to and points at the rule instead of restating it.
+- **The doctor no longer answers in two directories at once.** `scripts/check.sh` does not change
+  your working directory, so you read its output from wherever you ran it — normally the workspace
+  root — but it named some files from there and others from inside the docs hub, occasionally
+  within a single check: the repo-registry check headed itself with one form and then named the
+  same hub the other way two lines below. Every path it prints, and every path
+  `scripts/setup-workspace.sh` prints, is now written from the workspace root, so you can open what
+  it names without working out which base it meant. The setup wizard's two prompts that named a
+  file inside the docs hub now name it in full as well, using your project's real name.
+
+  Also fixed: an agent following `AGENTS.md` was told to scan `adr/README.md` for duplicate ADR
+  numbers before every push — a file that is not there from where the agent is standing. Its
+  sibling scan of `prompts/STEP-index.md` was always correct, because `prompts/` really does sit at
+  the workspace root.
 - **One repository you cannot clone no longer costs you the whole workspace.**
   `scripts/setup-workspace.sh` is what every developer after the first runs to assemble the project
   on their machine: it clones the repos `registries/repos.yml` gives a `remote:`, then writes the

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -6,10 +6,9 @@
 > or resume?" just below.**
 >
 > **Paths in this file are relative to the workspace root** (the folder that contains
-> `Code/` and `prompts/`) — that's where your agent runs. Inside the architecture-session and
-> template files under `templates/`, paths are instead relative to the docs hub
-> (`architecture/…`, `overview.md`), but any reference that crosses repos — notably
-> `prompts/STEP-index.md` — is always written in full. (See `METHOD.md` §7, "Path conventions in docs".)
+> `Code/` and `prompts/`) — that's where your agent runs, so every path below can be used
+> as-is. Other documents in the docs hub write some paths relative to the hub instead:
+> `Code/{{PROJECT}}-docs/METHOD.md` §7, "Path conventions in docs", is the rule.
 
 ## First action — kickoff or resume?
 **Before doing anything else, decide which mode you're in** by reading the `PROJECT-STATUS`
@@ -252,5 +251,6 @@ STEP when more than one contributor is active. The rules that bind you as an age
   two authors can append the same `ADR-NNNN` and git merges both into a silent duplicate. Pull,
   take `max + 1`, add the row and create the ADR file, then **commit and push immediately**;
   before every push (even a clean merge) scan with
-  `grep -oE '^\|[[:space:]]*ADR-[0-9]+' adr/README.md | grep -oE 'ADR-[0-9]+' | sort | uniq -d`, and if it's non-empty or the push is
-  rejected, recompute `max + 1`, renumber, and push again. See `runbooks/collaboration.md` §6.
+  `grep -oE '^\|[[:space:]]*ADR-[0-9]+' Code/{{PROJECT}}-docs/adr/README.md | grep -oE 'ADR-[0-9]+' | sort | uniq -d`,
+  and if it's non-empty or the push is rejected, recompute `max + 1`, renumber, and push again.
+  See `Code/{{PROJECT}}-docs/runbooks/collaboration.md` §6.

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -488,7 +488,8 @@ repo is brought in.
 begins with `/` or `~`, and no segment of it is `..`.** Usually that is a `Code/*`
 sibling — the layout `init.sh` and the scaffolding above assume — but any contained path works.
 The point is reproducibility: a contributor clones the docs hub, runs
-`scripts/setup-workspace.sh`, and assembles the whole workspace from the registry alone.
+`Code/{{PROJECT}}-docs/scripts/setup-workspace.sh`, and assembles the whole workspace from the
+registry alone.
 `location:` says where the repo is; the optional `remote:` says where to clone it from.
 **No repo's code is rewritten, and none is forced to move.** A repo that already exists is
 adopted either by moving into the workspace or, when it genuinely cannot move, by staying
@@ -535,13 +536,48 @@ the `Upcoming Prompts/` working folder, no other file should sit at the workspac
 one-time `init.sh` may linger there until you delete it post-bootstrap — that's expected). If
 any *other* file appears, ask whether it belongs in a repo (usually the docs hub) and move it.
 
-**Path conventions in docs.** Top-level agent-facing docs (`AGENTS.md`, `BOOTSTRAP-PROMPT.md`,
-this file) write paths **relative to the workspace root** — `Code/{{PROJECT}}-docs/architecture/…`,
-`prompts/STEP-index.md`. The exception is the **session and template files** under
-`templates/`: because they live and operate inside the docs hub, they write hub-local paths
-(`architecture/*-data-model.md`, `adr/`, `overview.md`) relative to the hub. Either way, a reference
-that **crosses into another repo is always written in full** — most notably
-`prompts/STEP-index.md`, which lives in `prompts/`, never the hub, so it is never written bare.
+**Path conventions in docs.** A shell command and a path you merely name are written
+differently. Writing one as the other is how an instruction becomes a dead end.
+
+**A shell command is written from where the text has the reader standing.** Unless the text says
+otherwise that is the **workspace root** — the folder a contributor opens and an agent is pointed
+at: `Code/{{PROJECT}}-docs/scripts/setup-workspace.sh`,
+`Code/{{PROJECT}}-docs/scripts/check.sh --check-in`. This holds in **every** document, the
+hub-local ones below included, and it holds whether the reader is being told to run the command or
+warned off it — a warning has to name the program unambiguously too. Anything that works from
+somewhere else **names that directory in the same breath**: step 8 of
+`runbooks/splitting-repos.md` says to run `scripts/setup-workspace.sh` *from the new hub*.
+
+**Everything else follows the file it is written in.** A document inside the docs hub names the
+hub's own contents **hub-local** — `registries/repos.yml`, `runbooks/check-in.md`,
+`architecture/*-data-model.md`, `adr/`, `overview.md` — and **hub-local is measured from the hub's
+root, not from the file**, so `runbooks/check-in.md` writes `registries/repos.yml`, never
+`../registries/repos.yml`. The exception is a document that **declares it stands its reader at the
+workspace root**: `AGENTS.md`, `BOOTSTRAP-PROMPT.md` and `ONBOARDING.md` say so in their opening
+lines, and `runbooks/register-repo.md` before its first step. Those write **every** path from the
+workspace root, references included; that is the point of declaring it.
+
+**Either way, a reference that crosses into another repo is always written in full** — most
+notably `prompts/STEP-index.md`, which lives in `prompts/`, never the hub, so it is never written
+bare.
+
+**A bare name is a name, not a path.** `status.sh` names the tool where the sentence is about what
+it does; `architecture/` and `inputs/` name areas of the hub where the sentence is about the area.
+Write the path out when the reader has to reach the thing. (`init.sh` and `doctor.sh` sit at the
+workspace root, so a bare mention of them is already root-relative.)
+**Which placeholder a path carries — `{{PROJECT}}` or `<project>` — is a separate rule**, stated
+in `ONBOARDING.md` §6.
+
+**A path a tool prints follows the reader, not the tool.** `scripts/check.sh` and
+`scripts/setup-workspace.sh` never change the caller's directory, so what they print is read
+from the workspace root and is written from there — a heading naming the file a check reads,
+and the fix beside it, must not answer in two different bases.
+
+**A Markdown link target is none of the above.** The `](…)` half of a link resolves against the
+file that contains it — that is Markdown, not a convention of ours. So `ONBOARDING.md` links to
+the collaboration runbook as `runbooks/collaboration.md` even though its prose writes that path
+in full, and a link out of a hub subdirectory still needs the `../` a hub-local reference does
+not. Adjust a link's display text if it needs it; never its target.
 
 **Mono-repo for now:** the wizard offers a single-repo start — then the **workspace root
 itself is that one repo** (the lone exception to "the root is not a repo" above), with

--- a/Code/{{PROJECT}}-docs/ONBOARDING.md
+++ b/Code/{{PROJECT}}-docs/ONBOARDING.md
@@ -9,6 +9,9 @@ This is not the first project bootstrap. The first maintainer ran `./init.sh` fr
 Throughstone scaffold to create the project. Later contributors use the generated project
 workspace and, for multi-repo projects, `Code/<project>-docs/scripts/setup-workspace.sh`.
 
+> Paths below are relative to the workspace root (the folder containing `Code/` and
+> `prompts/`).
+
 ## 1. Identify the project shape
 
 Most Throughstone projects are **multi-repo**:
@@ -49,8 +52,8 @@ workspace root:
 
 If a repo did not arrive, `setup-workspace.sh` names it and says why as it runs, then closes
 with a count. The one case it stays quiet about is a repo with no `remote:` in
-`registries/repos.yml` — it was never going to be cloned. Read its registry entry and ask the
-maintainer how that repo is provided.
+`Code/<project>-docs/registries/repos.yml` — it was never going to be cloned. Read its registry
+entry and ask the maintainer how that repo is provided.
 
 ## 3. Create your local user profile
 
@@ -124,9 +127,9 @@ Before editing code or durable docs:
    STEP `Done` in `prompts/STEP-index.md`.
 
 For team and concurrency details, read
-[`runbooks/collaboration.md`](runbooks/collaboration.md). That runbook owns the full rules
-for reserving STEP numbers, branch naming, shared-file edits, ADR numbering, overlap
-warnings, and push races.
+[`Code/<project>-docs/runbooks/collaboration.md`](runbooks/collaboration.md). That runbook owns
+the full rules for reserving STEP numbers, branch naming, shared-file edits, ADR numbering,
+overlap warnings, and push races.
 
 ## 6. Keep paths straight
 

--- a/Code/{{PROJECT}}-docs/runbooks/README.md
+++ b/Code/{{PROJECT}}-docs/runbooks/README.md
@@ -7,7 +7,7 @@ Some runbooks inspect code; some operate the system; many do both. Each runbook 
 improvised under pressure.
 
 ## Two kinds of runbook
-The method (`../METHOD.md`) draws a line that matters for how you *invoke* each one:
+The method (`METHOD.md`) draws a line that matters for how you *invoke* each one:
 
 - **STEP-shaped** — runs as a tracked STEP with substeps that record status in the
   `prompts/STEP-index.md`/PLAN. Its PLAN is thin and points at the runbook; you don't author substep
@@ -20,14 +20,14 @@ The method (`../METHOD.md`) draws a line that matters for how you *invoke* each 
   **secrets rotation**, **an explicitly requested early S0 security baseline**, and the **incident** Part-1
   response are these. **Collaboration** is neither — it's reference you read once when a second
   contributor joins. Throughstone scaffold/method updates live separately at
-  `../UPDATING-THROUGHSTONE.md`.
+  `UPDATING-THROUGHSTONE.md`.
 
 The shipped runbooks are **defaults you customize** — they deliberately leave CI/CD, release
 versioning, and ecosystem-specific commands to your team's tooling. The *discipline* is the
 durable part; fill in your project's specifics.
 
 New-contributor onboarding is intentionally not a runbook. It is project setup and
-first-contribution STEP guidance, so it lives at [`../ONBOARDING.md`](../ONBOARDING.md).
+first-contribution STEP guidance, so it lives at [`ONBOARDING.md`](../ONBOARDING.md).
 
 ## Index
 

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -30,8 +30,9 @@ found.
 
 ## Part 1 — Doc drift and conditional coverage  *(substep N.1)*
 
-> **Start with the mechanical pass.** Run `scripts/check.sh --check-in` first — in seconds it
-> catches the *structural* drift this part otherwise checks by hand: duplicate STEP/ADR numbers,
+> **Start with the mechanical pass.** From the workspace root, run
+> `Code/{{PROJECT}}-docs/scripts/check.sh --check-in` first — in seconds it catches the
+> *structural* drift this part otherwise checks by hand: duplicate STEP/ADR numbers,
 > invalid statuses, architecture docs missing `Version`/`Status`/Version-Log, and an ADR registry
 > that disagrees with the files on disk, plus architecture-session numbering and
 > conditional-template contract drift. **The `--check-in` flag is what adds the repo-registry

--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -275,8 +275,8 @@ flow (§6). The transition is mostly mechanical:
    registry of record is gone. **A repo Throughstone did not create gets neither** — never
    create a remote for it and never push its history (`register-repo.md`); (b) add the
    `remote:` fields in `registries/repos.yml`, for every repo that has one; (c) have each new
-   contributor run `scripts/setup-workspace.sh` to clone them. Number reservation (§2) relies
-   on this shared `prompts/` remote.
+   contributor run `Code/{{PROJECT}}-docs/scripts/setup-workspace.sh`, from the workspace root,
+   to clone them. Number reservation (§2) relies on this shared `prompts/` remote.
 
    **Mono-repo-for-now** (`METHOD.md` §7) has one repo, the workspace root, so this is one
    remote rather than several: create it, push the root repo's existing history to it, and have
@@ -284,10 +284,10 @@ flow (§6). The transition is mostly mechanical:
    same as any other repo — `init.sh` writes it when it made the remote itself, and until a row
    has one the check-in flags it, because work with no remote lives on one laptop. A mono project
    may sit without a remote for a while; that warning is the reminder, not an error. But **don't
-   run `scripts/setup-workspace.sh`** — no row in that file is a repo to clone (one *is* the
-   repository you already have; the rest are folders inside it), and the script is for multi-repo
-   workspaces: run in a mono clone it overwrites the committed
-   root `CLAUDE.md`, `AGENTS.md` and `doctor.sh` with per-machine pointers asserting the root is
+   run `Code/{{PROJECT}}-docs/scripts/setup-workspace.sh`** — no row in that file is a repo to
+   clone (one *is* the repository you already have; the rest are folders inside it), and the
+   script is for multi-repo workspaces: run in a mono clone it overwrites the committed root
+   `CLAUDE.md`, `AGENTS.md` and `doctor.sh` with per-machine pointers asserting the root is
    not a repo. Everything else is the same, including number reservation, which needs a shared
    remote and not a particular number of them. Whether to split is a separate question, answered
    by the architecture rather than by the size of the team — see `splitting-repos.md`.

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -96,9 +96,9 @@ If the answer is *"the workspace root stops being a repo"*, you are in **Part 2*
 folder there leaves the new repo *nested inside* the origin — the root reports it as an untracked
 directory, and step 9's `git status` check fails on it. It also strands the repo you just made:
 `collaboration.md` §9 tells a mono project not to put `remote:` fields in `registries/repos.yml`
-and not to run `scripts/setup-workspace.sh`, so nothing on the mono onboarding path would ever
-clone it onto a teammate's machine. **Run Part 2 first**, then Part 1 as often as you like on the
-repos it leaves you.
+and not to run `Code/<project>-docs/scripts/setup-workspace.sh`, so nothing on the mono
+onboarding path would ever clone it onto a teammate's machine. **Run Part 2 first**, then
+Part 1 as often as you like on the repos it leaves you.
 
 **2. Should you split at all?** *(Part 1 only — for Part 2 the layout decision was made at
 `init.sh` time.) Default: proceed.* One exchange, and the two questions worth asking are: would
@@ -481,12 +481,12 @@ repos of their own. This happens at most once per project.
       `node_modules/`, a `dist/` — means that repo's ignore file did not survive step 5's
       reconcile.
     - Each code repo **builds and tests**.
-    - `scripts/check.sh` at **0 fail(s), 0 warning(s)** — warnings do not fail the run, so "green"
-      is not the criterion.
-    - `scripts/links.sh` clean.
+    - `Code/<project>-docs/scripts/check.sh` at **0 fail(s), 0 warning(s)** — warnings do not
+      fail the run, so "green" is not the criterion.
+    - `Code/<project>-docs/scripts/links.sh` clean.
     - A **real teammate clone**: a fresh empty directory, clone the docs hub into
-      `Code/<project>-docs/` inside it, run `scripts/setup-workspace.sh` there, and confirm every
-      registered repo actually arrives.
+      `Code/<project>-docs/` inside it, run `Code/<project>-docs/scripts/setup-workspace.sh` from
+      that new workspace root, and confirm every registered repo actually arrives.
     - The pre-split commit resolves in every new repo.
 11. **Swap.** **Stop before the rename** — show which directory becomes which. Then **rename** the
     old workspace aside — do not delete it — and move the build directory into its place. Abort is
@@ -499,10 +499,10 @@ repos of their own. This happens at most once per project.
     clone of the host, not in your live workspace. Do this **after the swap is verified, never
     before** — a complete pushed copy stays on the host through the whole destructive window. That README needs
     one sentence for anyone else holding a clone: *start a fresh empty folder, clone the docs hub
-    into `Code/<project>-docs/` inside it, and run `scripts/setup-workspace.sh` there — do not
-    reuse your old project folder.* Re-onboarding in place leaves the new repos nested inside the
-    retired one, and every check passes. **Stop before you push that commit** — show the README and
-    the tree it leaves behind.
+    into `Code/<project>-docs/` inside it, and from that folder run
+    `Code/<project>-docs/scripts/setup-workspace.sh` — do not reuse your old project folder.*
+    Re-onboarding in place leaves the new repos nested inside the retired one, and every check
+    passes. **Stop before you push that commit** — show the README and the tree it leaves behind.
 13. **Write the STEP's PLAN** and archive it into the new `prompts/` repo — at `<phase>/step-NNNN/`
     and `STEP-index.md` from that repo's root, since the un-nest at step 5 moved `prompts/`'s
     contents up to it. Then mark the STEP done. Written now rather than at step 4, it never has to

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -43,6 +43,10 @@ done
 # doctor can be run from any working directory without resolving the template placeholder.
 DOCS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="$(cd "$DOCS_DIR/../.." && pwd)"
+# Printed paths are rendered from the workspace root, because that is where the caller is
+# standing: this script never changes the caller directory, and the documented flow runs it
+# from the workspace root. links.sh renders its diagnostics the same way.
+DOCS_REL="Code/$(basename "$DOCS_DIR")"
 # Authoritative project state is split between the workspace-root STEP index and docs-hub
 # registries/templates. Keep those assumptions centralized so each check reads the same files.
 INDEX="$ROOT/prompts/STEP-index.md"
@@ -86,7 +90,7 @@ if [ -f "$INDEX" ]; then
       printf '         %s appears on line(s): %s\n' "$d" "$lns"
     done
     maxn="$(grep -oE '^\|[[:space:]]*STEP-[0-9]+' "$INDEX" | grep -oE '[0-9]+' | sort -n | tail -1)"
-    hint "renumber the duplicate (the one reserved later) to STEP-$((maxn + 1)) — never reuse or delete a number; mark a row Abandoned if it won't be built. See runbooks/collaboration.md §2."
+    hint "renumber the duplicate (the one reserved later) to STEP-$((maxn + 1)) — never reuse or delete a number; mark a row Abandoned if it won't be built. See $DOCS_REL/runbooks/collaboration.md §2."
   else
     pass "no duplicate STEP numbers"
   fi
@@ -95,7 +99,7 @@ else
 fi
 
 # --- 2. Duplicate ADR numbers -------------------------------------------------
-hdr "2. Duplicate ADR numbers (adr/README.md)"
+hdr "2. Duplicate ADR numbers ($DOCS_REL/adr/README.md)"
 if [ -f "$ADR_INDEX" ]; then
   # Invariant: ADR numbers are durable decision IDs. adr/README.md is the registry authority,
   # and duplicates catch copy/paste rows or renumbering drift before files are reconciled.
@@ -107,12 +111,12 @@ if [ -f "$ADR_INDEX" ]; then
       printf '         %s appears on line(s): %s\n' "$d" "$lns"
     done
     maxn="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE '[0-9]+' | sed 's/^0*//' | sort -n | tail -1)"
-    hint "renumber the later duplicate to $(printf 'ADR-%04d' "$((maxn + 1))") and rename its file to match — never reuse a number. See adr/README.md and runbooks/collaboration.md §6."
+    hint "renumber the later duplicate to $(printf 'ADR-%04d' "$((maxn + 1))") and rename its file to match — never reuse a number. See $DOCS_REL/adr/README.md and $DOCS_REL/runbooks/collaboration.md §6."
   else
     pass "no duplicate ADR numbers"
   fi
 else
-  warn "no adr/README.md — skipping ADR-number check"
+  warn "no $DOCS_REL/adr/README.md — skipping ADR-number check"
 fi
 
 # --- 3. Valid STEP / substep statuses -----------------------------------------
@@ -150,7 +154,7 @@ if [ -f "$INDEX" ]; then
   if [ -n "$bad" ]; then
     fail "invalid status value(s):"
     while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$bad"
-    hint "use exactly one of: Planned · In progress · Done · Deferred · Abandoned (a substep may also be N/A). See METHOD.md §1."
+    hint "use exactly one of: Planned · In progress · Done · Deferred · Abandoned (a substep may also be N/A). See $DOCS_REL/METHOD.md §1."
   else
     pass "all statuses valid"
   fi
@@ -179,7 +183,7 @@ else
   if [ "$missing_any" -eq 0 ]; then
     pass "all ${#docs[@]} architecture doc(s) have the required fields"
   else
-    hint "add the missing field(s) from templates/architecture-doc-template.md (Version / Status header, and a Version Log table). See METHOD.md §6."
+    hint "add the missing field(s) from $DOCS_REL/templates/architecture-doc-template.md (Version / Status header, and a Version Log table). See $DOCS_REL/METHOD.md §6."
   fi
 fi
 
@@ -200,7 +204,7 @@ if [ -f "$ADR_INDEX" ]; then
   [ -n "$missing_rows" ]  && { fail "file on disk but not in registry: $(echo "$missing_rows" | tr '\n' ' ')"; ok=0; hint "add a registry row in adr/README.md for the file(s), or delete the file if it shouldn't exist."; }
   [ "$ok" -eq 1 ] && pass "registry and files agree ($(emit "$reg_ids" | grep -c . ) ADR(s))"
 else
-  warn "no adr/README.md — skipping ADR registry/disk check"
+  warn "no $DOCS_REL/adr/README.md — skipping ADR registry/disk check"
 fi
 
 # --- 6. Legacy local user profile fields --------------------------------------
@@ -211,14 +215,14 @@ hdr "6. Legacy local user profile fields"
 if [ -f "$OVERVIEW" ]; then
   legacy_profile_fields="$(grep -nE '^## (Your experience level|Planning communication style)[[:space:]]*$' "$OVERVIEW" || true)"
   if [ -n "$legacy_profile_fields" ]; then
-    warn "overview.md contains legacy personal preference section(s):"
+    warn "$DOCS_REL/overview.md contains legacy personal preference section(s):"
     while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$legacy_profile_fields"
-    hint "create/update root .throughstone/local-user.md for the active user, then remove these personal-preference sections from overview.md after confirming they are not project facts. See UPDATING-THROUGHSTONE.md."
+    hint "create/update root .throughstone/local-user.md for the active user, then remove these personal-preference sections from $DOCS_REL/overview.md after confirming they are not project facts. See UPDATING-THROUGHSTONE.md."
   else
-    pass "overview.md has no legacy local user preference sections"
+    pass "$DOCS_REL/overview.md has no legacy local user preference sections"
   fi
 else
-  pass "no overview.md yet (project not initialized?) — skipping legacy local user profile check"
+  pass "no $DOCS_REL/overview.md yet (project not initialized?) — skipping legacy local user profile check"
 fi
 
 # --- 7. Workspace-root hygiene (multi-repo only) ------------------------------
@@ -241,7 +245,7 @@ else
   done
   if [ -n "$stray" ]; then
     warn "unexpected entr(ies) at workspace root:$stray — should these be inside a repo (usually the docs hub)?"
-    hint "move durable content into a repo (almost always Code/<project>-docs/); the root holds only per-machine pointers, the repo folders, and Upcoming Prompts/. See METHOD.md §7."
+    hint "move durable content into a repo (almost always Code/<project>-docs/); the root holds only per-machine pointers, the repo folders, and Upcoming Prompts/. See $DOCS_REL/METHOD.md §7."
   else
     pass "only the expected pointers / repos at the workspace root"
   fi
@@ -256,7 +260,7 @@ session_templates=("$SESSION_TEMPLATE_DIR"/[0-9][0-9]-*.md)
 if [ ${#session_templates[@]} -eq 0 ]; then
   warn "no numbered architecture-session templates found — skipping numbering check"
 elif [ ! -f "$STEP_INDEX_SEED" ]; then
-  warn "no templates/step-index-seed.md found — skipping numbering check"
+  warn "no $DOCS_REL/templates/step-index-seed.md found — skipping numbering check"
 else
   numbering_ok=1
   max_prefix=0
@@ -294,7 +298,7 @@ else
       }
     ' "$STEP_INDEX_SEED")"
     if [ -z "$seed_row" ]; then
-      fail "$b has no matching 1.$minor row in templates/step-index-seed.md"
+      fail "$b has no matching 1.$minor row in $DOCS_REL/templates/step-index-seed.md"
       numbering_ok=0
       seed_label=""
       seed_output=""
@@ -344,7 +348,7 @@ else
     case "$template_minors" in
       *" $seed_minor "*) : ;;
       *)
-        fail "templates/step-index-seed.md has 1.$seed_minor ('$seed_label') but no matching numbered session template"
+        fail "$DOCS_REL/templates/step-index-seed.md has 1.$seed_minor ('$seed_label') but no matching numbered session template"
         numbering_ok=0
         ;;
     esac
@@ -360,7 +364,7 @@ else
   if [ "$numbering_ok" -eq 1 ]; then
     pass "numbered architecture sessions match headings and STEP-index seed; Cross-Cutting Review is last"
   else
-    hint "keep numbered session files, their '(Session 1.N)' headings, and templates/step-index-seed.md rows in lockstep; the Cross-Cutting Review remains the final numbered session."
+    hint "keep numbered session files, their '(Session 1.N)' headings, and $DOCS_REL/templates/step-index-seed.md rows in lockstep; the Cross-Cutting Review remains the final numbered session."
   fi
 fi
 
@@ -396,12 +400,12 @@ else
   if [ "$conditional_ok" -eq 1 ]; then
     pass "all ${#conditional_templates[@]} conditional template(s) expose applicability, invocation, output, next action, and complete late-follow-up bookkeeping"
   else
-    hint "copy an existing conditional template's contract: explicit applicability, 'Run it by name', Output, Next, and both STEP-1 / late-follow-up PLAN, architecture-index, and active-substep bookkeeping. See METHOD.md §4."
+    hint "copy an existing conditional template's contract: explicit applicability, 'Run it by name', Output, Next, and both STEP-1 / late-follow-up PLAN, architecture-index, and active-substep bookkeeping. See $DOCS_REL/METHOD.md §4."
   fi
 fi
 
 # --- 10. Check-in cadence marker (overview.md) --------------------------------
-hdr "10. Check-in cadence marker (overview.md)"
+hdr "10. Check-in cadence marker ($DOCS_REL/overview.md)"
 # The optional `<!-- CHECK-IN-CADENCE: N -->` line in overview.md sets the check-in target N
 # (status.sh defaults to 20 when the line is absent). Warn — never fail — if the line is present
 # but N isn't a positive integer; its absence is always fine.
@@ -411,12 +415,12 @@ if [ -f "$OVERVIEW" ]; then
   elif grep -qE 'CHECK-IN-CADENCE:[[:space:]]*[1-9][0-9]*([[:space:]]|-->|$)' "$OVERVIEW"; then
     pass "CHECK-IN-CADENCE is a positive integer"
   else
-    warn "overview.md CHECK-IN-CADENCE is not a positive integer — status.sh falls back to the default (20):"
+    warn "$DOCS_REL/overview.md CHECK-IN-CADENCE is not a positive integer — status.sh falls back to the default (20):"
     printf '         %s\n' "$(grep -E 'CHECK-IN-CADENCE:' "$OVERVIEW" | head -1)"
     hint "set it to a positive whole number of STEPs (e.g. <!-- CHECK-IN-CADENCE: 20 -->), or delete the line to accept the default."
   fi
 else
-  pass "no overview.md yet (project not initialized?) — skipping check-in cadence check"
+  pass "no $DOCS_REL/overview.md yet (project not initialized?) — skipping check-in cadence check"
 fi
 
 # --- 11. Repo registry (registries/repos.yml) — check-in only ------------------
@@ -434,9 +438,9 @@ fi
 # named. The root row is covered by nothing else: if it has no remote, it is flagged like any
 # other repo.
 if [ "$CHECK_IN" -eq 1 ]; then
-  hdr "11. Repo registry (registries/repos.yml)"
+  hdr "11. Repo registry ($DOCS_REL/registries/repos.yml)"
   if [ ! -f "$REPOS_REGISTRY" ]; then
-    warn "no registries/repos.yml — skipping repo registry check"
+    warn "no $DOCS_REL/registries/repos.yml — skipping repo registry check"
   else
     # Walk each `- name:` block and report the rows missing a location, and the rows no
     # recorded remote covers. Comment lines are skipped, so the example row at the bottom is not
@@ -480,7 +484,7 @@ if [ "$CHECK_IN" -eq 1 ]; then
     [ -z "$no_loc" ] && [ -z "$no_rem" ] && pass "$rows row(s): all have a location, and a recorded remote covers every one"
   fi
 else
-  hdr "11. Repo registry (registries/repos.yml)"
+  hdr "11. Repo registry ($DOCS_REL/registries/repos.yml)"
   pass "skipped — run with --check-in (this check belongs to the periodic check-in)"
 fi
 

--- a/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
+++ b/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
@@ -78,7 +78,7 @@ mkdir -p "$ROOT/.throughstone"
 REG="$DOCS_DIR/registries/repos.yml"
 missing=0
 if [ -f "$REG" ]; then
-  echo "Cloning sibling repos with remotes from registries/repos.yml ..."
+  echo "Cloning sibling repos with remotes from $DOCS_REL/registries/repos.yml ..."
   # Parse repos.yml block-aware: pair each repo's own location with its own remote.
   # The registry is the multi-repo inventory, and remote: is optional. Walking each `- name:`
   # block keeps locations and remotes aligned when only some repos are cloneable; comment lines
@@ -127,13 +127,13 @@ if [ -f "$REG" ]; then
     END { if (loc != "" && rem != "") print loc "|" rem }
   ' "$REG")
 else
-  echo "No registries/repos.yml — skipping clone step."
+  echo "No $DOCS_REL/registries/repos.yml — skipping clone step."
 fi
 
 echo "Done. Open this folder in your agent; it will discover the context via the pointers."
 if [ "$missing" -gt 0 ]; then
   echo
   echo "$missing repo(s) above did not arrive. The workspace itself is complete — fix the remote"
-  echo "or the location in registries/repos.yml, or clone the repo yourself, then re-run this"
+  echo "or the location in $DOCS_REL/registries/repos.yml, or clone the repo yourself, then re-run this"
   echo "script to pick it up."
 fi

--- a/init.sh
+++ b/init.sh
@@ -500,7 +500,8 @@ if [ "$COLLAB" = "2" ]; then
     ADR_AUTHORITY="consensus of maintainers"
   else
     echo "  In a team, significant ADRs land as Proposed and are flipped to Accepted by a"
-    echo "  designated authority (recorded in adr/README.md so it's on disk, not folklore)."
+    echo "  designated authority (recorded in Code/${SLUG}-docs/adr/README.md so it's on"
+    echo "  disk, not folklore)."
     ADR_AUTHORITY="$(ask 'Who accepts ADRs? e.g. tech lead / consensus of maintainers / ADR review on PR' 'consensus of maintainers')"
     echo "  Heads-up: team collaboration relies on shared Git remotes so everyone clones"
     echo "  from the same place. You can still skip that now and add remotes later."
@@ -508,7 +509,8 @@ if [ "$COLLAB" = "2" ]; then
       echo "  NOTE: you picked mono-repo + team. That works — what a team needs is shared"
       echo "  remotes, not several repos. One thing to know: the overlap warning is"
       echo "  repo-granular, so it is meaningless when every STEP touches the one repo."
-      echo "  Fall back to the PLAN's file/area notes — see runbooks/collaboration.md §4."
+      echo "  Fall back to the PLAN's file/area notes — see"
+      echo "  Code/${SLUG}-docs/runbooks/collaboration.md §4."
     fi
   fi
 fi

--- a/tests/check-repo-registry.sh
+++ b/tests/check-repo-registry.sh
@@ -93,8 +93,13 @@ doctor() {
   local work="$1"; shift
   DOC_OUT="$(bash "$(doctor_of "$work")" "$@" 2>&1)"
   DOC_STATUS=$?
-  SEC="$(printf '%s\n' "$DOC_OUT" | awk '/^11\. Repo registry/ { f = 1 } f && /^Summary$/ { exit } f')"
-  [ -n "$SEC" ] || bad "the doctor printed no check 11 section at all (args: ${*:-none})"
+  # The heading names the registry file, and that name now carries the project slug, so the
+  # assertions read the section body only: a refutation must not match the path in a heading.
+  SEC="$(printf '%s\n' "$DOC_OUT" | awk '/^11\. Repo registry/ { f = 1; next } f && /^Summary$/ { exit } f')"
+  case "$DOC_OUT" in
+    *"11. Repo registry"*) ;;
+    *) bad "the doctor printed no check 11 section at all (args: ${*:-none})" ;;
+  esac
 }
 
 has()    { case "$SEC" in *"$1"*) return 0 ;; *) return 1 ;; esac; }


### PR DESCRIPTION
Six instructions in the docs could not be followed from the directory their own text
stands the reader in. Each named a script by a path relative to the docs hub, to somebody
standing at the workspace root. The first line of the periodic check-in was one of them —
the only one on a path anyone walks regularly, and the reason this was worth doing.

The convention that should have caught them, in `METHOD.md` §7, sorted documents into two
piles and put `runbooks/` in neither, which is where most of the broken instructions lived.
It also named `METHOD.md` itself as writing workspace-root paths while `METHOD.md` writes
hub-relative ones 89 times to 5, so the paragraph stating the convention was the document
breaking it hardest.

The rule now turns on what a path is *for*, an axis chosen by measurement rather than taste.
Sorted by document it condemned 231 sites across the hub that read correctly today. Sorted
by purpose it condemns 31, of which 13 are one document's known drift. A shell command is
written from where the text stands you — the workspace root unless the text says otherwise,
and that holds whether you are told to run it or warned off it, because a warning has to name
the program unambiguously too. Everything else follows the file it is written in. The rule
also settles what "relative to the hub" is measured from, what a bare `status.sh` or
`architecture/` means, that a Markdown link target follows Markdown rather than either
convention, and that a path a tool *prints* follows the reader rather than the tool.

That last clause has teeth: `scripts/check.sh` does not change the caller's directory, so one
run of it answered in two bases — the repo-registry check headed itself one way and named the
same hub the other way two lines below. Its printed paths and `scripts/setup-workspace.sh`'s
now render from the workspace root, the way `scripts/links.sh` already renders its diagnostics.
`AGENTS.md` had copied the old convention into its own header and drifted from it; it now
declares where its paths are relative to and cites the rule instead of restating it, and the
ADR duplicate scan it tells an agent to run before every push now names a file that is there.
The setup wizard's two prompts that named a hub file now name it in full, using the project's
real name.

**Verified by running rather than by reading.** Every repaired instruction was executed
verbatim from the directory its own text names, in a copy with the placeholder substituted the
way the wizard substitutes it: all exit 0, and the teammate-clone case produced the three root
files `ONBOARDING.md` tells the reader to look for. Every pre-existing form fails from that
same directory with exit 127, and the old ADR path errors with no such file. A sweep of every
tracked Markdown file for commands that cannot run where the reader stands leaves seven hits:
two correct by the rule's own exception, five in `UPDATING-THROUGHSTONE.md`, which is not this
change's to edit. `templates/` carries no hub-relative commands at all, checked both ways.
Generated text was checked at every generation point. No script or test encodes this
convention, and `scripts/links.sh` structurally cannot — it strips inline code so examples do
not look like links.

Changing what `check.sh` prints broke a test, which was the useful part: it refuted a repo name
across the whole of the repo-registry check *including its heading*, and the heading now carries
the project name. The assertion is about what the check reports, so it now reads the section body
and proves the section ran by finding the heading separately — confirmed by mutation, not by
re-running it green.

Suite 14/14, `check.sh` 0 fail, `links.sh` 0 fail, 17 path-resolution cases passing.

Known and left alone, deliberately: `UPDATING-THROUGHSTONE.md` still has three instructions of
this shape and `AGENTS.md` 13 reference-form inconsistencies; both are recorded rather than swept,
because converting every path in the hub is about a thousand sites, most of which read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
