### PR TITLE
Say what the Throughstone notice covers, inside the notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,26 @@ any project built with it.
   row can name the procedure instead.
 
 ### Changed
+- **The Throughstone notice now says what it covers.** `LICENSE-THROUGHSTONE` was the scaffold's own
+  `LICENSE` under another name — 28 lines of BSD-3 and a copyright line, with the word "Throughstone"
+  appearing nowhere but the filename. The text inside says "THIS SOFTWARE IS PROVIDED BY THE
+  COPYRIGHT HOLDERS" and never says what "this software" is; sitting at the root of a repository, the
+  only available reading of that is the repository. A file whose entire job is to cover the method's
+  own material could therefore be read as licensing the project's — the opposite of its purpose, and
+  most misleading in exactly the case that matters most: a private codebase the method did not
+  create. The notice now opens with its scope. It states that it is **not** the repository's license,
+  that it covers Throughstone-authored material and nothing else, that everything else is licensed by
+  the repository's owners under their own terms — and that "this software" in the license below means
+  the Throughstone material. The BSD-3 text underneath is unchanged, and the rule for where the
+  notice goes is unchanged and unconditional: every repo in a Throughstone project gets it, whether
+  the method created the repo or adopted one that already existed.
+
+  It is also **a real file now**, shipped at `LICENSE-THROUGHSTONE` in the docs hub, instead of
+  something `init.sh` manufactured at bootstrap by renaming the scaffold's root `LICENSE`. That
+  rename is precisely why the notice could never carry a scope preamble: the same bytes are
+  Throughstone's own repository license, where an opening line saying "this is not this repository's
+  license" would be false. `init.sh` now drops the root `LICENSE` alongside the other template files
+  it removes, and copies the shipped notice as before.
 - **STEP-1 branches, and STEP projections, follow control rather than layout.** STEP-1 work takes the
   `step-0001-architecture` branch in **every** repository it writes into — previously the docs hub and
   `prompts/` in a multi-repo project, or the root repo in mono-repo-for-now, which left a repository

--- a/Code/{{PROJECT}}-docs/LICENSE-THROUGHSTONE
+++ b/Code/{{PROJECT}}-docs/LICENSE-THROUGHSTONE
@@ -1,0 +1,43 @@
+SCOPE — read this first.
+
+This file is NOT this repository's license, and it says nothing about the code in it.
+It covers one thing: material authored by the Throughstone method and left in this
+repository — documentation, templates, and configuration the method wrote, not this
+project's own work.
+
+Everything else in this repository is licensed by its owners under their own terms.
+Where they state those terms, that statement governs; the absence of one grants nothing.
+
+"This software" in the license below means the Throughstone-authored material, and
+nothing more.
+
+--------------------------------------------------------------------------------
+
+BSD 3-Clause License
+
+Copyright (c) 2026 Mark A. Herschberg
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -41,5 +41,7 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 > this repo's `LICENSE` is the canonical project-license file copied unchanged into each
 > application-code repo when it is created. `.throughstone/project-license` records the durable
 > selection independently, and the repo-scaffolding helper validates the two before copying.
-> A repo Throughstone creates also gets `LICENSE-THROUGHSTONE` for the scaffold README and CI
-> templates it keeps, plus a `LICENSING.md` making that notice's limited scope visible.
+> Every repo in the project gets `LICENSE-THROUGHSTONE` — one Throughstone created, or one that
+> already existed and was adopted. The notice opens by stating its own scope: it covers
+> Throughstone-authored material, and it is not the repository's license. A repo Throughstone
+> created also gets a `LICENSING.md` making the same boundary visible beside its project license.

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -121,6 +121,19 @@ pressing Enter through setup no longer licenses a project MIT without anyone nam
 project's posture was chosen when it was created and is recorded in `.throughstone/project-license`;
 it does not change. Worth knowing only if you bootstrap another project from muscle memory.
 
+**The Throughstone notice now states its scope, and refreshing yours is optional.**
+`LICENSE-THROUGHSTONE` used to be 28 lines of BSD-3 with no sentence saying what it applied to — its
+only scoping was the word in its filename, while the text inside referred to "this software" without
+ever defining it. At the root of a repository, that reads as the repository. It now opens by saying
+it is not the repository's license, that it covers Throughstone-authored material only, and that
+everything else is licensed by the repository's owners on their own terms. The BSD-3 text is
+unchanged, and so is the rule for where the notice goes: every repo in the project has one.
+
+The copies already in your repos are **stamped files — yours, per the bucket table above** — and
+nothing rewrites them. If you want the clearer wording, copy the 1.8
+`Code/<project>-docs/LICENSE-THROUGHSTONE` over each copy you hold; every copy is byte-identical to
+the docs hub's, so one file replaces them all. Nothing breaks if you leave them as they are.
+
 **The rule that went away.** The method used to say a mono-repo-for-now project had to split before
 taking on a second contributor. It gave two reasons and neither holds. The STEP-number push race
 works exactly the same in a mono repo with a shared remote — what a team needs is *shared* remotes,

--- a/init.sh
+++ b/init.sh
@@ -727,10 +727,11 @@ say "Detaching from the template's git history..."
 # only the user's initialized project state, not Throughstone's development history.
 rm -rf "$ROOT/.git"
 # The root LICENSE is the Throughstone scaffold's own license (BSD-3-Clause, © Mark A.
-# Herschberg), not the generated project's license. Retained scaffold material (METHOD.md,
-# templates/, runbooks/, scripts/) stays under it, and BSD-3 clause 1 requires preserving the
-# notice. Relocate it as LICENSE-THROUGHSTONE below; open-source projects get their selected
-# project LICENSE separately, while proprietary projects intentionally do not.
+# Herschberg) and covers the whole scaffold repository, so it must not travel into a generated
+# project where it would read as that project's license. Retained scaffold material (METHOD.md,
+# templates/, runbooks/, scripts/) still needs its notice, and BSD-3 clause 1 still requires
+# preserving it -- that job belongs to Code/<project>-docs/LICENSE-THROUGHSTONE, which ships as
+# its own file and opens by saying what it does and does not cover. Drop the root LICENSE here.
 #
 # README/CHANGELOG/TODO/ARTIFACT-TRAIL are Throughstone-template files: the front door, release
 # history, maintainer backlog, and public explanation of the scaffold's output. After bootstrap
@@ -738,6 +739,7 @@ rm -rf "$ROOT/.git"
 # workspace root. Drop them; generated-project context starts in the docs hub. Mono-repo projects
 # can add their own versions later.
 rm -f "$ROOT/README.md" "$ROOT/CHANGELOG.md" "$ROOT/TODO.md" "$ROOT/ARTIFACT-TRAIL.md"
+rm -f "$ROOT/LICENSE"
 # Community/health files describe the Throughstone template itself: contribution policy,
 # security contact, code of conduct, and trademark posture. Carrying them forward would leak the
 # template maintainer's contacts and assert Throughstone governance inside the user's project.
@@ -794,10 +796,10 @@ grep -rlF '{{TRUNK_BRANCH}}' . --exclude-dir=.git 2>/dev/null | while read -r f;
   TRUNK_BRANCH="$TRUNK_BRANCH" perl -pi -e 's/\Q{{TRUNK_BRANCH}}\E/$ENV{TRUNK_BRANCH}/g' "$f"
 done
 
-# Relocate the scaffold's BSD license into the docs hub (retained as attribution per BSD-3,
-# next to the method files it covers — not deleted). Open-source project licenses are stamped
-# separately into each repo in step 6; private projects get no project LICENSE.
-[ -f "$ROOT/LICENSE" ] && mv "$ROOT/LICENSE" "$DOCS/LICENSE-THROUGHSTONE"
+# The scaffold notice ships as Code/<project>-docs/LICENSE-THROUGHSTONE and is already in
+# place by now — it is a real file with its own scope preamble, not this root LICENSE renamed.
+# The root LICENSE is dropped with the other template files above. Open-source project licenses
+# are stamped separately into each repo in step 6; private projects get no project LICENSE.
 # LICENSE-THROUGHSTONE follows retained scaffold material. In multi-repo mode prompts/ is its
 # own repo and contains Throughstone-authored seed content, so retain the scaffold notice there
 # too; this is distinct from the project LICENSE stamped below for open-source projects. In


### PR DESCRIPTION
`LICENSE-THROUGHSTONE` never said what it covered.

It was the scaffold's own `LICENSE` under another name — 28 lines of BSD-3 and a copyright line, with the word "Throughstone" appearing nowhere but the filename. The text inside says *"THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS"* and never defines "this software". At the root of a repository, the only available reading of that is the repository. So a file whose entire job is to cover the method's own material could be read as licensing the project's — the opposite of its purpose, and most misleading in the case that matters most: a private codebase the method did not create, where this is the only license-shaped file present.

The scoping was being done by the filename. It now happens in the file.

## What changed

**The notice opens with its scope.** It states that it is not the repository's license, that it covers Throughstone-authored material and nothing else, that everything else is licensed by the repository's owners under their own terms, and that "this software" in the license below means the Throughstone material. The BSD-3 text underneath is untouched.

**The rule for where it goes is unchanged and stays unconditional.** Every repo in a Throughstone project gets one, whether the method created it or adopted a repo that already existed. There is no judgement about how much Throughstone-authored material is "enough" to earn a notice, and none should be added — a notice that states its own scope is safe wherever it lands.

**The notice is a real file now.** It shipped as nothing at all: `init.sh` manufactured it at bootstrap by renaming the scaffold's root `LICENSE`. That rename is exactly why it could never carry this preamble — the same bytes are Throughstone's own repository license, where "this is not this repository's license" would be false. It now ships at `Code/{{PROJECT}}-docs/LICENSE-THROUGHSTONE`, and `init.sh` drops the root `LICENSE` alongside the other template files it already removes rather than moving it.

Everything downstream reads the same docs-hub file it read before: the copies into `prompts/` and the mono root, and `apply-project-license.sh` in both its modes.

## Verification

`tests/init-license-validation.sh`, `init-fresh-template-guard.sh`, `init-mono-origin-reuse.sh`, `init-trunk-branch.sh`, `links.sh` and `session-template-contract.sh` all pass.

Bootstrapped four real projects from this tree and checked what came out:

| | root `LICENSE` | notice present | scoped |
|---|---|---|---|
| multi-repo, private | removed | docs hub + `prompts/` | yes |
| mono-repo, private | removed | docs hub + root | yes |
| multi-repo, MIT | removed | docs hub | yes |
| repo stamped by the helper | MIT `LICENSE` written | + `LICENSING.md` | yes |
| repo taking `--notice-only` | their `LICENSE` untouched | notice only | yes |

## Notes for the reviewer

`METHOD.md` still carries a sentence saying not to copy the notice into repos holding no Throughstone-authored material, which the unconditional rule above supersedes. It is deliberately **not** touched here: that file has been substantially rewritten on the base working branch, which already removes the sentence, so editing it here would create a merge conflict for no gain. Same reasoning for `runbooks/register-repo.md`.

The `CHANGELOG` `[Unreleased]` section and the migration guide's 1.8 notes are known to be mid-revision on a separate branch; this adds one entry to each and changes nothing else in them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
