### PR TITLE
Let the Cross-Cutting Review settle a doc-versus-code conflict by reading the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,44 @@ any project built with it.
   reading a session file now finds the work list under one name instead of learning a per-file name.
   `METHOD.md` §4 records the skeleton as part of the contract for adding a session, and a new
   maintainer test enforces it.
+- **The Cross-Cutting Review now settles a doc-versus-code contradiction by reading the code, and
+  says which decisions may never get an ADR.**
+  `templates/architecture-sessions/14-cross-cutting-review.md` is the closing pass of the
+  architecture STEP: it reads everything the other thirteen sessions produced and checks it hangs
+  together. It was written for docs describing a system nobody has built yet, so on a project that
+  already has code — one brought into the method, or a repository registered in place — three of
+  its six checks had nothing to say about the one thing that can settle an argument. Three rules
+  close that, and none of them changes what the review does on a project with no code yet.
+
+  **Consistency (check 2)**: where code exists, a contradiction is settled by reading the code
+  rather than by re-deciding it — the code is authoritative for what the system *does*, the docs
+  for what it is *meant* to do. A doc that misread consistent code is an ordinary doc fix, with no
+  decision to take and no row to file. The two outcomes that leave a real gap behind — two
+  patterns genuinely both live in the code, or a doc states an intent the project never actually
+  decided on — each file a `registries/risks.yml` row, because the periodic check-in already
+  re-reads every open row and a gap left in a document nobody opens again only widens. One case
+  is deliberately carved out and sent to `runbooks/check-in.md` instead: where the doc records a
+  decision the project really took and the code has drifted from it, the code is the defect, and
+  rewriting the doc to match would bless the drift. The classification turns on what the doc
+  meant, which the doc often does not say, so **where you cannot tell, file the row**: an extra
+  row the next check-in closes costs little, and an intention deleted by a doc fix is not
+  recoverable. Being unsure what the *code* does is the opposite case — **re-read it before
+  filing a risk**, so the register never carries debt invented out of our own misreading.
+
+  **Foreclosure (check 4)**: the walk over the "Forecloses / tradeoff" entries is unchanged and
+  gains one forward question — does the architecture, as designed or as already built, support
+  what the Phasing & Roadmap doc commits to later, or is rework needed before that phase starts?
+
+  **Decision coverage (check 5)**: still write the ADRs that are missing, and a decision made
+  *during* the review is contemporaneous and gets an ordinary one. What is ruled out is
+  reconstructing history — a choice made before the project kept ADRs, whose reasons nobody
+  available knows, is recorded in the architecture doc and left there. An ADR is a dated record of
+  *why*, and a guessed rationale is worse than no ADR.
+
+  `METHOD.md` §3 moves with it. Architecture docs are the single source of truth for the
+  **intended** design; the sentence used to say "the current design", which read as though a doc
+  outranked the code on a question of fact, while `runbooks/check-in.md` has always reconciled the
+  two in both directions.
 - **`registries/` now ships with every project, and `--registries` is deprecated.** The flag pruned
   the directory in mono-repo layout, on the reasoning that one self-contained repo has no siblings
   to inventory. But `registries/` is not only `repos.yml`: pruning it also took `risks.yml`, the

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -78,8 +78,10 @@ Everything lives in the docs hub: `Code/{{PROJECT}}-docs/`.
 | **Architecture docs** | `architecture/NN-*.md` | *What is the system?* | Living. Versioned (see §6), maintained as reality changes. |
 | **ADRs** | `adr/ADR-NNNN-*.md` | *Why is it this way?* | Point-in-time. Never rewritten — superseded or amended. |
 
-- **Architecture docs** are the single source of truth for the current design. When
-  something changes, you update the doc and bump its version log.
+- **Architecture docs** are the single source of truth for the intended design. When
+  something changes, you update the doc and bump its version log. Where a doc and the code
+  disagree, the code is authoritative for what the system *does* and the doc for what it is
+  *meant* to do — reconcile the two rather than leaving them apart (`runbooks/check-in.md`).
 - **ADRs** capture a decision at the moment it's made — context, the choice, alternatives
   rejected, consequences. You don't edit an ADR's decision later; you write a new ADR that
   supersedes it, or append a dated amendment. There's an index at `adr/README.md`.

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -415,9 +415,9 @@ a literal `~` folder under the workspace root and report it as an ordinary clone
 `$HOME/lib` still makes a literal `$HOME` directory, and no guard can tell that from a directory
 somebody meant to call that.
 
-**Templates and guidance text, with nothing to undo.** Two edits to
-`templates/architecture-sessions/*.md` and four documentation fixes. None of them rewrites
-anything you already produced; they affect work you do after pulling them.
+**Templates and guidance text, with nothing to undo.** Three edits to
+`templates/architecture-sessions/*.md`, one to `METHOD.md` §3, and four documentation fixes. None
+of them rewrites anything you already produced; they affect work you do after pulling them.
 
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
   here to run this session…" and ends by releasing a reader who wasn't sent to run it. When you
@@ -431,6 +431,20 @@ anything you already produced; they affect work you do after pulling them.
   items are. If you have **customized session templates or added your own**, adopt the same heading so
   generic readers find your work list too — `METHOD.md` §4 documents the skeleton, and it is the only
   change you might want to make by hand.
+- **The Cross-Cutting Review reads the code when the docs disagree.** Session 1.14's consistency
+  check now says that where code exists, a contradiction between two architecture docs is settled
+  by reading the code rather than by re-deciding it, and that the two outcomes leaving a real gap
+  behind — two patterns genuinely both in the code, or a doc stating an intent the code
+  contradicts — each file a `registries/risks.yml` row, so every check-in re-reads them. The
+  foreclosure check keeps its walk and gains a forward question about the roadmap. Decision
+  coverage still asks for the ADRs that are missing, and now says a decision made *during* the
+  review is an ordinary ADR while a pre-method choice nobody can explain is recorded in the
+  architecture doc rather than given an invented rationale. `METHOD.md` §3 moves with it:
+  architecture docs are the single source of truth for the **intended** design, and where a doc
+  and the code disagree the code is authoritative for what the system does. Nothing to undo — this
+  changes reviews you run from now on. If you have **already run session 1.14** on a project that
+  has code, the three rules are worth one pass at your next check-in, which reconciles the docs
+  against the code anyway.
 - **Lifting a document into `architecture/` now names all three header fields.** `inputs/README.md`
   told you to add the `Version` / `Status` header and omitted the **Version Log**, which `check.sh`
   check 4 also requires of every numbered architecture doc — so a lifted spec could fail the check
@@ -455,7 +469,7 @@ anything you already produced; they affect work you do after pulling them.
   `runbooks/check-in.md` with the two files above; if a past check-in reported no deferred coverage,
   it is worth re-running the sweep once by hand.
 
-Pull `templates/architecture-sessions/*.md`, `METHOD.md` §4 and §6, `inputs/README.md`,
+Pull `templates/architecture-sessions/*.md`, `METHOD.md` §3, §4 and §6, `inputs/README.md`,
 `templates/architecture-doc-template.md`, and `runbooks/check-in.md` as a group. Nothing else in this group is affected: these files
 change no script behavior and touch no project state.
 

--- a/Code/{{PROJECT}}-docs/templates/architecture-sessions/14-cross-cutting-review.md
+++ b/Code/{{PROJECT}}-docs/templates/architecture-sessions/14-cross-cutting-review.md
@@ -71,14 +71,41 @@ between "we have a pile of docs" and "we have a coherent architecture."
    backup/RPO and availability target vs. the data model's loss-tolerance decisions;
    security boundaries vs. the actual component boundaries; terms used
    differently than the Glossary architecture doc defines them.
+
+   **Where code already exists, settle the conflict against the code rather than by re-deciding
+   it.** The code is authoritative for what the system *does*; the docs stay authoritative for
+   what it is *meant* to do. Read the code, then classify each conflict:
+   - **A doc got it wrong** — one doc misread code that is itself consistent. An ordinary doc
+     fix: no decision to take to the user, and no risk row, because nothing is left behind.
+   - **Both patterns really are in the code.** Record both, and file a `registries/risks.yml`
+     row with a revisit trigger so each check-in re-reads it. If the user decides now which one
+     the project converges on, write that decision up as an ADR.
+   - **Intent vs. reality** — a doc states a design the code contradicts. If the intent was
+     never a decision this project took, the architecture docs record what is built and the
+     intent becomes forward work, with a `registries/risks.yml` row so the gap is re-read at
+     each check-in rather than widening unwatched. If the doc records a decision the project
+     *did* take and the code drifted from it, the code is the defect — file a bug rather than
+     rewriting the doc to bless the drift (`runbooks/check-in.md`).
+
+   The classification turns on what the doc meant, which you often cannot tell from the doc
+   alone. Where you cannot, treat it as intent vs. reality and file the row: an extra row the
+   next check-in closes costs little, and an intention deleted by a doc fix is not recoverable.
+   Being unsure what the *code* does is the opposite case — re-read it before filing a risk, and
+   never record debt for our own misreading.
 3. **Completeness.** Is anything referenced but never specified? Any area that should have
    been covered for *this* project but wasn't? Any **Open Questions** still unresolved that
    would block implementation?
 4. **Foreclosure check.** Walk the "Forecloses / tradeoff" entries across all docs. Does any
    Phase-1 shortcut block a capability the Phasing & Roadmap architecture doc committed to a later phase? If so,
-   flag it — it may need a cheaper approach now.
+   flag it — it may need a cheaper approach now. Then ask the same question of the architecture
+   as a whole: does it, as designed or as already built, support what that doc commits to later,
+   or is rework needed before that phase starts? Record required rework as forward STEPs or risks.
 5. **Decision coverage.** Are the significant, contested, or deferred decisions recorded as
-   **ADRs**? Write any that are missing (`templates/adr-template.md`).
+   **ADRs**? Write any that are missing (`templates/adr-template.md`). A decision made *during*
+   this review is contemporaneous — it gets an ordinary ADR like any other. **What you must not
+   do is reconstruct history:** where a choice was made before the project kept ADRs and nobody
+   available knows why, record what was chosen in the architecture doc and leave it there. An
+   ADR is a dated record of *why*, and a guessed rationale is worse than no ADR at all.
 6. **Index accuracy.** Does `prompts/STEP-index.md` match what actually got produced
    (statuses, output docs)? And does `architecture/README.md`'s index list every
    architecture doc that exists (number, title, version, status)?
@@ -86,8 +113,8 @@ between "we have a pile of docs" and "we have a coherent architecture."
 ## Output
 - A **review summary** — write it to the STEP-1 folder
   (`Upcoming Prompts/{{PROJECT}}-STEP-1-REVIEW.md`): what was checked, findings, fixes
-  applied, the disposition of every discovered conditional-session template, and any
-  decisions still needed from the user.
+  applied, any `registries/risks.yml` rows filed, the disposition of every discovered
+  conditional-session template, and any decisions still needed from the user.
 - **Apply the fixes** to the affected architecture docs (bump their Version Logs); write any
   missing ADRs and add them to the `adr/README.md` registry.
 - **Populate `architecture/README.md`'s index** — one row per architecture doc produced


### PR DESCRIPTION
Three general rules into the Cross-Cutting Review — the closing pass of the architecture STEP,
which reads every architecture doc and ADR the other thirteen sessions produced and checks they
hang together. It was written for docs describing a system nobody has built yet, so on a project
that already has code, three of its six checks had nothing to say about the one thing that can
settle an argument. They ship ungated: a project designed from scratch can register a repository
that already exists, so this is not adoption-only.

- **Consistency (check 2)** — where code exists, settle a contradiction by reading the code
  rather than by re-deciding it. The code is authoritative for what the system *does*, the docs
  for what it is *meant* to do. A doc that misread consistent code is an ordinary fix. The two
  outcomes leaving a real gap behind file a `registries/risks.yml` row, so the periodic check-in
  re-reads them. Drift from a decision the project really took is carved out and routed to
  `runbooks/check-in.md` as a bug, so the rule never blesses drift.
- **Foreclosure (check 4)** — the walk is unchanged and gains one forward question about the
  roadmap. It keeps working on a project with no code.
- **Decision coverage (check 5)** — rewritten so it does not contradict itself: write the ADRs
  that are missing, a decision made *during* the review is an ordinary ADR, and what is ruled out
  is reconstructing a rationale nobody remembers.

`METHOD.md` §3 moves with it: architecture docs are the single source of truth for the
**intended** design, and where a doc and the code disagree the code is authoritative for what the
system does. Plus a `CHANGELOG.md` entry and an `UPDATING-THROUGHSTONE.md` bullet.

No new `## ` section — `tests/session-template-contract.sh` pins the heading sequence across all
17 session templates, so the new prose lives inside the existing numbered checks.

**Verification:** the 16-script suite the way CI runs it, green before the change and green after
(and green again after the two review fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
