### PR TITLE
Stop the next-action helper sending a finished STEP-1 back into architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,20 @@ any project built with it.
   creep back in.
 
 ### Fixed
+- **A project that has finished its architecture STEP is no longer sent back into it — forever.**
+  `./doctor.sh status` answers "what do I do next?" by walking `METHOD.md` §10's rules in order and
+  stopping at the first match. The rule about open STEP-1 substeps sat above the point where the
+  helper read the STEP-1 row's own status, so a STEP-1 marked `Done` over any session row still
+  `Planned` was reported as *"Architecture (STEP-1) in progress"* with the open session as the next
+  action. Because that rule stops the walk, this was not a wrong answer at one moment: it was the
+  answer from then on. A STEP `In progress` five STEPs later printed the identical line, and the
+  work actually in flight was invisible to the helper. The STEP-1 row now decides, in both
+  directions — the close-out rule already read it that way, since substeps all final under a row
+  that is still open means closing STEP-1 *is* the work, and this is the same rule facing the other
+  way: the row says architecture is over, so no open substep is resolvable and the rules below
+  answer instead. A baseline that closes STEP-1 without running every session is a legitimate
+  state, not a mistake to route back into. §10 said none of this and now says it, in the rule and
+  in the quick-resolver table above it.
 - **Two rules now say what they left to inference.** `runbooks/check-in.md` says to tell the agent
   *"run the check-in"*, while `METHOD.md` §10 says an in-progress STEP runs only the substep you
   ask for by name — and a check-in has two substeps. Nothing said whether that phrase authorised

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -691,7 +691,7 @@ Quick resolver:
 
 | First matching state in `prompts/STEP-index.md` | Next action |
 | --- | --- |
-| STEP-1 has an open design substep | Run the lowest-numbered open session |
+| STEP-1's own row is not `Done`, and it has an open design substep | Run the lowest-numbered open session |
 | STEP-1 design is done, Cross-Cutting Review open | Run Cross-Cutting Review |
 | STEP-1 complete and no implementation STEPs exist yet | Run the planning session |
 | Conditional-session follow-up STEP planned and none in progress | Plan that conditional follow-up, then wait for approval |
@@ -706,9 +706,15 @@ never in place of it. It never blocks work, and no rule below it is skipped beca
 due.
 
 
-1. **STEP-1 has a `Planned` / `In progress` substep?** → run the lowest-numbered open one
+1. **STEP-1's own row is not `Done`, and STEP-1 has a `Planned` / `In progress` substep?** →
+   run the lowest-numbered open one
    in a fresh chat using `Run STEP-1.N: <Session label from the index>`; the label is
-   optional but preferred because it gives the chat/task a clearer title. Skip any substep marked `N/A` or `Deferred`. A substep with a
+   optional but preferred because it gives the chat/task a clearer title. Skip any substep marked `N/A` or `Deferred`.
+   **The row is what says whether architecture is over.** Once STEP-1 reads `Done` an open substep
+   is no longer the next action, and the rules below answer instead: a baseline that closed STEP-1
+   without running every session is a legitimate state, not a mistake to route back into. The
+   mirror holds as well — substeps all final while the row is still open means the close-out is
+   the work (§5), not the planning session. A substep with a
    **letter suffix** (e.g. `1.6a`, `1.7a`) is a **conditional session** the kickoff slotted
    in — use `Run STEP-1.Xa: <Conditional session label>` plus the invocation **by name**
    (*"run the identity-auth session"* / *"run the native-app session"* / *"run the privacy

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -133,6 +133,22 @@ defaults to proprietary rather than open source, so pressing Enter through setup
 licenses a project MIT without anyone naming one. Your own posture was chosen when this project was
 created, is recorded in `.throughstone/project-license`, and does not change.
 
+**A finished STEP-1 is no longer sent back into architecture, and there is nothing for you to do.**
+`./doctor.sh status` walks `METHOD.md` §10's rules in order and stops at the first one that
+matches. The rule about open STEP-1 substeps sat above the point where the helper read the STEP-1
+row's own status, so a project whose STEP-1 row says `Done` while a session row is still `Planned`
+was told *"Architecture (STEP-1) in progress — run STEP-1.N"*. Because that rule stops the walk,
+the answer never changed again: a STEP `In progress` twenty STEPs later printed the same line, and
+the STEP actually in flight was invisible to the helper. **The row now decides.** Once STEP-1 reads
+`Done`, an open substep is no longer resolvable and the helper answers from the rules below it —
+the planning session, or whatever STEP your index says is next. The mirror case is unchanged:
+substeps all final while the row is still open still tells you to close STEP-1 out. Nothing of
+yours is rewritten, and no row needs renaming; if you flipped session rows to `Done` only to get a
+sensible answer out of the helper, you no longer need to. Optional sessions left `Deferred` are
+swept by the check-in either way — `runbooks/check-in.md`'s conditional-session coverage
+enumerates every conditional template and asks for a current disposition each time, without
+consulting the STEP-1 row.
+
 **`private` and `proprietary` now mean two different things, and if you script `init.sh` there is
 one rename.** `private` refers to repository visibility and nothing else; `proprietary` is the
 licence posture. They were the same word in two unrelated questions — the licence question offered

--- a/Code/{{PROJECT}}-docs/scripts/status.sh
+++ b/Code/{{PROJECT}}-docs/scripts/status.sh
@@ -195,14 +195,20 @@ all_final=0; [ "$nonfinal" -eq 0 ] && [ "$n_steps" -gt 0 ] && all_final=1
 
 # --- Resolve (METHOD.md §10, first match wins) --------------------------------
 # First-match precedence is intentional:
-# - open STEP-1 substeps come before implementation planning;
+# - open STEP-1 substeps come before implementation planning, but only while the STEP-1 row is
+#   itself open;
 # - active ordinary or conditional STEPs beat planned follow-up conditional STEPs;
 # - planned conditional follow-ups beat ordinary planned implementation STEPs.
 where=""; next=""
 if [ "$unknown_sub" -gt 0 ]; then
   where="Architecture (STEP-1) has ${unknown_sub} substep(s) with an unrecognized status."
   next="run ./doctor.sh check and fix any invalid STEP-1 substep statuses, then re-run ./doctor.sh status."
-elif [ -n "$lowsub" ]; then                                 # §10.1 / §10.2
+# Both substep arms are gated on the STEP-1 row: the row is what says whether architecture is
+# over, and it decides in both directions. The close-out arm below reads it from the other side —
+# substeps all final while the row is still open means the close-out is the work — so a Done
+# STEP-1 falls through to that same pair (METHOD.md §10, whose closing rule makes the index
+# authoritative for which STEP is next).
+elif [ -n "$lowsub" ] && [ "$step1_st" != "Done" ]; then    # §10.1 / §10.2
   where="Architecture (STEP-1) in progress — ${done_sub}/${total_sub} substeps complete."
   # Identify the Cross-Cutting Review by its Session-column label, not a hardcoded number.
   # Adding a standard session shifts the review. Check the lettered-conditional case
@@ -229,7 +235,9 @@ elif [ -n "$lowsub" ]; then                                 # §10.1 / §10.2
   else
     next="Run STEP-${lowsub}: ${lowsub_se}."
   fi
-elif [ "$total_sub" -gt 0 ] && [ "$done_sub" -lt "$total_sub" ]; then
+# Gated for the same reason, and the gate is load-bearing: this arm is otherwise unreachable, so
+# without it a Done STEP-1 with open substeps lands here and is told to fix statuses that are valid.
+elif [ "$total_sub" -gt 0 ] && [ "$done_sub" -lt "$total_sub" ] && [ "$step1_st" != "Done" ]; then
   where="Architecture (STEP-1) has ${done_sub}/${total_sub} substeps final, but no runnable open substep could be resolved."
   next="run ./doctor.sh check and fix any invalid STEP-1 substep statuses, then re-run ./doctor.sh status."
 elif [ "$have_impl" -eq 0 ]; then                           # §10.3 (or STEP-1 not yet run)

--- a/tests/status-step1-precedence.sh
+++ b/tests/status-step1-precedence.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for the STEP-1 row's authority over its own substeps in status.sh.
+#
+# METHOD.md §10 resolves the next action top-down and the first matching rule wins, with the
+# index authoritative for which STEP is next. The substep rules sit near the top of that walk,
+# so they have to be gated on the STEP-1 row: a STEP-1 marked Done over a still-open substep
+# used to report "Architecture (STEP-1) in progress" and send the reader back into an
+# architecture session, and — because that rule stops the walk — it kept reporting it for the
+# rest of the project's life, hiding whatever STEP was actually in flight.
+#
+# The two directions of the same disagreement are both asserted here. The row wins in each:
+# Done over an open substep means architecture is over, and an open row under substeps that are
+# all final means the close-out is the work.
+
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATUS="$ROOT/Code/{{PROJECT}}-docs/scripts/status.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-step1-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+index="$TMP_ROOT/STEP-index.md"
+
+# write_index STEP_ROWS SUB_ROWS — write the two tables the resolver reads. The substep table
+# needs its own header: the parser locates each table's columns from the header it finds, so a
+# substep row is only a substep row while a `Substep` header is in scope.
+write_index() {
+  {
+    printf '# Resolver fixture\n\n'
+    printf '| STEP | Title | Owner | Status | Repos (projection) | Scope (one line) |\n'
+    printf '|------|-------|-------|--------|--------------------|------------------|\n'
+    printf '%s\n\n' "$1"
+    printf '| Substep | Session | Status | Output doc |\n'
+    printf '|---------|---------|--------|------------|\n'
+    printf '%s\n' "$2"
+  } > "$index"
+}
+
+# run_status — point status.sh at the fixture index without touching scaffold docs.
+run_status() {
+  THROUGHSTONE_STEP_INDEX="$index" "$STATUS"
+}
+
+# assert_contains OUTPUT EXPECTED — preserve the relevant resolver sentence while allowing the
+# rest of the status report to evolve.
+assert_contains() {
+  local output="$1" expected="$2"
+  if ! printf '%s\n' "$output" | grep -Fq "$expected"; then
+    printf 'FAIL: expected status output to contain: %s\n' "$expected" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+}
+
+# assert_absent OUTPUT UNEXPECTED — the routed-backwards answers are what this file exists to
+# keep out, so they are asserted against directly rather than only implied by the right answer.
+assert_absent() {
+  local output="$1" unexpected="$2"
+  if printf '%s\n' "$output" | grep -Fq "$unexpected"; then
+    printf 'FAIL: expected status output NOT to contain: %s\n' "$unexpected" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+}
+
+open_substeps='| 1.1 | System Overview | Done | architecture/01-system-overview.md |
+| 1.7 | Data Model | Planned | architecture/07-data-model.md |'
+
+# A STEP-1 row marked Done closes architecture even with sessions left open — the state an
+# adopted codebase lands in, since its baseline closes STEP-1 without running every session.
+# The next action is the planning session, not the open substep.
+write_index \
+'| STEP-1 | Architecture | | Done | | Fixture |' \
+"$open_substeps"
+output="$(run_status)"
+assert_contains "$output" 'implementation not yet outlined.'
+assert_contains "$output" 'run the planning session'
+assert_absent "$output" 'Run STEP-1.7'
+assert_absent "$output" 'Architecture (STEP-1) in progress'
+
+# The same index once the project is building. This is the case that made the defect permanent
+# rather than momentary: the substep rule stops the walk, so the STEP in flight was never
+# reached and every later status call repeated the architecture answer.
+write_index \
+'| STEP-1 | Architecture | | Done | | Fixture |
+| STEP-5 | Build the thing | | In progress | | Fixture |' \
+"$open_substeps"
+output="$(run_status)"
+assert_contains "$output" 'Building — STEP-5 (Build the thing) is In progress.'
+assert_absent "$output" 'Run STEP-1.7'
+
+# Planned implementation work is likewise reachable underneath a Done STEP-1.
+write_index \
+'| STEP-1 | Architecture | | Done | | Fixture |
+| STEP-2 | Ordinary implementation | | Planned | | Fixture |' \
+"$open_substeps"
+output="$(run_status)"
+assert_contains "$output" 'next up is STEP-2 (Ordinary implementation).'
+assert_absent "$output" 'Run STEP-1.7'
+
+# Control: while the STEP-1 row is open, an open substep is still the next action. The gate must
+# not cost the rule it guards.
+write_index \
+'| STEP-1 | Architecture | | In progress | | Fixture |' \
+"$open_substeps"
+output="$(run_status)"
+assert_contains "$output" 'Architecture (STEP-1) in progress — 1/2 substeps complete.'
+assert_contains "$output" 'Run STEP-1.7: Data Model.'
+
+# Control, the mirror case: substeps all final under a row that is still open means the close-out
+# is the work. Both directions are the same rule — the row is what says whether STEP-1 is over.
+write_index \
+'| STEP-1 | Architecture | | In progress | | Fixture |' \
+'| 1.1 | System Overview | Done | architecture/01-system-overview.md |
+| 1.7 | Data Model | Done | architecture/07-data-model.md |'
+output="$(run_status)"
+assert_contains "$output" 'all 2 substeps are final, but the STEP-1 row is still "In progress".'
+assert_contains "$output" 'close out STEP-1'
+
+# Control: an unrecognized substep status is a data problem and outranks both, Done row or not.
+write_index \
+'| STEP-1 | Architecture | | Done | | Fixture |' \
+'| 1.1 | System Overview | Done | architecture/01-system-overview.md |
+| 1.7 | Data Model | Blocked | architecture/07-data-model.md |'
+output="$(run_status)"
+assert_contains "$output" 'substep(s) with an unrecognized status.'
+
+echo "status.sh STEP-1 row precedence: PASS"


### PR DESCRIPTION
## What was wrong

`./doctor.sh status` answers "what do I do next?" by walking `METHOD.md` §10's rules in order and stopping at the first match. The rule about open STEP-1 substeps sat above the point where the helper reads the STEP-1 row's own status, so a STEP-1 marked `Done` over any session row still `Planned` was reported as *"Architecture (STEP-1) in progress"*, with the open session as the next action.

Because that rule stops the walk, this was not a wrong answer at one moment. It was the answer from then on:

```
# STEP-1 Done, one session still Planned, no implementation STEPs yet
Where you are:  Architecture (STEP-1) in progress — 1/2 substeps complete.
Next action:    → Run STEP-1.7: Data Model.

# The same index, now with STEP-5 In progress
Where you are:  Architecture (STEP-1) in progress — 1/2 substeps complete.
Next action:    → Run STEP-1.7: Data Model.
```

Byte-identical — the STEP actually in flight was invisible to the helper.

## The fix

Both substep arms are now gated on the STEP-1 row's own status. The second gate is load-bearing rather than symmetry: that arm was unreachable (every substep is counted as final, open or unknown, and the unknown case is handled above it), so with only the first gate a `Done` STEP-1 with open substeps would land there and be told to go fix substep statuses that are perfectly valid.

The row decides in both directions. The close-out arm already read it that way — substeps all final under a row that is still open means closing STEP-1 *is* the work — and this is the same rule facing the other way, so a `Done` STEP-1 falls through to that same pair:

```
# STEP-1 Done, one session still Planned, no implementation STEPs yet
Where you are:  Architecture (STEP-1) complete (1/2 substeps); implementation not yet outlined.
Next action:    → run the planning session …

# The same index, now with STEP-5 In progress
Where you are:  Building — STEP-5 (Build the thing) is In progress.
```

A baseline that closes STEP-1 without running every session is a legitimate state, not a mistake to route back into. `METHOD.md` §10 stated none of this and now states it, in rule 1 and in the quick-resolver table above it.

## Files

| File | Change |
|---|---|
| `Code/{{PROJECT}}-docs/scripts/status.sh` | two conditions, plus the comment explaining why both are needed |
| `Code/{{PROJECT}}-docs/METHOD.md` | §10 rule 1 and the quick-resolver row gain the qualifier |
| `Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md` | one paragraph in the existing 1.8 migration section — nothing for an upgrading project to do |
| `CHANGELOG.md` | entry under `[Unreleased] → Fixed` |
| `tests/status-step1-precedence.sh` | new |

## Verification

- The new test covers both directions of the disagreement, the two controls it must not cost (an open row with an open substep; the mirror close-out case), and the unrecognised-status arm that outranks both. It was run against the unfixed script and **fails** there, so it is testing the fix rather than the fixture.
- The full suite was run locally the way CI runs it (`env -u CI` over `tests/*.sh`): **16 of 16 pass**, ~4½ minutes.

## Deliberately not changed

A STEP-1 row marked `Deferred` or `Abandoned` over open substeps still routes into architecture. That is the status quo, not a regression, and nobody defers STEP-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
