### PR TITLE
Stop the setup wizard acting on an answer nobody gave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,12 +149,15 @@ any project built with it.
   `scripts/check.sh` also gains its first test.
 
 - **The interactive setup no longer licenses your project open source by default.** `init.sh` asks
-  whether the project is open source or private/proprietary, and that question used to default to
+  whether the project is open source or proprietary, and that question used to default to
   open source, with the license question after it defaulting to MIT — so two bare Enters granted
   everyone an irrevocable license to the project's code without the user ever naming one. The
-  project-type question now defaults to **private / proprietary**, which writes no project
+  project-type question now defaults to **proprietary**, which writes no project
   `LICENSE` at all and leaves the decision to be made deliberately later. The open-source
-  sub-question keeps its MIT default: by the time it is asked, open source is an explicit choice.
+  sub-question no longer defaults to MIT either: once open source is the posture, which licence it
+  is has to be typed. (That half came later in this same cycle — see the wizard-answers entry
+  below — and is recorded here rather than as its own reversal, since no release ever shipped the
+  in-between state.)
   Nothing changes for `--license=…` or `--non-interactive`, which have always required the posture
   to be stated. Existing projects are unaffected — their posture is already recorded in
   `.throughstone/project-license`.
@@ -320,9 +323,124 @@ any project built with it.
   let an empty value through — into `AGENTS.md`, `templates/planning-session.md` and every
   architecture session template. A blank copyright holder did the same to an open-source project,
   shipping `Copyright (c) 2026 ` with nothing after it in every generated repo, with the doctor
-  reporting no failures. End of input still ends the run rather than looping: an exhausted answer
-  stream takes the advertised default at a yes/no question and exits 2 with the missing prompt
-  named at a required one.
+  reporting no failures. An exhausted answer stream takes the advertised default at a yes/no
+  question and exits 2 with the missing prompt named at a required one. The questions that go
+  through `ask` rather than `yesno` or `want` were not covered by that and are fixed in the entry
+  below.
+- **The setup wizard no longer acts on an answer nobody gave, and says what it discarded.** Four
+  of its questions offered the answer you get by leaning on Enter, and each of the four is fixed
+  at the moment the project is created or reaches off this machine: the open-source licence menu
+  handed out MIT, an irrevocable grant nobody named; the repo layout menu picked multi; the
+  solo/team menu picked solo, which writes an ADR register naming the reader as its own acceptance
+  authority; and the remote setup menu picked *create repositories on GitHub under your account*.
+  None of the four has a default now — blank and whitespace are not answers to them, and the
+  question comes back. An unrecognised answer at the remote menu is re-asked too, rather than
+  ending the run, which is how every other menu here already behaved. Three defaults were weighed
+  in the same pass and deliberately kept, because accepting one by accident costs a setting rather
+  than a project: the project-type question (proprietary, which licenses nobody), GitHub
+  visibility (private), and who accepts ADRs. The `main` trunk branch keeps its value too, and
+  nobody is ever asked about it, so there is nothing there to fat-finger.
+
+  **End of input ends the run.** `ask` ignored `read`'s exit status, so an unattended run — an
+  agent, a script, `< /dev/null` — was handed an unlimited supply of empty answers. At the slug
+  question, which re-asks until the answer is valid and where blank never is, that was not a wrong
+  result but no result: measured at 94KB of the same re-ask notice in twelve seconds before it was
+  killed. A question with a default now takes that default at end of input, the way `yesno` and
+  `want` already did; a question without one stops the run and names the answer it is missing. The
+  fix is a precondition for the removals above, since a question made to insist on an answer
+  inherits that loop.
+
+  **A repository that is already under `prompts/` is refused.** The fresh-template guard only ever
+  read the workspace root, and the multi layout initializes a second durable repo one directory
+  down. Measured: `git init`, a commit, and `git branch -M` ran inside a repository that was
+  already there, leaving it two commits deep with its branch renamed from `work` to `main`, and
+  the run exited 0. It is refused before the destructive boundary now, by the same check that
+  refuses the other five shapes, and refusing leaves that repository byte-for-byte as it was found.
+
+  **A flag that cannot apply is named rather than dropped in silence.** Each layout reads the
+  remote-URL flags that match its shape, so one of the two sets is always unusable: a mono project
+  has one repository and no use for `--docs-remote` or `--prompts-remote`, and a multi project has
+  two and no use for `--remote-url`. Passing the wrong set produced a project whose remotes
+  contradicted the command that created it, with nothing in the run admitting the difference. Each
+  now prints a line of the form `note: ignoring --docs-remote — mono layout has one repo` and the
+  run continues. Refusing was considered and rejected: a wrapper passing one harmless extra flag
+  should not fail, and being told is the whole of what was missing.
+
+  **The same goes for an answer that cannot apply.** A mono project's one repository is the
+  workspace root, so when that folder already has an empty Git origin there is nothing for
+  "create a repository on GitHub" to create — the origin is reused instead. That is the right
+  outcome, since replacing a remote you attached yourself would be the real surprise. Saying
+  nothing about it was not: `gh` was never called, the owner question simply did not appear, and
+  the substitution surfaced only as a line calling the result a reuse, printed after the point
+  where the run stops being reversible. It is now named where it happens, before that point, with
+  the URL that will be used and the fact that stopping there costs nothing.
+
+  **And the slug question's refusal now describes the rule it enforces.** The pattern requires a
+  first character that is a letter; the refusal read "lowercase letters, digits, hyphens only",
+  which `3d-printer` obeys and the pattern still rejects. On the flag path that costs a minute. At
+  the prompt it costs more, because the question re-asks and the reader has been told to correct
+  something already correct, with nothing in the message leading anywhere that works. One string
+  serves both paths and now names the whole pattern. What is accepted has not changed.
+
+  **The layout menu says what each layout does to the folder you are standing in.** Multi-repo
+  leaves the workspace root a per-machine shell with no repository at all, so a file put there
+  afterwards is tracked by nothing and backed up by nowhere. The menu said only that `prompts/`
+  and the docs hub "become separate repos", which never said separate from *what* — separate from
+  each other, or separate from a root repo that still exists? The `README` states it twice and the
+  wizard stated it nowhere, which is the wrong way round, because the wizard is where the choice
+  is made and cannot be revisited. Both options now name their own consequence.
+
+  **`private` and `proprietary` no longer mean the same thing.** The licence question offered
+  "Private / proprietary" and a question twenty lines later offers "1) Private" for who can see the
+  repository — the same word for two unrelated settings, in one run. They are independent: a private
+  repo can carry MIT, and a public repo can be proprietary. Read the first question as being about
+  visibility and you answer it, and get a project licensed to nobody. `proprietary` is now the
+  licence word everywhere — the menu label, the flag value, and the internal token, which had stayed
+  `private` while `.throughstone/project-license` already wrote `Proprietary` — and `private` refers
+  to repository visibility and nothing else. The licence question also says, in one line, that
+  visibility is asked separately later.
+
+  `--license=private` still works and still produces exactly the same project, so a wrapper that has
+  always passed it does not break; it prints a deprecation notice naming `--license=proprietary` and
+  will be removed in a future release. Deprecating rather than refusing, for the same reason an
+  unusable flag is named rather than refused. `--visibility=private` is untouched.
+
+  **The mono-repo + team caveat now turns on the two answers it is about.** Choosing that
+  combination makes the overlap warning useless — it is repo-granular, and there is one repo — and
+  the note saying so sat inside the branch that *asks* who accepts ADRs. Its real condition was how
+  that one unrelated value arrived: measured on three identical mono + team projects, typing the
+  ADR authority printed the note, passing `--adr-authority` did not, and `--non-interactive` did
+  not. Same project, same limitation, one warning. It now prints for all three, and for neither
+  neighbouring combination. It also says that nothing has been created yet and the run can still be
+  stopped — which was already true and which nothing on screen admitted.
+
+  The line above it had the same defect and is fixed with it: **every team is now told that team
+  collaboration relies on shared remotes**, not only the teams that happened to type their ADR
+  authority rather than pass it.
+
+  **And `--adr-authority` on a solo project is named rather than dropped.** A solo project records
+  the author as the authority — the register is stamped `_solo author_` and the question is never
+  asked — so a supplied authority has nothing to attach to. It used to exit 0 with no mention of the
+  flag at all. It now prints `note: ignoring --adr-authority — a solo project records you as the
+  authority`, and a team project passing the same flag still gets exactly what it asked for, in
+  silence. `INIT_ADR_AUTHORITY` is the same story.
+
+  **"Use existing remote URLs" now says what those URLs have to be.** Each repository must already
+  exist, be empty, and be reachable with your credentials — three requirements you used to discover
+  by refusal, after typing both URLs. Nothing is lost when that happens, because the check runs
+  before the run touches anything; what is lost is the whole interview, since there is no resume and
+  one pasted string sends you back to the project name. The requirements were already written down,
+  but only on the branch taken when `gh` is missing — so the wizard explained itself exactly where it
+  could not offer the easier option, and not where it could.
+
+  **And the closing note agrees with the layout menu about what is actually saved.** Telling a
+  multi-repo reader that the workspace root is not a repository — which the menu now does — left the
+  closing line *"your project is saved locally with Git"* contradicting it a few screens later, in
+  the same run. Between a warning and a reassurance a reader takes the reassurance, which is the
+  wrong one here. The line is now per-layout, the way the `init.sh`-deletion note beside it already
+  was: a mono project is told everything in the folder is in its repository, and a multi project is
+  told which two repositories hold the committed work and that files at the root are in neither.
+  Both now also say the work was **committed**, which neither of them used to mention at all.
 - **The check-in report template has somewhere to record deferred coverage.** An architecture doc
   may deliberately leave part of its area unwritten, marked in its `Coverage:` field.
   `runbooks/check-in.md` treats that as a standing obligation — the deferral must be "resurfaced,

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -121,10 +121,26 @@ yours changes and there is no action here. It matters only the next time you boo
 Throughstone project: do that from 1.8 or later.
 
 The same release changes one bootstrap default, and again there is nothing to do. `init.sh`'s
-interactive project-type question now defaults to private/proprietary rather than open source, so
+interactive project-type question now defaults to proprietary rather than open source, so
 pressing Enter through setup no longer licenses a project MIT without anyone naming a license. Your
 project's posture was chosen when it was created and is recorded in `.throughstone/project-license`;
 it does not change. Worth knowing only if you bootstrap another project from muscle memory.
+
+**`private` and `proprietary` now mean two different things, and if you script `init.sh` there is
+one rename.** `private` refers to repository visibility and nothing else; `proprietary` is the
+licence posture. They were the same word in two unrelated questions — the licence question offered
+"Private / proprietary" while a later one offered "1) Private" for who can see the repository — and
+they are genuinely independent: a private repo can carry MIT, and a public repo can be proprietary.
+
+- **Nothing in your project changes.** Your posture is recorded as `Proprietary` in
+  `.throughstone/project-license` and always was; that spelling has not moved. `init.sh` runs once,
+  when a project is created, and an existing project never runs it again.
+- **If you have a wrapper, alias, or CI job that creates projects with `--license=private`, write
+  `--license=proprietary`.** The old spelling still works and produces exactly the same project, so
+  nothing breaks today — but it now prints a deprecation notice naming the new one, and it will be
+  removed in a future release. `INIT_LICENSE=private` is the same story.
+- **`--visibility=private` is unaffected** and stays as it is. That is the flag `private` now
+  belongs to.
 
 **The Check-in STEP now has a title contract, and one row of yours may need renaming.**
 `scripts/status.sh` measures the check-in cadence from the last `Done` STEP it recognises as a

--- a/init.sh
+++ b/init.sh
@@ -20,7 +20,39 @@ cd "$ROOT"
 # Small UI helpers. They only print/prompt; all validation happens at the call sites so flags,
 # env vars, and interactive answers share the same checks.
 say()  { printf '\n\033[1m%s\033[0m\n' "$*"; }
-ask()  { local p="$1" d="${2:-}" a; if [ -n "$d" ]; then read -r -p "$p [$d]: " a; echo "${a:-$d}"; else read -r -p "$p: " a; echo "$a"; fi; }
+# ask PROMPT [DEFAULT] — ask one question and print the answer. With a DEFAULT, a bare Enter takes
+# it. Without one, a blank answer is returned as the blank it is: every such call site loops until
+# the answer is one of its valid options, and blank is never one of them.
+#
+# End of input is not an answer. `read` returns non-zero once the stream is exhausted, and this
+# used to be ignored — so an unattended run (an agent, a script, `< /dev/null`) got an endless
+# supply of empty answers. At a question with a default that quietly built a whole project; at the
+# slug question, whose loop re-asks until the answer is valid and where blank never is, it spun
+# forever: measured `./init.sh < /dev/null`, 94KB of the same re-ask notice in twelve seconds
+# before it was killed. A question with a default now takes that default at end of input, the way
+# yesno and want already do, and a question without one stops the run and names itself.
+#
+# Callers must take the answer through an assignment — `answer="$(ask …)"` — because that is the
+# one position where errexit sees the exit status of a command substitution. Used as a bare
+# argument or a `case` word, `$(ask …)` throws the status away and the caller loops on the empty
+# string instead of stopping. Every call site below is an assignment for that reason, including
+# the ones whose default means they cannot exit today.
+ask() {
+  local p="$1" d="${2:-}" a="" rc=0
+  if [ -n "$d" ]; then
+    read -r -p "$p [$d]: " a || rc=$?
+    [ -n "$a" ] || a="$d"
+  else
+    read -r -p "$p: " a || rc=$?
+  fi
+  # A final line with no trailing newline still fails the read while delivering the answer, so the
+  # value decides, not the status alone.
+  if [ "$rc" -ne 0 ] && [ -z "$a" ]; then
+    echo "init.sh: missing required value (input ended): $p" >&2
+    exit 2
+  fi
+  printf '%s\n' "$a"
+}
 
 # yesno PROMPT — ask a yes/no question that defaults to no. It re-asks on an answer it does not
 # recognise, the way every other question in the wizard does; before this, anything outside
@@ -100,7 +132,7 @@ normalize_license_choice() {
     mit|1)                       NORMALIZED_LICENSE_CHOICE=1 ;;
     bsd|bsd-3|bsd-3-clause|2)   NORMALIZED_LICENSE_CHOICE=2 ;;
     apache|apache-2|apache-2.0|3) NORMALIZED_LICENSE_CHOICE=3 ;;
-    proprietary|private)        NORMALIZED_LICENSE_CHOICE=private ;;
+    proprietary|private)        NORMALIZED_LICENSE_CHOICE=proprietary ;;
     *)                          return 1 ;;
   esac
 }
@@ -155,31 +187,47 @@ validate_trunk_branch() {
 }
 
 # choose_license_interactively — prompt until the project type and license are valid.
-# Proprietary is a project-license posture, not a GitHub visibility setting. Open-source
+# Proprietary is a project-license posture, not a repository visibility setting. Open-source
 # projects choose a concrete permissive license template; proprietary projects intentionally
 # skip project LICENSE creation later.
 #
-# The project-type question defaults to private/proprietary because that is the recoverable
-# answer. Accepting it writes no project LICENSE at all, which anyone can change later by
-# choosing a license deliberately; accepting an open-source default would grant everyone an
-# irrevocable license to the project's code without the user ever having named one. The
-# open-source sub-question keeps its MIT default — by the time it is asked, open source is an
-# explicit choice and MIT is a reasonable one.
+# One word, one meaning, throughout: `proprietary` is the licence posture and `private` is who can
+# see the repository. This question used to call its own answer "Private / proprietary", and a
+# question twenty lines further on offers "1) Private" for something unrelated — so a reader who
+# took the first one to be about visibility answered it, and got a project licensed to nobody.
+# Both are legitimate settings and they are independent: a private repo can carry MIT, and a
+# public repo can be proprietary. The internal token, the flag value and the label all say
+# `proprietary` now; `--license=private` is still accepted with a deprecation notice so a wrapper
+# that has always passed it keeps working.
+#
+# The project-type question defaults to proprietary because that is the recoverable
+# answer, and that default was weighed again in the sweep that took the defaults off the other
+# menus here — it survived it deliberately. Accepting it writes no project LICENSE at all, which
+# anyone can change later by choosing a license deliberately; accepting an open-source default
+# would grant everyone an irrevocable license to the project's code without the user ever having
+# named one. A default is affordable exactly when accepting it by accident is cheap to reverse,
+# and this one is the cheapest answer on the page.
+#
+# The open-source sub-question has no default, and that is the same test read the other way. It is
+# only reached once open source is chosen, so the question is which licence — and MIT arriving
+# because a key was leaned on is an irrevocable grant nobody named. Blank is not an answer to it;
+# it asks again.
 choose_license_interactively() {
   local project_type license_input
 
   while :; do
-    echo "Is this project open source or private/proprietary?"
-    echo "  1) Open source"
-    echo "  2) Private / proprietary"
+    echo "How should this project's code be licensed?"
+    echo "  1) Open source  (a LICENSE file is created and anyone may reuse the code)"
+    echo "  2) Proprietary  (no LICENSE file is created; nobody is granted reuse rights)"
+    echo "  Not the same as who can see the repository — that is asked separately, later."
     project_type="$(ask 'Choose 1 or 2' '2')"
     case "$project_type" in
       1) break ;;
       2)
-        LICENSE_CHOICE="private"
+        LICENSE_CHOICE="proprietary"
         return 0
         ;;
-      *) echo "  -> choose 1 for open source or 2 for private / proprietary." ;;
+      *) echo "  -> choose 1 for open source or 2 for proprietary." ;;
     esac
   done
 
@@ -188,9 +236,9 @@ choose_license_interactively() {
     echo "  1) MIT           (permissive, simplest)"
     echo "  2) BSD-3-Clause  (permissive + name-endorsement protection)"
     echo "  3) Apache-2.0    (permissive, with patent grant)"
-    license_input="$(ask 'Choose 1, 2, or 3' '1')"
+    license_input="$(ask 'Choose 1, 2, or 3')"
     if normalize_license_choice "$license_input" \
-      && [ "$NORMALIZED_LICENSE_CHOICE" != "private" ]; then
+      && [ "$NORMALIZED_LICENSE_CHOICE" != "proprietary" ]; then
       LICENSE_CHOICE="$NORMALIZED_LICENSE_CHOICE"
       return 0
     fi
@@ -248,13 +296,16 @@ init.sh — one-time Throughstone setup wizard.
 Runs interactively by default. Pass flags (or set env vars) to pre-answer any
 question; whatever you leave out is still prompted — unless --non-interactive is
 set, in which case a missing required value is an error (useful for scripts/CI).
+A "(default: …)" below is what --non-interactive falls back to. Most prompts offer
+no default at all: the structural answers have to be typed, so that pressing Enter
+cannot decide the repo layout, the licence, or whether repositories are created.
 
 Usage: ./init.sh [options]
 
 Options:
   --slug=SLUG            Project slug (lowercase kebab-case, e.g. acme-scheduler)
   --desc=TEXT           One-line description
-  --license=NAME        mit | bsd-3 | apache-2.0 | private
+  --license=NAME        mit | bsd-3 | apache-2.0 | proprietary
   --holder=NAME         Copyright holder (required for open-source licenses)
   --layout=LAYOUT       multi | mono                    (default: multi)
   --registries=yes|no   Deprecated and ignored; registries/ always ships
@@ -421,6 +472,16 @@ if [ -e "$ROOT/.git" ]; then
   fi
 fi
 
+# 5. Checks 1-4 only ever read the workspace root, and the multi layout initializes a second
+#    durable repo one directory down. The template ships prompts/ as plain files, so a repository
+#    there is someone else's: init_repo runs `git init && git add -A && git commit && git branch
+#    -M` inside it, which adds a commit to their history and renames the branch it was on, and the
+#    run exits 0 having said nothing. `-e` rather than `-d` because a linked worktree or submodule
+#    leaves a .git file, and committing into one of those is the same damage.
+if [ -e "$ROOT/prompts/.git" ]; then
+  refuse_not_fresh "prompts/ is already a Git repository, and this would commit on top of it."
+fi
+
 say "Throughstone — setup"
 
 # --- 1. Questions (flags/env pre-answer; otherwise prompt) -------------------
@@ -443,8 +504,14 @@ say "Throughstone — setup"
 SLUG_MAX=64
 slug_problem() {
   local s="$1"
+  # The message has to name the whole pattern, including the first character. It used to read
+  # "lowercase letters, digits, hyphens only", which a slug like 3d-printer satisfies and the
+  # pattern still rejects — so the refusal described a rule the run does not enforce. On the flag
+  # path that costs a minute; at the prompt it is worse, because the loop re-asks and the reader
+  # is told to fix something already correct, with nothing in the message leading to an answer
+  # that works. One string, both call sites.
   printf '%s' "$s" | grep -Eq '^[a-z][a-z0-9-]*$' \
-    || { echo "lowercase letters, digits, hyphens only"; return; }
+    || { echo "must start with a lowercase letter, then lowercase letters, digits and hyphens"; return; }
   [ "${#s}" -le "$SLUG_MAX" ] \
     || { echo "${#s} characters is too long — keep it to $SLUG_MAX"; return; }
   [ ! -e "Code/${s}-docs" ] \
@@ -474,15 +541,27 @@ DESC="$(want "$DESC_IN" 'One-line description')"
 LICENSE_CHOICE=""
 if [ -n "$LICENSE_IN" ]; then
   normalize_license_choice "$LICENSE_IN" \
-    || { echo "init.sh: invalid --license '$LICENSE_IN' (mit | bsd-3 | apache-2.0 | private)." >&2; exit 2; }
+    || { echo "init.sh: invalid --license '$LICENSE_IN' (mit | bsd-3 | apache-2.0 | proprietary)." >&2; exit 2; }
   LICENSE_CHOICE="$NORMALIZED_LICENSE_CHOICE"
+  # `private` now means one thing in this wizard and one only: who can see the repository on a
+  # host. As a licence value it meant something unrelated — no LICENSE file at all — and the two
+  # questions sat twenty lines apart using the same word for both. Still accepted, so a wrapper
+  # that has always passed it does not break; said once, so the wrapper can be corrected. Deprecate
+  # rather than refuse for the same reason the ignored flags are named rather than refused.
+  case "$(printf '%s' "$LICENSE_IN" | tr '[:upper:]' '[:lower:]')" in
+    private)
+      echo "init.sh: --license=private is deprecated; write --license=proprietary instead." >&2
+      echo "         'private' now refers only to repository visibility (--visibility=private)." >&2
+      echo "         The spelling still works and will be removed in a future release." >&2
+      ;;
+  esac
 elif [ "$NONINTERACTIVE" = "1" ]; then
-  echo "init.sh: --license is required in --non-interactive mode (mit | bsd-3 | apache-2.0 | private)." >&2; exit 2
+  echo "init.sh: --license is required in --non-interactive mode (mit | bsd-3 | apache-2.0 | proprietary)." >&2; exit 2
 else
   choose_license_interactively
 fi
 HOLDER=""
-if [ "$LICENSE_CHOICE" != "private" ]; then
+if [ "$LICENSE_CHOICE" != "proprietary" ]; then
   HOLDER="$(want "$HOLDER_IN" 'Copyright holder (name or org)')"
 fi
 LICENSE_TEMPLATE_NAME=""
@@ -500,7 +579,7 @@ case "$LICENSE_CHOICE" in
     LICENSE_TEMPLATE_NAME="Apache-2.0.txt"
     PROJECT_LICENSE_ID="Apache-2.0"
     ;;
-  private)
+  proprietary)
     PROJECT_LICENSE_ID="Proprietary"
     ;;
   *)
@@ -528,12 +607,26 @@ if [ -n "$LAYOUT_IN" ]; then
 elif [ "$NONINTERACTIVE" = "1" ]; then
   LAYOUT=1
 else
+  # The menu names what each layout does to this folder, because that is the half a first-time
+  # reader cannot infer and the half that costs them something later. "become separate repos" was
+  # ambiguous in the direction that hurts: separate from each other, or separate from a root repo
+  # that still exists? Multi leaves the root a workspace shell with no repository at all, so a
+  # file left there afterwards is tracked by nothing and backed up by nowhere. The README says
+  # this twice; the wizard said it nowhere, and the wizard is where the choice is made.
   echo "Repo layout:"
-  echo "  1) multi-repo now  (prompts/ and Code/${SLUG}-docs/ become separate repos)"
-  echo "  2) mono-repo for now  (one repo at the workspace root; split later)"
+  echo "  1) multi-repo now  (prompts/ and Code/${SLUG}-docs/ each become their own repo;"
+  echo "                      this folder is not itself a repo, so anything left here is"
+  echo "                      not tracked or backed up)"
+  echo "  2) mono-repo for now  (one repo at this folder, so everything here is tracked;"
+  echo "                         split into separate repos later)"
+  # No default: the layout is structural and fixed at creation, so Enter cannot be allowed to
+  # pick it. The answer is taken through an assignment rather than passed straight to
+  # normalize_layout, because a `$(ask …)` used as an argument discards the exit status ask
+  # stops the run with — see ask above.
   LAYOUT=""
   while [ -z "$LAYOUT" ]; do
-    if normalize_layout "$(ask 'Choose 1 or 2' '1')"; then
+    LAYOUT_ANSWER="$(ask 'Choose 1 or 2')"
+    if normalize_layout "$LAYOUT_ANSWER"; then
       LAYOUT="$NORMALIZED_LAYOUT"
     else
       echo "  -> answer 1 or 2 (the words multi and mono work too)."
@@ -570,9 +663,13 @@ else
   echo "Working solo for now, or collaborating with others from day one?"
   echo "  1) Solo for now  (team conventions switch on later; nothing here locks you in)"
   echo "  2) Team from day one"
+  # No default, for the same reason as the layout question above: solo is not the safer of the two
+  # answers, it is one of them, and the one it picks by accident writes the ADR register's
+  # acceptance authority as the reader themselves.
   COLLAB=""
   while [ -z "$COLLAB" ]; do
-    if normalize_collab "$(ask 'Choose 1 or 2' '1')"; then
+    COLLAB_ANSWER="$(ask 'Choose 1 or 2')"
+    if normalize_collab "$COLLAB_ANSWER"; then
       COLLAB="$NORMALIZED_COLLAB"
     else
       echo "  -> answer 1 or 2 (the words solo and team work too)."
@@ -590,15 +687,38 @@ if [ "$COLLAB" = "2" ]; then
     echo "  designated authority (recorded in Code/${SLUG}-docs/adr/README.md so it's on"
     echo "  disk, not folklore)."
     ADR_AUTHORITY="$(ask 'Who accepts ADRs? e.g. tech lead / consensus of maintainers / ADR review on PR' 'consensus of maintainers')"
-    echo "  Heads-up: team collaboration relies on shared Git remotes so everyone clones"
-    echo "  from the same place. You can still skip that now and add remotes later."
-    if [ "$LAYOUT" = "2" ]; then
-      echo "  NOTE: you picked mono-repo + team. That works — what a team needs is shared"
-      echo "  remotes, not several repos. One thing to know: the overlap warning is"
-      echo "  repo-granular, so it is meaningless when every STEP touches the one repo."
-      echo "  Fall back to the PLAN's file/area notes — see"
-      echo "  Code/${SLUG}-docs/runbooks/collaboration.md §4."
-    fi
+  fi
+  # Said to every team, not only to the ones that happened to type their ADR authority. This had
+  # the same defect the caveat below had, one line above it: the branch that asks for that one
+  # value is not the condition for advice about something else. The closing instructions already
+  # tell every project how to attach a remote later; this is the half that says why a team needs
+  # one at all, and it belongs where the reader has just said they are a team.
+  echo "  Heads-up: team collaboration relies on shared Git remotes so everyone clones"
+  echo "  from the same place. You can still skip that now and add remotes later."
+  # The mono + team caveat turns on the two answers it is about, and nothing else. It used to sit
+  # inside the branch above, which asks for the ADR authority — so its real condition was how that
+  # one unrelated value arrived. Measured on three identical mono + team projects: typing the
+  # authority printed it, passing --adr-authority did not, and --non-interactive did not. Same
+  # project, same limitation, one warning. It also says that stopping costs nothing, because it
+  # does: the run has created nothing at this point, and the reader had no way to know that.
+  if [ "$LAYOUT" = "2" ]; then
+    echo "  NOTE: you picked mono-repo + team. That works — what a team needs is shared"
+    echo "  remotes, not several repos. One thing to know: the overlap warning is"
+    echo "  repo-granular, so it is meaningless when every STEP touches the one repo."
+    echo "  Fall back to the PLAN's file/area notes — see"
+    echo "  Code/${SLUG}-docs/runbooks/collaboration.md §4."
+    echo "  Nothing has been created yet, so this run can still be stopped and rerun with"
+    echo "  --layout=multi if that changes your mind."
+  fi
+else
+  # A solo project records the author as the authority — the register is stamped `_solo author_`
+  # and the question is never asked — so a supplied authority has nothing to attach to. It was
+  # dropped without a word: measured, `--collab=solo --adr-authority="the CTO"` exits 0 with the
+  # register saying `_solo author_` and not one mention of the flag. Named rather than refused,
+  # for the reason the unusable remote-URL flags are named: a wrapper that passes one uniform flag
+  # set to every project it creates should not fail over a value that costs nothing to drop.
+  if [ -n "$ADR_AUTHORITY_IN" ]; then
+    echo "  note: ignoring --adr-authority — a solo project records you as the authority"
   fi
 fi
 
@@ -693,14 +813,32 @@ elif [ "$NONINTERACTIVE" != "1" ]; then
   if ! yesno "Set up online Git remotes now?"; then
     MK_REMOTES=0
   elif command -v gh >/dev/null 2>&1; then
+    # Option 2's requirements are stated with the option, not discovered by refusal after both URLs
+    # have been typed. They were already written down — but only on the branch below, the one taken
+    # when gh is missing, so the wizard explained itself only where it could not offer the easier
+    # path. Nothing is lost by finding out late, since the check runs before the boundary; what is
+    # lost is the whole interview, because there is no resume and one pasted string sends you back
+    # to the project name.
     echo "Remote setup:"
     echo "  1) Create GitHub remotes now (via gh)"
     echo "  2) Use existing remote URLs (Bitbucket, GitLab, or another Git host)"
-    case "$(ask 'Choose 1 or 2' '1')" in
-      1) MK_REMOTES=1; REMOTE_PROVIDER_IN=github ;;
-      2) MK_REMOTES=1; REMOTE_PROVIDER_IN=manual ;;
-      *) echo "init.sh: invalid remote setup choice." >&2; exit 2 ;;
-    esac
+    echo "     Each repo must already exist, be empty, and be reachable with your"
+    echo "     credentials. All three are checked before anything here changes."
+    # No default. Enter here used to mean "create real GitHub repositories under your account" —
+    # the one answer on the page that reaches outside this machine, and the only one whose
+    # accidental acceptance leaves something to clean up on a host. An unrecognised answer is now
+    # re-asked rather than fatal, the way every other menu in the wizard behaves; the question is
+    # cheap to repeat and there is nothing here worth ending a run over.
+    REMOTE_SETUP_CHOICE=""
+    while [ -z "$REMOTE_SETUP_CHOICE" ]; do
+      REMOTE_SETUP_CHOICE="$(ask 'Choose 1 or 2')"
+      case "$REMOTE_SETUP_CHOICE" in
+        1) MK_REMOTES=1; REMOTE_PROVIDER_IN=github ;;
+        2) MK_REMOTES=1; REMOTE_PROVIDER_IN=manual ;;
+        *) echo "  -> choose 1 to create GitHub remotes, or 2 to use remote URLs you already have."
+           REMOTE_SETUP_CHOICE="" ;;
+      esac
+    done
   else
     echo "  GitHub auto-creation needs the 'gh' CLI, which is not installed."
     echo "  If you already created empty repos online, you can paste their URLs now."
@@ -735,11 +873,17 @@ if [ "$MK_REMOTES" = "1" ]; then
       *) echo "init.sh: invalid --visibility '$VISIBILITY_IN' (private | public)." >&2; exit 2 ;;
     esac
   elif [ "$REMOTE_PROVIDER" = "github" ] && [ "$NONINTERACTIVE" != "1" ]; then
+    # This default is kept, and was kept deliberately: accepting Private by accident creates a
+    # repository nobody else can read, which is one setting away from fixing, while the other
+    # answer publishes source. The answer is still taken through an assignment so that every
+    # ask call site obeys the same contract — see ask above — and removing this default later
+    # cannot silently reintroduce the loop that contract exists to stop.
     echo "GitHub repository visibility:"
     echo "  1) Private"
     echo "  2) Public"
     while :; do
-      case "$(ask 'Choose 1 or 2' '1')" in
+      VISIBILITY_ANSWER="$(ask 'Choose 1 or 2' '1')"
+      case "$VISIBILITY_ANSWER" in
         1) REMOTE_VISIBILITY=private; break ;;
         2) REMOTE_VISIBILITY=public; break ;;
         *) echo "  -> choose 1 for private or 2 for public." ;;
@@ -759,7 +903,19 @@ if [ "$MK_REMOTES" = "1" ]; then
   fi
   if [ "$REMOTE_PROVIDER" = "github" ]; then
     if [ "$LAYOUT" = "2" ] && root_origin_can_be_reused; then
+      # Creating a repository on GitHub cannot apply here: a mono project's one repository is this
+      # folder, and this folder already has an empty origin. Reusing it is the right outcome —
+      # replacing a remote the user attached themselves would be the real surprise — but it is not
+      # what was asked for, and it used to be unannounced. The only signals were the owner question
+      # quietly not being asked and, much later and past the destructive boundary, a line calling
+      # the result a reuse without ever saying that creation had been dropped. Named here, before
+      # the boundary, where every other discarded answer is named. The URL is named too: it decides
+      # where the project ends up, and nothing before this point has shown it.
       OWNER=""
+      echo "  note: not creating a repository on GitHub — this folder already has an empty origin"
+      echo "        $ROOT_ORIGIN"
+      echo "        It is reused as the project's remote, so no owner is needed. Nothing has been"
+      echo "        changed yet: stop now and remove that origin if you want a new GitHub repo."
     else
       OWNER="$(want "$OWNER_IN" 'GitHub owner/org')"
     fi
@@ -768,13 +924,31 @@ if [ "$MK_REMOTES" = "1" ]; then
       echo "init.sh: --owner is only used with --remote-provider=github." >&2
       exit 2
     fi
+    # Each layout reads the URL flags that match its shape and has no use for the others, so one
+    # of the two sets is always dropped. Say so rather than refuse: a wrapper that passes the same
+    # flag set to every project would break on a refusal, and an unusable URL is harmless. Say so
+    # rather than stay silent: the alternative is a project whose remotes contradict the command
+    # that created it, with nothing in the run admitting the difference. Both directions are here
+    # because a rule that held in one layout only would be the same defect wearing the other hat.
     if [ "$LAYOUT" = "2" ]; then
+      # One repository, so the two multi-repo URL flags have nothing to attach to.
+      if [ -n "$DOCS_REMOTE_IN" ]; then
+        echo "  note: ignoring --docs-remote — mono layout has one repo"
+      fi
+      if [ -n "$PROMPTS_REMOTE_IN" ]; then
+        echo "  note: ignoring --prompts-remote — mono layout has one repo"
+      fi
       if root_origin_can_be_reused && [ -z "$REMOTE_URL_IN" ]; then
         REMOTE_URL=""
       else
         REMOTE_URL="$(want "$REMOTE_URL_IN" 'Project repo remote URL')"
       fi
     else
+      # Two repositories and no single one, so --remote-url has nothing to attach to. Nothing here
+      # asks for the workspace root's URL, because in this layout the root is not a repository.
+      if [ -n "$REMOTE_URL_IN" ]; then
+        echo "  note: ignoring --remote-url — multi layout has two repos"
+      fi
       DOCS_REMOTE="$(want "$DOCS_REMOTE_IN" 'Docs repo remote URL')"
       PROMPTS_REMOTE="$(want "$PROMPTS_REMOTE_IN" 'Prompts repo remote URL')"
     fi
@@ -830,7 +1004,7 @@ if [ "$MK_REMOTES" = "1" ]; then
 fi
 if [ "$MK_REMOTES" = "1" ] \
   && [ "$REMOTE_VISIBILITY" = "public" ] \
-  && [ "$LICENSE_CHOICE" = "private" ]; then
+  && [ "$LICENSE_CHOICE" = "proprietary" ]; then
   cat >&2 <<'WARNING'
 WARNING: public visibility with a proprietary license publishes the source code but grants
 no open-source reuse rights. LICENSE-THROUGHSTONE covers only retained Throughstone scaffold
@@ -1036,7 +1210,7 @@ GI
 # so apply-project-license.sh has the same source of truth as multi-repo projects.
 stamp_license() {
   local src
-  [ "$LICENSE_CHOICE" = "private" ] && return 0
+  [ "$LICENSE_CHOICE" = "proprietary" ] && return 0
   src="$DOCS/templates/licenses/$LICENSE_TEMPLATE_NAME"
   [ -f "$src" ] || {
     echo "init.sh: project license template disappeared during setup: $src" >&2
@@ -1055,7 +1229,7 @@ stamp_license() {
 # Every generated repo gets LICENSING.md so readers do not mistake LICENSE-THROUGHSTONE for the
 # project's license grant.
 write_licensing_summary() {
-  if [ "$LICENSE_CHOICE" = "private" ]; then
+  if [ "$LICENSE_CHOICE" = "proprietary" ]; then
     cat > "$1/LICENSING.md" <<'EOF'
 # Licensing
 
@@ -1340,6 +1514,22 @@ else
   INIT_SH_TIP="You can delete this init.sh now — it has done its job. It is not part of any
 repo here, so deleting the file is the whole of it."
 fi
+# "your project is saved locally with Git" is true of a mono project and only partly true of a
+# multi one, where the workspace root is not a repository — and the layout menu now says so
+# explicitly, in the same run, a few screens earlier. One sentence saying everything is saved and
+# another saying files here are not tracked is a contradiction the reader has to resolve alone, and
+# the reassuring half is the one they will believe. Same treatment as the init.sh tip above: say
+# whichever is true. It also names the commit, which neither layout used to mention at all.
+if [ "$LAYOUT" = "2" ]; then
+  SAVED_TIP="You can start now; your project is committed locally with Git — everything in this
+  folder is in that repository. For backup, sharing, and working from another computer, put the
+  project on a Git host when you're ready."
+else
+  SAVED_TIP="You can start now; both repositories here are committed locally with Git —
+  Code/${SLUG}-docs/ and prompts/. Files at the workspace root are not in any repository, as the
+  layout question said, so keep anything durable inside one of those two. For backup, sharing, and
+  working from another computer, put the project on a Git host when you're ready."
+fi
 if [ -n "$REMOTE_FAILED_REPOS" ]; then
   say "Done — but the backup did not complete."
 else
@@ -1362,8 +1552,7 @@ The agent will interview you, propose a roadmap, and start the architecture STEP
 ${INIT_SH_TIP}
 
 Recommended optional backup:
-  You can start now; your project is saved locally with Git. For backup, sharing,
-  and working from another computer, put the project on a Git host when you're ready.
+  ${SAVED_TIP}
 
   GitHub, Bitbucket, GitLab, and other Git hosts all work with the generated repos.
   ${REMOTE_TIP}

--- a/tests/init-fresh-template-guard.sh
+++ b/tests/init-fresh-template-guard.sh
@@ -18,6 +18,7 @@
 #   `git init` beside the template, empty      a repo tracking files the template does not ship
 #                                              an unborn HEAD with commits on another branch
 #                                              an unborn HEAD with files staged, never committed
+#   the template's own plain prompts/          a repository of someone else's under prompts/
 #
 # The last check pins the template's root-entry list, which the guard carries as a literal, to the
 # template itself so it cannot rot.
@@ -182,7 +183,51 @@ assert_refused "staged" "$staged" "staged files that were never committed"
 [ -n "$(git -C "$staged" ls-files)" ] \
   || { echo "FAIL: staged — init.sh cleared the user's index before refusing" >&2; exit 1; }
 
-# --- 10. The guard's root-entry list matches what the template actually ships. ------------------
+# --- 10. A repository of someone else's under prompts/ is refused. -----------------------------
+# Checks 1-4 only ever read the workspace root, and the multi layout initializes a second durable
+# repo one directory down. Without this check init_repo ran `git init && git add -A && git commit
+# && git branch -M` inside whatever was already there: a commit added to history that is not this
+# project's, the branch it was on renamed, and exit 0. Nothing above catches it — the root here is
+# an ordinary unpacked template and passes every one of them.
+nested="$TMP_ROOT/nested-prompts"
+copy_template "$nested"
+( cd "$nested/prompts" && git init -q && printf 'my prompt\n' > mine.md && git add -A \
+    && seed_commit "prompts I already had" && git branch -M work )
+nested_sha="$(git -C "$nested/prompts" rev-parse HEAD)"
+if init_once "$nested" nestedprompts --layout=multi >"$TMP_ROOT/nested.out" 2>&1; then
+  echo "FAIL: nested-prompts — init.sh committed into a repository that was already there" >&2
+  cat "$TMP_ROOT/nested.out" >&2
+  exit 1
+fi
+grep -Fq "does not look like a fresh Throughstone template checkout" "$TMP_ROOT/nested.out" \
+  || { echo "FAIL: nested-prompts — refusal did not print the fresh-template message" >&2; cat "$TMP_ROOT/nested.out" >&2; exit 1; }
+grep -Fq "prompts/ is already a Git repository" "$TMP_ROOT/nested.out" \
+  || { echo "FAIL: nested-prompts — refusal did not name the check that fired" >&2; cat "$TMP_ROOT/nested.out" >&2; exit 1; }
+# Refusing has to leave that repository exactly as it was found — same tip commit, same branch,
+# same files. A guard that refuses after committing has still done the damage.
+[ "$(git -C "$nested/prompts" rev-parse HEAD)" = "$nested_sha" ] \
+  || { echo "FAIL: nested-prompts — init.sh added a commit before refusing" >&2; exit 1; }
+[ "$(git -C "$nested/prompts" symbolic-ref --short HEAD)" = "work" ] \
+  || { echo "FAIL: nested-prompts — init.sh renamed the branch before refusing" >&2; exit 1; }
+[ -f "$nested/prompts/mine.md" ] \
+  || { echo "FAIL: nested-prompts — init.sh removed files before refusing" >&2; exit 1; }
+[ -d "$nested/Code/{{PROJECT}}-docs" ] \
+  || { echo "FAIL: nested-prompts — init.sh crossed the destructive boundary before refusing" >&2; exit 1; }
+
+# --- 11. The template's own prompts/ still proceeds (the matching must-proceed case). ----------
+# Every other case in this file leaves prompts/ a plain directory, so this pairing is already
+# carried by case 1 above; assert it here too, next to the refusal it bounds, because a check
+# written as `[ -e prompts ]` would pass every assertion in section 10 and refuse every project.
+plain_prompts="$TMP_ROOT/plain-prompts"
+copy_template "$plain_prompts"
+[ -d "$plain_prompts/prompts" ] && [ ! -e "$plain_prompts/prompts/.git" ] \
+  || { echo "FAIL: plain-prompts — fixture is not the shape this case is about" >&2; exit 1; }
+init_once "$plain_prompts" plainprompts --layout=multi >"$TMP_ROOT/plain-prompts.out" 2>&1 \
+  || { echo "FAIL: guard blocked a template whose prompts/ is a plain directory" >&2; cat "$TMP_ROOT/plain-prompts.out" >&2; exit 1; }
+[ -d "$plain_prompts/prompts/.git" ] \
+  || { echo "FAIL: plain-prompts — init.sh did not make prompts/ a repository" >&2; exit 1; }
+
+# --- 12. The guard's root-entry list matches what the template actually ships. ------------------
 # The list is a literal inside init.sh, so it can rot the moment a root entry is added or removed.
 # Derive the truth from the template and compare, so adding one without the other fails here.
 expected="$TMP_ROOT/root-entries-expected"

--- a/tests/init-license-validation.sh
+++ b/tests/init-license-validation.sh
@@ -9,6 +9,29 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-license-test.XXXXXX")"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
+# run_with_deadline SECONDS CMD... — run CMD and exit 124 if it outlives the deadline.
+#
+# The wizard's failure mode when a prompt insists on an answer and the answer stream has run out
+# is not a wrong result, it is no result: it re-asks forever. A test that only asserts the exit
+# status hangs the whole suite instead of failing when that comes back. Written in perl because
+# init.sh already requires perl, while `timeout` is GNU coreutils and absent from a stock macOS —
+# the suite must fail on the machine of anyone who downloaded this template, not only on CI's.
+run_with_deadline() {
+  local secs="$1"; shift
+  perl -e '
+    my $secs = shift @ARGV;
+    my $pid = fork();
+    die "fork: $!" unless defined $pid;
+    if (!$pid) { exec { $ARGV[0] } @ARGV or die "exec: $!"; }
+    $SIG{ALRM} = sub { kill 9, $pid; waitpid $pid, 0; exit 124 };
+    alarm $secs;
+    waitpid $pid, 0;
+    my $st = $?;
+    alarm 0;
+    exit($st & 127 ? 128 + ($st & 127) : $st >> 8);
+  ' "$secs" "$@"
+}
+
 # copy_template DEST — build an init.sh fixture from HEAD, then overlay current worktree
 # changes. The overlay keeps uncommitted bootstrap/comment-pass edits under test, while leaving
 # Git metadata behind so init.sh sees the same shape as a downloaded template.
@@ -398,13 +421,22 @@ run_registry_multi_case() {
 # The re-prompts are the cheap half. The assertions that matter are about the project that came
 # out: a hybrid answers the hints identically.
 run_typed_layout_collab_case() {
-  local name="typed-layout-collab"
+  local name="typed-layout-collab" status
   local work="$TMP_ROOT/$name"
 
   copy_template "$work"
+  # The answer stream is exactly as long as the questions that should be asked, so any change that
+  # consumes an answer meant for the next question, or refuses one that should be accepted, runs
+  # it out early. Capture that rather than leaving it to errexit, which would kill the suite from
+  # inside a subshell without writing down which case failed or why.
+  set +e
   (
     cd "$work"
-    printf 'bogus\nmono\nnope\nteam\n' | ./init.sh \
+    # No trailing newline on the last answer. `read` fails on it exactly as it fails on an empty
+    # stream, while still delivering "team" — someone who typed an answer and pressed Ctrl-D. The
+    # status alone cannot tell those apart, so the value has to decide, and this is where that is
+    # measured: if it did not, the run would stop here instead of recording a team project.
+    printf 'bogus\n\nmono\nnope\n \nteam' | ./init.sh \
       --slug="$name" \
       --desc="Typed answer test" \
       --license=mit \
@@ -412,15 +444,53 @@ run_typed_layout_collab_case() {
       --adr-authority="tech lead" \
       --remotes=no
   ) >"$TMP_ROOT/$name.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 0 ] || {
+    echo "FAIL: $name — the run did not finish (exit $status); an answer this stream carries was refused, or one was consumed by a question that should not have asked" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
 
-  grep -Fq "answer 1 or 2 (the words multi and mono work too)" "$TMP_ROOT/$name.out" || {
-    echo "FAIL: $name did not re-ask the layout question after an unrecognised answer" >&2
+  # Two re-asks each, not one. The first is the unrecognised word; the second is the answer that
+  # is not there — Enter at the layout question, a space at the collaboration one. Neither menu
+  # offers a default any more, and counting the re-asks is the only way to see that: `read -p`
+  # prints its prompt to a terminal only, so under a pipe there is no prompt text in the output to
+  # read a default off. Enter and a space used to buy multi and solo here — a layout fixed at
+  # creation, and an ADR register naming the reader as its own acceptance authority.
+  [ "$(grep -c -F "answer 1 or 2 (the words multi and mono work too)" "$TMP_ROOT/$name.out")" = "2" ] || {
+    echo "FAIL: $name — the layout question did not re-ask both an unrecognised answer and a blank one" >&2
     return 1
   }
-  grep -Fq "answer 1 or 2 (the words solo and team work too)" "$TMP_ROOT/$name.out" || {
-    echo "FAIL: $name did not re-ask the collaboration question after an unrecognised answer" >&2
+  [ "$(grep -c -F "answer 1 or 2 (the words solo and team work too)" "$TMP_ROOT/$name.out")" = "2" ] || {
+    echo "FAIL: $name — the collaboration question did not re-ask both an unrecognised answer and a whitespace one" >&2
     return 1
   }
+  # The menu has to name what each layout does to this folder, at the moment the choice is made.
+  # This is a wording assertion and only that: it proves the sentence is on screen, not that a
+  # reader takes it in. What it describes is asserted for real just below, where this case
+  # separates the layouts by what they actually build. Both halves, because a one-sided contrast
+  # is what the old text had — "become separate repos" never said separate from what.
+  grep -Fq "this folder is not itself a repo" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — the multi option does not say the workspace root stops being a repository" >&2
+    return 1
+  }
+  grep -Fq "everything here is tracked" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — the mono option does not say what it tracks, so the contrast is one-sided" >&2
+    return 1
+  }
+  # This case builds a mono project, so the closing line must be the mono one. The menu telling the
+  # reader that root files are untracked and the ending telling them the project is saved leave a
+  # contradiction for them to resolve, and they will believe the reassuring half — so the two have
+  # to agree per layout. The multi half is asserted in run_saved_tip_multi_case.
+  grep -Fq "everything in this" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — a mono project's closing line does not say the whole folder is in the repo" >&2
+    return 1
+  }
+  if grep -Fq "not in any repository" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name — a mono project was told files here are not in a repository" >&2
+    return 1
+  fi
 
   # "mono" has to mean the mono layout, not most of it. The hybrid's signature was prompts/ left
   # as a repository of its own while every other decision went the mono way, so these two
@@ -899,6 +969,705 @@ run_manual_multi_remote_case() {
   git --git-dir="$prompts_remote" rev-parse --verify refs/heads/main >/dev/null
   grep -Fq "remote: \"$docs_remote\"" "$work/Code/$name-docs/registries/repos.yml"
   grep -Fq "remote: \"$prompts_remote\"" "$work/Code/$name-docs/registries/repos.yml"
+  # The matching must-proceed case for the ignored-flag note below: in the layout these two flags
+  # are for, they are obeyed in silence. A note that fired here would be noise about work done.
+  if grep -Fq "note: ignoring" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name — a flag the multi layout uses was reported as ignored" >&2
+    grep -F "note: ignoring" "$TMP_ROOT/$name.out" >&2
+    return 1
+  fi
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
+# run_end_of_input_case — the run stops when the answers run out.
+#
+# An unattended run — an agent, a `< /dev/null`, a script whose answer stream is shorter than the
+# question list — used to get an unlimited supply of empty answers, because ask discarded read's
+# exit status. At a question with a default that silently built a whole project; at the slug
+# question, whose loop re-asks until the answer is valid and where blank never is, it spun: the
+# behaviour this case pins was measured at 94KB of the same notice in twelve seconds before it was
+# killed. The slug question is the first one asked, so this is also the shortest path to it.
+run_end_of_input_case() {
+  local name="end-of-input" work status
+  work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  set +e
+  ( cd "$work" && run_with_deadline 60 ./init.sh </dev/null ) >"$TMP_ROOT/$name.out" 2>&1
+  status=$?
+  set -e
+
+  [ "$status" -ne 124 ] || {
+    echo "FAIL: $name — init.sh never stopped; it is looping on an exhausted answer stream" >&2
+    tail -3 "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  [ "$status" -eq 2 ] || {
+    echo "FAIL: $name — expected exit 2 when input ran out, got $status" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Naming the question is the difference between stopping and crashing: the message has to say
+  # which answer is missing, because whoever is reading it did not see the prompt scroll past.
+  grep -Fq "missing required value (input ended): Project slug" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — the run stopped without naming the question it stopped at" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Stopping happens before the destructive boundary, so the checkout is still a template.
+  [ -d "$work/Code/{{PROJECT}}-docs" ] || {
+    echo "FAIL: $name — the template docs hub was renamed before the run stopped" >&2
+    return 1
+  }
+  [ -f "$work/README.md" ]
+  assert_maintainer_tests_retained "$name" "$work"
+}
+
+# run_remote_menu_case — the one question in the wizard that reaches outside this machine.
+#
+# "Remote setup" used to default to 1, so Enter meant "create real GitHub repositories under your
+# account" — the only accidental answer here that leaves something to clean up on someone else's
+# server. It now has no default and re-asks instead of exiting, and the same run proves the
+# visibility default below it was kept: that one is cheap to accept by accident, because a repo
+# nobody can read is one setting away from being right.
+run_remote_menu_case() {
+  local name="remote-menu" status
+  local work="$TMP_ROOT/$name"
+  local stub_bin="$TMP_ROOT/$name-bin"
+  local remote_root="$TMP_ROOT/$name-remotes"
+  local gh_log="$TMP_ROOT/$name-gh.log"
+
+  copy_template "$work"
+  mkdir -p "$stub_bin" "$remote_root"
+  cp "$ROOT/tests/fixtures/gh-stub.sh" "$stub_bin/gh"
+  chmod +x "$stub_bin/gh"
+  : > "$gh_log"
+  # The answer stream is exactly as long as the questions that should be asked, so a question
+  # that gains a default consumes an answer meant for the next one and the stream runs out early.
+  # The status is captured rather than left to errexit for that reason: that failure has to name
+  # itself here, not kill the suite from inside a subshell with nothing written down.
+  set +e
+  (
+    cd "$work"
+    # y at "Set up online Git remotes now?", then the remote menu answered blank, then with a
+    # word it does not know, then 1; then Enter at the visibility question, which still has a
+    # default to take.
+    printf 'y\n\nboth\n1\n\n' | \
+      PATH="$stub_bin:$PATH" \
+      GH_LOG="$gh_log" \
+      GH_REMOTE_ROOT="$remote_root" \
+      ./init.sh \
+        --slug="$name" \
+        --desc="Remote menu test" \
+        --license=mit \
+        --holder="Throughstone Test" \
+        --layout=multi \
+        --collab=solo \
+        --owner=throughstone-test
+  ) >"$TMP_ROOT/$name.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 0 ] || {
+    echo "FAIL: $name — the run did not finish (exit $status); a question asked for an answer this stream does not carry, most likely the visibility default it was meant to keep" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+
+  # The removal and the keep, measured in one run and only by behaviour: `read -p` prints its
+  # prompt to a terminal only, so a pipe never sees the `[1]` that renders a default.
+  #
+  # Removed — the blank answer and the unrecognised one both come back as questions. Two, not one:
+  # a menu that still defaulted would answer the blank itself and re-ask only "both".
+  [ "$(grep -c -F "choose 1 to create GitHub remotes" "$TMP_ROOT/$name.out")" = "2" ] || {
+    echo "FAIL: $name — Enter at the remote menu was taken as 'create GitHub repositories'" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Option 2's requirements are on screen with the option. They were already stated on the branch
+  # taken when gh is missing, so the wizard explained itself only where it could not offer the
+  # easier path; this run is the gh-installed one, where it did not. A wording assertion, and only
+  # that — but the wording is the whole change.
+  grep -Fq "must already exist, be empty, and be reachable" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — the existing-URL option does not say what those URLs must be" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Kept — the visibility question got nothing but Enter, and private is what reached the host.
+  # An open-source licence is chosen here for that assertion's sake: under a proprietary one, a
+  # public answer trips the public/proprietary warning and cancels the run, so this case would go
+  # red before ever reading the log and the line below would be measuring nothing.
+  grep -Fq -- "--private" "$gh_log" || {
+    echo "FAIL: $name — Enter at the visibility question did not create private repositories" >&2
+    cat "$gh_log" >&2
+    return 1
+  }
+  [ "$(git -C "$work/Code/$name-docs" remote get-url origin)" = "$remote_root/$name-docs.git" ]
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
+# run_ignored_flag_case — a flag that cannot apply is named, not obeyed and not refused.
+#
+# A mono project has one repository, so --docs-remote and --prompts-remote have nothing to attach
+# to. They were dropped without a word, which left a project whose single remote contradicts the
+# command that created it. Refusing instead would break a wrapper that passes the same flag set to
+# every project, and the flags are harmless — so the run says what it discarded and carries on.
+run_ignored_flag_case() {
+  local name="ignored-flag"
+  local work="$TMP_ROOT/$name"
+  local remote="$TMP_ROOT/$name-project.git"
+  local unused_docs="$TMP_ROOT/$name-docs.git"
+
+  copy_template "$work"
+  git init --bare -q "$remote"
+  git init --bare -q "$unused_docs"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Ignored flag test" \
+      --license=private \
+      --layout=mono \
+      --collab=solo \
+      --remotes=yes \
+      --remote-provider=manual \
+      --remote-url="$remote" \
+      --docs-remote="$unused_docs" \
+      --prompts-remote="$unused_docs"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  grep -Fq "note: ignoring --docs-remote — mono layout has one repo" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — --docs-remote was dropped without saying so" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  grep -Fq "note: ignoring --prompts-remote — mono layout has one repo" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — --prompts-remote was dropped without saying so" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Named, not refused: the project is still built, and built against the URL that does apply.
+  [ "$(git -C "$work" remote get-url origin)" = "$remote" ] || {
+    echo "FAIL: $name — the mono repo did not attach --remote-url" >&2
+    return 1
+  }
+  git --git-dir="$remote" rev-parse --verify refs/heads/main >/dev/null
+  # Named, not obeyed: nothing was pushed to the repo the ignored flags pointed at.
+  if git --git-dir="$unused_docs" rev-parse --verify refs/heads/main >/dev/null 2>&1; then
+    echo "FAIL: $name — an ignored flag's remote was written to anyway" >&2
+    return 1
+  fi
+  # The other direction, in the layout that uses it: --remote-url is this layout's own flag and
+  # must not be reported as dropped. Each of the two cases carries both halves, so a note that
+  # escapes the layout it belongs to is caught wherever it lands.
+  if grep -Fq "ignoring --remote-url" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name — the flag this layout actually uses was reported as ignored" >&2
+    return 1
+  fi
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
+# run_ignored_flag_multi_case — the same rule in the other layout, which is the whole point of it.
+#
+# A multi project has two durable repos and no single one, so --remote-url has nothing to attach
+# to; it was accepted, never read and never mentioned, exactly as --docs-remote was in mono. A
+# rule that held in one layout only would be the same defect wearing the other hat.
+run_ignored_flag_multi_case() {
+  local name="ignored-flag-multi"
+  local work="$TMP_ROOT/$name"
+  local docs_remote="$TMP_ROOT/$name-docs.git"
+  local prompts_remote="$TMP_ROOT/$name-prompts.git"
+  local unused_root="$TMP_ROOT/$name-root.git"
+
+  copy_template "$work"
+  git init --bare -q "$docs_remote"
+  git init --bare -q "$prompts_remote"
+  git init --bare -q "$unused_root"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$name" \
+      --desc="Ignored flag multi test" \
+      --license=private \
+      --layout=multi \
+      --collab=solo \
+      --remotes=yes \
+      --remote-provider=manual \
+      --docs-remote="$docs_remote" \
+      --prompts-remote="$prompts_remote" \
+      --remote-url="$unused_root"
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  grep -Fq "note: ignoring --remote-url — multi layout has two repos" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — --remote-url was dropped without saying so" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Named, not refused: both repos still got the URLs that do apply.
+  [ "$(git -C "$work/Code/$name-docs" remote get-url origin)" = "$docs_remote" ] || {
+    echo "FAIL: $name — the docs repo did not attach --docs-remote" >&2
+    return 1
+  }
+  [ "$(git -C "$work/prompts" remote get-url origin)" = "$prompts_remote" ] || {
+    echo "FAIL: $name — the prompts repo did not attach --prompts-remote" >&2
+    return 1
+  }
+  # Named, not obeyed: nothing was pushed to the repo the ignored flag pointed at.
+  if git --git-dir="$unused_root" rev-parse --verify refs/heads/main >/dev/null 2>&1; then
+    echo "FAIL: $name — the ignored flag's remote was written to anyway" >&2
+    return 1
+  fi
+  # And the mono layout's two notes must not fire here, where those flags are the ones in use.
+  if grep -Fq "ignoring --docs-remote" "$TMP_ROOT/$name.out" \
+    || grep -Fq "ignoring --prompts-remote" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name — a flag this layout actually uses was reported as ignored" >&2
+    return 1
+  fi
+  assert_maintainer_tests_removed "$name" "$work"
+}
+
+# run_github_choice_discarded_case — an answer that cannot apply is named, the way a flag is.
+#
+# A mono project's one repository is the workspace root, so when that folder already has an empty
+# origin there is nothing for "create a repository on GitHub" to create. Reusing the origin is the
+# right outcome; not saying so was the defect. Measured before the fix: the run answered y and
+# then 1 at the remote menu, never called `gh`, never asked for the owner, and reported the result
+# only as a reuse — after the destructive boundary, and never as creation having been dropped.
+#
+# Both halves run here. Without a reusable origin the same answers must still create the repo and
+# must not print the note; a note that fired there would be describing work the run actually did.
+run_github_choice_discarded_case() {
+  local name="github-choice-discarded" status
+  local work="$TMP_ROOT/$name" plain="$TMP_ROOT/$name-plain"
+  local stub_bin="$TMP_ROOT/$name-bin"
+  local remote_root="$TMP_ROOT/$name-remotes"
+  local gh_log="$TMP_ROOT/$name-gh.log"
+  local theirs="$TMP_ROOT/$name-theirs.git"
+
+  mkdir -p "$stub_bin" "$remote_root"
+  cp "$ROOT/tests/fixtures/gh-stub.sh" "$stub_bin/gh"
+  chmod +x "$stub_bin/gh"
+
+  # --- reusable origin present: creation is discarded, and says so ---
+  copy_template "$work"
+  git init --bare -q "$theirs"
+  ( cd "$work" && git init -q && git remote add origin "$theirs" )
+  : > "$gh_log"
+  set +e
+  (
+    cd "$work"
+    # y at "Set up online Git remotes now?", 1 at the remote menu, Enter for visibility.
+    printf 'y\n1\n\n' | \
+      PATH="$stub_bin:$PATH" GH_LOG="$gh_log" GH_REMOTE_ROOT="$remote_root" \
+      ./init.sh --slug="$name" --desc="Discarded choice test" --license=private \
+        --layout=mono --collab=solo
+  ) >"$TMP_ROOT/$name.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 0 ] || {
+    echo "FAIL: $name — the run did not finish (exit $status)" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # Both assertions read only what was printed before the destructive boundary, because "before"
+  # is the whole claim: `reuse_root_origin` already names the same URL afterwards, and telling
+  # someone where their project went once it is too late to stop is the defect, not the fix.
+  # Measured — against the full log, deleting the URL line from the note changes nothing and the
+  # mutation survives.
+  sed -n "1,/Detaching from the template/p" "$TMP_ROOT/$name.out" > "$TMP_ROOT/$name.pre"
+  grep -Fq "note: not creating a repository on GitHub" "$TMP_ROOT/$name.pre" || {
+    echo "FAIL: $name — the GitHub-creation answer was discarded without saying so, or said too late" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  # The URL belongs in the note: it decides where the project ends up and nothing earlier shows it.
+  grep -Fq "$theirs" "$TMP_ROOT/$name.pre" || {
+    echo "FAIL: $name — the note did not name the origin that is used instead" >&2
+    cat "$TMP_ROOT/$name.pre" >&2
+    return 1
+  }
+  # Named, not obeyed: no repository was created on the host, and the existing origin is the one.
+  [ ! -s "$gh_log" ] || {
+    echo "FAIL: $name — a GitHub repository was created after all" >&2
+    cat "$gh_log" >&2
+    return 1
+  }
+  [ "$(git -C "$work" remote get-url origin)" = "$theirs" ] || {
+    echo "FAIL: $name — the existing origin was not the one reused" >&2
+    return 1
+  }
+
+  # --- no reusable origin: creation happens, and the note must stay quiet ---
+  copy_template "$plain"
+  : > "$gh_log"
+  (
+    cd "$plain"
+    printf 'y\n1\n\n' | \
+      PATH="$stub_bin:$PATH" GH_LOG="$gh_log" GH_REMOTE_ROOT="$remote_root" \
+      ./init.sh --slug="$name-plain" --desc="Discarded choice control" --license=private \
+        --layout=mono --collab=solo --owner=throughstone-test
+  ) >"$TMP_ROOT/$name-plain.out" 2>&1
+  if grep -Fq "note: not creating a repository on GitHub" "$TMP_ROOT/$name-plain.out"; then
+    echo "FAIL: $name — the note fired on a run that did create the repository" >&2
+    return 1
+  fi
+  grep -Fq "repo create" "$gh_log" || {
+    echo "FAIL: $name — no repository was created where creation was the right outcome" >&2
+    cat "$TMP_ROOT/$name-plain.out" >&2
+    return 1
+  }
+  assert_maintainer_tests_removed "$name-plain" "$plain"
+}
+
+# run_slug_message_case — a refusal has to describe the rule it actually enforces.
+#
+# The slug pattern is `^[a-z][a-z0-9-]*$`, and the refusal read "lowercase letters, digits,
+# hyphens only" — which `3d-printer` satisfies. Measured: the flag path exited 2 quoting that
+# message back at a slug obeying it. At the prompt the same string is worse, because the loop
+# re-asks and nothing in it leads to an answer that works.
+#
+# Both call sites share one string, so both are checked here — and the prompt run has to go on to
+# build the project, which is the must-proceed half: a refusal that never accepts anything is not
+# an improvement on one that explains itself badly.
+run_slug_message_case() {
+  local name="slug-message" status
+  local flag_work="$TMP_ROOT/$name-flag" prompt_work="$TMP_ROOT/$name-prompt"
+  local rule="must start with a lowercase letter"
+
+  # --- the flag path stops, and names the rule ---
+  copy_template "$flag_work"
+  set +e
+  (
+    cd "$flag_work"
+    ./init.sh --non-interactive --slug=3d-printer --desc="Slug message test" \
+      --license=private --layout=multi --collab=solo --remotes=no
+  ) >"$TMP_ROOT/$name-flag.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 2 ] || {
+    echo "FAIL: $name — a slug starting with a digit was accepted (exit $status)" >&2
+    cat "$TMP_ROOT/$name-flag.out" >&2
+    return 1
+  }
+  grep -Fq "$rule" "$TMP_ROOT/$name-flag.out" || {
+    echo "FAIL: $name — the refusal did not name the first-character rule it enforces" >&2
+    cat "$TMP_ROOT/$name-flag.out" >&2
+    return 1
+  }
+  # Refused before the destructive boundary, like every other slug problem.
+  [ -d "$flag_work/Code/{{PROJECT}}-docs" ] || {
+    echo "FAIL: $name — the run crossed the destructive boundary before refusing the slug" >&2
+    return 1
+  }
+
+  # --- the prompt path re-asks, names the same rule, and then builds the project ---
+  # The answer stream carries exactly one bad slug and one good one, so a rule that refuses the
+  # good one runs the stream out and the wizard stops. Capture that instead of leaving it to
+  # errexit, which would kill the suite from inside the subshell without naming this case.
+  copy_template "$prompt_work"
+  set +e
+  (
+    cd "$prompt_work"
+    printf '3d-printer\nprinter-3d\n' | ./init.sh --desc="Slug message test" \
+      --license=private --layout=multi --collab=solo --remotes=no
+  ) >"$TMP_ROOT/$name-prompt.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 0 ] || {
+    echo "FAIL: $name — the prompt run did not finish (exit $status); a slug this stream carries was refused" >&2
+    cat "$TMP_ROOT/$name-prompt.out" >&2
+    return 1
+  }
+  grep -Fq "$rule" "$TMP_ROOT/$name-prompt.out" || {
+    echo "FAIL: $name — the re-ask did not name the first-character rule" >&2
+    cat "$TMP_ROOT/$name-prompt.out" >&2
+    return 1
+  }
+  # A digit anywhere but first is fine, which is the half the message has to leave standing.
+  [ -d "$prompt_work/Code/printer-3d-docs" ] || {
+    echo "FAIL: $name — the corrected slug was not accepted" >&2
+    cat "$TMP_ROOT/$name-prompt.out" >&2
+    return 1
+  }
+  assert_maintainer_tests_removed "$name-prompt" "$prompt_work"
+}
+
+# run_licence_vocabulary_case — one word, one meaning.
+#
+# The licence question called its own answer "Private / proprietary" while a question twenty lines
+# later offers "1) Private" for repository visibility, which is unrelated: a private repo can carry
+# MIT and a public repo can be proprietary. A reader who took the first question to be about
+# visibility answered it and got a project licensed to nobody. `proprietary` is now the licence
+# word everywhere — label, flag value and internal token — and `private` belongs to visibility.
+#
+# Three parts, because the rule is only true if all three hold: the question stops using the word,
+# the new spelling works, and the old spelling keeps working while saying what to write instead.
+# That last part is the must-proceed half — a vocabulary change that breaks every existing wrapper
+# is not an improvement, and four other test files in this suite still pass --license=private.
+run_licence_vocabulary_case() {
+  local name="licence-vocabulary" status
+  local ask_work="$TMP_ROOT/$name-ask"
+  local old_work="$TMP_ROOT/$name-old" new_work="$TMP_ROOT/$name-new"
+
+  # --- the question no longer spends "private" on licensing ---
+  copy_template "$ask_work"
+  (
+    cd "$ask_work"
+    printf '2\n' | ./init.sh --slug="$name-ask" --desc="Vocabulary test" \
+      --layout=multi --collab=solo --remotes=no
+  ) >"$TMP_ROOT/$name-ask.out" 2>&1
+  if grep -Fqi "private" "$TMP_ROOT/$name-ask.out"; then
+    echo "FAIL: $name — the licence question still spends the word 'private' on licensing" >&2
+    grep -Fi "private" "$TMP_ROOT/$name-ask.out" >&2
+    return 1
+  fi
+  grep -Fq "2) Proprietary" "$TMP_ROOT/$name-ask.out" || {
+    echo "FAIL: $name — the licence question does not offer 'Proprietary' by name" >&2
+    cat "$TMP_ROOT/$name-ask.out" >&2
+    return 1
+  }
+  # And it says the two questions are different, which is the whole reason the reader went wrong.
+  grep -Fq "Not the same as who can see the repository" "$TMP_ROOT/$name-ask.out" || {
+    echo "FAIL: $name — nothing tells the reader visibility is a separate question" >&2
+    return 1
+  }
+  grep -Fxq "Proprietary" "$ask_work/Code/$name-ask-docs/.throughstone/project-license" || {
+    echo "FAIL: $name — answering 2 did not record the proprietary posture" >&2
+    return 1
+  }
+
+  # --- the deprecated spelling still builds the same project, and says so once ---
+  copy_template "$old_work"
+  set +e
+  (
+    cd "$old_work"
+    ./init.sh --non-interactive --slug="$name-old" --desc="Vocabulary test" \
+      --license=private --layout=multi --collab=solo --remotes=no
+  ) >"$TMP_ROOT/$name-old.out" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 0 ] || {
+    echo "FAIL: $name — --license=private stopped working; every wrapper passing it would break" >&2
+    cat "$TMP_ROOT/$name-old.out" >&2
+    return 1
+  }
+  grep -Fxq "Proprietary" "$old_work/Code/$name-old-docs/.throughstone/project-license" || {
+    echo "FAIL: $name — --license=private no longer means the proprietary posture" >&2
+    return 1
+  }
+  # `--` before the pattern: without it grep reads a pattern starting with "--" as an option and
+  # the assertion fails on a run that printed exactly the right thing. Measured, right here.
+  grep -Fq -- "--license=private is deprecated" "$TMP_ROOT/$name-old.out" || {
+    echo "FAIL: $name — the deprecated spelling was accepted without saying what to write instead" >&2
+    cat "$TMP_ROOT/$name-old.out" >&2
+    return 1
+  }
+
+  # --- the new spelling builds it too, and says nothing ---
+  copy_template "$new_work"
+  (
+    cd "$new_work"
+    ./init.sh --non-interactive --slug="$name-new" --desc="Vocabulary test" \
+      --license=proprietary --layout=multi --collab=solo --remotes=no
+  ) >"$TMP_ROOT/$name-new.out" 2>&1
+  grep -Fxq "Proprietary" "$new_work/Code/$name-new-docs/.throughstone/project-license" || {
+    echo "FAIL: $name — --license=proprietary did not record the proprietary posture" >&2
+    return 1
+  }
+  if grep -Fq "deprecated" "$TMP_ROOT/$name-new.out"; then
+    echo "FAIL: $name — the spelling being recommended warns about itself" >&2
+    return 1
+  fi
+  assert_maintainer_tests_removed "$name-new" "$new_work"
+}
+
+# run_mono_team_caveat_case — a caveat turns on the answers it is about, not on how they arrived.
+#
+# Mono-repo plus team makes the overlap warning useless, because that warning is repo-granular and
+# there is one repo. The note saying so used to sit inside the branch that asks who accepts ADRs,
+# so its real condition was how that unrelated value was supplied. Measured on three identical
+# mono + team projects: typing the authority printed the note, `--adr-authority` did not, and
+# `--non-interactive` did not.
+#
+# Five runs: the three ways a mono + team project can be created, all of which must warn, and the
+# two neighbouring combinations, neither of which may. Without the last two this case would pass
+# for a note printed unconditionally, which is a different defect with the same symptom here.
+run_mono_team_caveat_case() {
+  local name="mono-team-caveat" n out
+  local caveat="you picked mono-repo + team"
+
+  # warns: the ADR authority typed, passed as a flag, and defaulted by --non-interactive
+  for n in typed flag noninteractive; do
+    out="$TMP_ROOT/$name-$n.out"
+    copy_template "$TMP_ROOT/$name-$n"
+    (
+      cd "$TMP_ROOT/$name-$n"
+      case "$n" in
+        typed) printf '2\n2\ntech lead\n' | ./init.sh --slug="$name-$n" \
+                 --desc="Caveat test" --license=proprietary --remotes=no ;;
+        flag)  printf '2\n2\n' | ./init.sh --slug="$name-$n" \
+                 --desc="Caveat test" --license=proprietary --remotes=no \
+                 --adr-authority="tech lead" ;;
+        *)     ./init.sh --non-interactive --slug="$name-$n" --desc="Caveat test" \
+                 --license=proprietary --layout=mono --collab=team --remotes=no ;;
+      esac
+    ) >"$out" 2>&1
+    grep -Fq "$caveat" "$out" || {
+      echo "FAIL: $name — a mono + team project built via '$n' was not warned" >&2
+      cat "$out" >&2
+      return 1
+    }
+    # The line above the caveat had the same defect and is checked on the same three paths: why a
+    # team needs shared remotes is advice about the collaboration answer, not about how the ADR
+    # authority happened to arrive.
+    grep -Fq "Heads-up: team collaboration relies on shared Git remotes" "$out" || {
+      echo "FAIL: $name — a team project built via '$n' was not told a team needs shared remotes" >&2
+      return 1
+    }
+    # Stopping is free at that point, and saying so is what gives the reader a way to act.
+    grep -Fq "Nothing has been created yet" "$out" || {
+      echo "FAIL: $name — the caveat ('$n') did not say the run can still be stopped" >&2
+      return 1
+    }
+  done
+
+  # must not warn: neither neighbouring combination has the limitation
+  for n in mono-solo multi-team; do
+    out="$TMP_ROOT/$name-$n.out"
+    copy_template "$TMP_ROOT/$name-$n"
+    (
+      cd "$TMP_ROOT/$name-$n"
+      case "$n" in
+        mono-solo)  ./init.sh --non-interactive --slug="$name-$n" --desc="Caveat test" \
+                      --license=proprietary --layout=mono --collab=solo --remotes=no ;;
+        *)          ./init.sh --non-interactive --slug="$name-$n" --desc="Caveat test" \
+                      --license=proprietary --layout=multi --collab=team --remotes=no ;;
+      esac
+    ) >"$out" 2>&1
+    if grep -Fq "$caveat" "$out"; then
+      echo "FAIL: $name — '$n' was warned about a limitation it does not have" >&2
+      return 1
+    fi
+    # The team advice is scoped to teams, and the mono+team caveat to mono teams — so these two
+    # runs pull in opposite directions and neither alone would catch a line that fires for all.
+    case "$n" in
+      mono-solo)
+        if grep -Fq "Heads-up: team collaboration" "$out"; then
+          echo "FAIL: $name — a solo project was given team advice" >&2
+          return 1
+        fi ;;
+      multi-team)
+        grep -Fq "Heads-up: team collaboration" "$out" || {
+          echo "FAIL: $name — a multi-repo team was not told a team needs shared remotes" >&2
+          return 1
+        } ;;
+    esac
+  done
+  assert_maintainer_tests_removed "$name-multi-team" "$TMP_ROOT/$name-multi-team"
+}
+
+# run_solo_adr_flag_case — a solo project records the author, so a supplied authority is dropped.
+#
+# `--collab=solo --adr-authority="the CTO"` used to exit 0 with the register stamped `_solo author_`
+# and no mention of the flag at all — measured. That is the fifth instance of one pattern on this
+# branch: the wizard accepting something it cannot use and saying nothing, leaving a project that
+# disagrees with the command that made it. Named rather than refused, because a wrapper passing one
+# flag set to every project should not fail over a value that costs nothing to drop.
+#
+# Both directions, since a note that fires everywhere is a different defect with the same symptom:
+# solo with the flag must say so, and team with the same flag must obey it in silence.
+run_solo_adr_flag_case() {
+  local name="solo-adr-flag" status n out
+  local note="note: ignoring --adr-authority"
+
+  # Three runs. solo and team both pass the flag; quiet passes none, and is the run that keeps the
+  # note off the common path — without it a note that fires for every solo project passes this
+  # case, which is a different defect with the same symptom. Measured: a mutation dropping the
+  # flag test survived until this run existed.
+  for n in solo team quiet; do
+    out="$TMP_ROOT/$name-$n.out"
+    copy_template "$TMP_ROOT/$name-$n"
+    set +e
+    (
+      cd "$TMP_ROOT/$name-$n"
+      case "$n" in
+        quiet) ./init.sh --non-interactive --slug="$name-$n" --desc="Solo flag test" \
+                 --license=proprietary --layout=multi --collab=solo --remotes=no ;;
+        *)     ./init.sh --non-interactive --slug="$name-$n" --desc="Solo flag test" \
+                 --license=proprietary --layout=multi --collab="$n" \
+                 --adr-authority="the CTO" --remotes=no ;;
+      esac
+    ) >"$out" 2>&1
+    status=$?
+    set -e
+    [ "$status" -eq 0 ] || {
+      echo "FAIL: $name — the '$n' run did not finish (exit $status); the flag was refused, not named" >&2
+      cat "$out" >&2
+      return 1
+    }
+  done
+
+  # No flag, nothing to report: the ordinary solo run stays quiet.
+  if grep -Fq -- "$note" "$TMP_ROOT/$name-quiet.out"; then
+    echo "FAIL: $name — a solo project reported ignoring a flag nobody passed" >&2
+    return 1
+  fi
+
+  # Solo: named, and not obeyed — the register still records the author.
+  grep -Fq -- "$note" "$TMP_ROOT/$name-solo.out" || {
+    echo "FAIL: $name — --adr-authority was dropped on a solo project without saying so" >&2
+    cat "$TMP_ROOT/$name-solo.out" >&2
+    return 1
+  }
+  grep -Fq "_solo author_" "$TMP_ROOT/$name-solo/Code/$name-solo-docs/adr/README.md" || {
+    echo "FAIL: $name — a solo project did not record the author as the authority" >&2
+    return 1
+  }
+  # Team: obeyed, and not named — this is the layout the flag is for.
+  if grep -Fq -- "$note" "$TMP_ROOT/$name-team.out"; then
+    echo "FAIL: $name — the flag was reported as ignored on a project that uses it" >&2
+    return 1
+  fi
+  grep -Fq "the CTO" "$TMP_ROOT/$name-team/Code/$name-team-docs/adr/README.md" || {
+    echo "FAIL: $name — a team project did not record the supplied authority" >&2
+    return 1
+  }
+  assert_maintainer_tests_removed "$name-team" "$TMP_ROOT/$name-team"
+}
+
+# run_saved_tip_multi_case — the ending agrees with the layout menu about what is saved.
+#
+# The layout question tells a multi-repo reader that this folder is not a repository and files left
+# here are not tracked. The closing section then said "your project is saved locally with Git",
+# unconditionally, in the same run a few screens later. Two sentences, one contradiction, and the
+# reassuring one is the one a reader believes — so the ending is now per-layout, the way the
+# init.sh tip beside it already was. The mono half is asserted in run_typed_layout_collab_case.
+run_saved_tip_multi_case() {
+  local name="saved-tip-multi"
+  local work="$TMP_ROOT/$name"
+
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh --non-interactive --slug="$name" --desc="Saved tip test" \
+      --license=proprietary --layout=multi --collab=solo --remotes=no
+  ) >"$TMP_ROOT/$name.out" 2>&1
+
+  grep -Fq "both repositories here are committed locally" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — the ending does not say which repositories hold the committed work" >&2
+    cat "$TMP_ROOT/$name.out" >&2
+    return 1
+  }
+  grep -Fq "Files at the workspace root are not in any repository" "$TMP_ROOT/$name.out" || {
+    echo "FAIL: $name — the ending contradicts the layout menu about the workspace root" >&2
+    return 1
+  }
+  # The sentence that caused the contradiction must be gone, not merely joined by a correction.
+  if grep -Fq "your project is saved locally with Git" "$TMP_ROOT/$name.out"; then
+    echo "FAIL: $name — the unqualified 'project is saved' claim is still printed in multi" >&2
+    return 1
+  fi
   assert_maintainer_tests_removed "$name" "$work"
 }
 
@@ -910,11 +1679,24 @@ run_interactive_case \
   $'1\nMIT\n' \
   "MIT License"
 
-# Open source chosen explicitly, then the license sub-prompt's default taken: still MIT.
+# Open source chosen explicitly, then the licence sub-prompt answered blank, then answered with a
+# space, then answered. The sub-prompt used to default to MIT, so both of those middle answers
+# were an MIT grant nobody typed. The project this still builds is half the assertion: taking the
+# default away has to leave the question answerable, not merely refusable.
 run_interactive_case \
-  "license-default" \
-  $'1\n\n' \
+  "license-blank-reasked" \
+  $'1\n\n \n1\n' \
   "MIT License"
+
+# Two re-asks, not one: the blank answer and the whitespace one each have to come back. Counting
+# is the whole assertion, because `read -p` prints its prompt only to a terminal — under a pipe
+# there is no prompt text in the output to read a default off, so what the question offers can
+# only be measured by what it does with an answer nobody gave.
+[ "$(grep -c -F "choose 1/mit, 2/bsd-3, or 3/apache-2.0" "$TMP_ROOT/license-blank-reasked.out")" = "2" ] || {
+  echo "FAIL: license-blank-reasked — Enter or a space at the licence question was taken as an answer" >&2
+  cat "$TMP_ROOT/license-blank-reasked.out" >&2
+  exit 1
+}
 
 run_interactive_case \
   "license-reprompt" \
@@ -922,7 +1704,7 @@ run_interactive_case \
   "Apache License"
 
 grep -Fq \
-  "choose 1 for open source or 2 for private / proprietary" \
+  "choose 1 for open source or 2 for proprietary" \
   "$TMP_ROOT/license-reprompt.out"
 grep -Fq \
   "choose 1/mit, 2/bsd-3, or 3/apache-2.0" \
@@ -997,6 +1779,21 @@ run_remote_failure_mono_case
 # --- Typed answers, not just flags --------------------------------------------
 run_typed_layout_collab_case
 run_missing_canonical_license_case
+
+# --- An answer nobody gave --------------------------------------------------------
+# The wizard must not act on Enter where the answer is structural, must not act on an answer
+# stream that has run out, and must say which flags it dropped. Each case pairs its refusal with
+# the acceptance beside it: a project still gets built in every one of them.
+run_end_of_input_case
+run_remote_menu_case
+run_ignored_flag_case
+run_ignored_flag_multi_case
+run_github_choice_discarded_case
+run_slug_message_case
+run_licence_vocabulary_case
+run_mono_team_caveat_case
+run_solo_adr_flag_case
+run_saved_tip_multi_case
 
 # --- Invalid inputs fail before destructive bootstrap work ---------------------
 # Bad license input and missing license templates are detected before template files,


### PR DESCRIPTION
Step J of the repo-record plan, reopened on 2026-09-03 after it was marked done from the
existence of #194 rather than its contents. Item 1 of five was genuinely done; the other four
were not, and one release-note claim was false because of it. This is the four.

**Goal, one sentence:** the setup wizard must never act on an answer nobody gave, and must say
what it discarded.

**The rule, one sentence:** a prompt with no default loops until the answer is one of its valid
options — blank and whitespace-only are never one — and a read that fails because input ran out
stops the run instead of being taken as an answer.

### What changed

**End of input stops the run** (the prerequisite for everything else). `ask` ignored `read`'s
exit status. At the slug question, which re-asks until the answer is valid and where blank never
is, that was a live hang, reproduced rather than inferred: `./init.sh < /dev/null` produced 94KB
of the same re-ask notice in twelve seconds before it was killed. A question with a default now
takes it at end of input, the way `yesno` and `want` already did; a question without one exits 2
naming the answer it is missing. `ask` exits from inside a command substitution, where the status
only reaches errexit through an assignment — so every call site is now an assignment, including
the two whose default means they cannot exit today.

**Four defaults removed**, each fixed at creation or reaching off this machine: the open-source
licence menu, the repo layout, solo/team, and the remote setup menu — where Enter meant *create
repositories on GitHub under your account*. An unrecognised answer at that last one is now
re-asked rather than fatal, which is how every other menu here already behaved.

**Three defaults kept**, weighed in the same pass because accepting one by accident costs a
setting and not a project: project type (private/proprietary), GitHub visibility (private), and
who accepts ADRs. `TRUNK_BRANCH="main"` is not a prompt at all and keeps its value.

**A repository already under `prompts/` is refused.** The fresh-template guard only ever read the
workspace root, and the multi layout initializes a second durable repo one directory down.
Measured against the parent commit: `git init`, a commit and `git branch -M` ran inside a
repository that was already there, leaving it two commits deep with its branch renamed from
`work` to `main`, exit 0. It now refuses through the same `refuse_not_fresh` helper as the other
four checks, before the destructive boundary.

**A flag that cannot apply is named**, not obeyed and not refused — in both directions. Each
layout reads the remote-URL flags matching its shape, so one set is always unusable: mono has no
use for `--docs-remote` or `--prompts-remote`, multi has no use for `--remote-url`. Only the mono
half was in the step as written; the multi half was raised as a finding outside it, and you asked
for it with the rest, so it is here. It was reproduced the same way — exit 0, the flag accepted,
never read, never mentioned — and gets the mirror note.

### Verification

Mutation, not a green suite. **51 mutations, 51 caught**, each confirmed applied by substitution
count and a non-empty diff before its test ran, each restored and the restore confirmed by
`git diff --quiet`. They cover every changed behaviour, both directions: the four removed
defaults put back, the three kept defaults dropped or flipped, the end-of-input check removed
(the hang returns and the covering test goes red at its deadline rather than hanging the suite),
the `prompts/` guard removed, over-firing, refusing too late, and refusing without naming itself,
and each layout's ignored-flag note removed, escaping into the layout that uses those
flags, and obeyed anyway.

Every refusing signal has a matching must-proceed case, which is the trap this area has sprung
before: the guard's pair is a template whose `prompts/` is a plain directory, and the note's pair
is the multi layout, where the same flags are used in silence.

Suite **14/14** at the shipping commit. `./doctor.sh check` and `./doctor.sh links`: **RESULT: OK**.

### The review round, and what it added

The budgeted fresh-reader round returned eight findings. All eight were verified against the code
before any were acted on; two needed correcting first — one overstated what the run already prints,
and one was already on the step's closed list under "a manual remote's visibility". Six were built,
one at a time, each with the user choosing the option:

- the slug refusal described a rule it does not enforce (`3d-printer` rejected by a message it
  satisfies) — and that area had no test coverage at all before now;
- the layout menu never said the multi-repo workspace root stops being a repository;
- `private` meant licence posture *and* repository visibility in the same run, twenty lines apart —
  `proprietary` is now the licence word at every level including the internal token, with
  `--license=private` deprecated rather than refused so no wrapper breaks;
- the mono+team caveat fired only if the ADR authority was typed rather than passed, so of three
  identical projects one got the warning — as did the shared-remotes advice one line above it;
- `--adr-authority` on a solo project was accepted and dropped in silence;
- "use existing remote URLs" never said the repos must exist, be empty, and be reachable — except
  on the branch taken when `gh` is missing, where it always had.

Three of the six were closed by the user's judgment rather than built, and are recorded as such.

### A second review round, on transcripts rather than code

Every fix above added text the wizard prints, and no review had read that text as a sequence — a
code review cannot see ordering, volume, or two notes contradicting each other. So the last round
was run against five verbatim terminal transcripts of real runs, captured under a pty (bash's
`read -p` prints its prompt only to a terminal, so a piped run records every `echo` and not one
question).

It found a regression introduced by this very commit, and **no test could have**: the layout menu's
new line saying the workspace root is not a repository contradicted the closing line *"your project
is saved locally with Git"*, unconditionally printed a few screens later in the same run. Between a
warning and a reassurance a reader takes the reassurance, and here that is the wrong half. Fixed
per-layout, the treatment the `init.sh`-deletion note beside it already had; both halves now also
say the work was **committed**, which neither mentioned before.

The round's other ~17 findings are real, verified, and deliberately **not** built: they concern what
the wizard *teaches* and what its closing report *claims*, which is a different kind of work wanting
its own scope. They are written up in `.dev/repo-record.md` (gitignored) under *"What the wizard
says, not what it does"*, together with the three items recorded as closed so they are not
re-proposed — including one the round re-proposed after the user had already declined it.

**Three of my own assertions were wrong and mutation found them**, not the suite going green: one
read the whole log where it meant to read the note (so deleting the URL from the note changed
nothing), one had no run holding a note *off* the common path, and one used `grep -F` with a
pattern starting `--`, which grep reads as an option — it failed against a run that printed exactly
the right thing. A fourth mutation was itself invalid: deleting an `if` block left an `else`
holding only comments, so `init.sh` stopped parsing and the suite went red for a syntax error
rather than for coverage. It was redone as a no-op substitution.

Three assertions were rewritten during verification because a mutation showed they measured
nothing: two cases failed silently through errexit inside a subshell and now capture and name the
status, and the visibility assertion was masked by the public/proprietary warning until the case
switched to an open-source licence.

### Release notes

`CHANGELOG.md`'s wizard-answers entry claimed *"End of input still ends the run rather than
looping"* — true of `yesno` and `want`, false at every question going through `ask`. Building item
3 makes it true; the sentence is narrowed to what it actually covered and a new entry carries the
rest. The licence entry above it said the open-source sub-question *"keeps its MIT default"*,
which this removes — corrected in place rather than written up as a reversal, since no release
shipped the in-between state. No `UPDATING-THROUGHSTONE.md` entry: `init.sh` is one-time and refuses to run on an
initialized project, so no existing project is affected.

### Files

`init.sh`, `tests/init-license-validation.sh`, `tests/init-fresh-template-guard.sh` — the step's
file column — plus `CHANGELOG.md`, the one exception the step owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
