### PR TITLE
Describe the workspace helper in the order it actually runs

### DIFF
--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -136,8 +136,8 @@ that selection against the docs hub's canonical `LICENSE`, copies the project li
 for open-source projects, and creates no project `LICENSE` for proprietary projects. It also
 copies `LICENSE-THROUGHSTONE` because the standard generated repo retains Throughstone-authored
 README and CI scaffolding, and writes `LICENSING.md` to make those scopes explicit.
-`Code/{{PROJECT}}-docs/scripts/setup-workspace.sh` sets up a new developer's machine (clones the siblings, writes
-the root pointers). From the workspace root, `./doctor.sh status`, `./doctor.sh check`, and
+`Code/{{PROJECT}}-docs/scripts/setup-workspace.sh` sets up a new developer's machine (writes the root pointers,
+then clones the siblings). From the workspace root, `./doctor.sh status`, `./doctor.sh check`, and
 `./doctor.sh links` are thin shortcuts to `Code/{{PROJECT}}-docs/scripts/status.sh`,
 `Code/{{PROJECT}}-docs/scripts/check.sh`, and `Code/{{PROJECT}}-docs/scripts/links.sh`.
 New human or agent contributor joining an existing project? Read


### PR DESCRIPTION
`AGENTS.md` told an agent that `scripts/setup-workspace.sh` "clones the siblings, writes the root pointers".

That was the order until the clone-resilience fix reversed it. The pointer files — `AGENTS.md`, `CLAUDE.md` and `doctor.sh` at the workspace root — are now written **first**, and the clone step runs after, so a single repository nobody can reach no longer aborts the run before those files exist and leave a joining contributor with no workspace at all.

`ONBOARDING.md` was brought into line with the new order in that same change. This one sentence in `AGENTS.md` was missed — and it is the sentence an agent reads.

**Scope:** two lines, one paragraph. No behaviour change; the helper itself is untouched.

**Verified:** `./doctor.sh check` and `./doctor.sh links` both `RESULT: OK`; `tests/*.sh` 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
