### PR TITLE
Run an inherited codebase's tests before building on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,35 @@ any project built with it.
   `prompts/README.md` no longer describes a due Check-in STEP as something the resolver answers
   with. `tests/status-checkin-cadence.sh` now holds both halves of the contract, so a gate cannot
   creep back in.
+- **The planning session now asks whether it is planning against code somebody else wrote, and
+  runs that code's tests before anything is built on it.** Before it proposes the STEP sequence it
+  puts one question to you — *is any of the code this phase builds on code this project did not
+  write, that no check-in has yet run over?* — and if the answer is yes, it puts a check-in titled
+  `Check-in: baseline` at the front of the phase, whose job is `runbooks/check-in.md` run once,
+  end to end, both substeps. The runbook itself is unchanged, a failing inherited suite included.
+  Where the phase has a STEP that takes the repository on, the check-in follows that STEP rather
+  than preceding it — it has nothing to reconcile against until the repo is registered.
+
+  Nothing ran that suite before the project started building on top of it. STEP-1 writes documents
+  and runs nothing, which is correct when there is no code yet; but a project whose architecture
+  names a repository that already exists registers it where it sits rather than scaffolding into
+  it, and then finished STEP-1 holding a full set of architecture documents describing a baseline
+  **nobody had checked against a green build** — and started adding features on it. The periodic
+  check-in would have reached that suite eventually, twenty STEPs of new work later, with the
+  inherited baseline and everything built on top of it already mixed together.
+
+  **It asks instead of working the answer out.** The registry records how each repo arrived, and
+  reading that was the obvious implementation, but it is not readable at the moment the decision
+  has to be made: on the path where the planning session is what takes the repository on, the row
+  is written later, by the STEP this session is in the middle of outlining. A project can also be
+  set up around a codebase that was already there, and a repo can be taken on in a phase long
+  after the first. The person in the chair knows the answer in every case, so the session asks
+  them — nothing reads how a repo arrived, and that rule is unchanged.
+
+  **The question carries its own stop**, which is why there is no second rule to keep in step with
+  it: it asks about code no check-in has run over yet, so a project re-planning a later phase does
+  not spend a whole STEP re-baselining code the cadence has already swept, and a repository taken
+  on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
 - **A project that has finished its architecture STEP is no longer sent back into it — forever.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,8 +317,8 @@ any project built with it.
   write, that no check-in has yet run over?* — and if the answer is yes, it puts a check-in titled
   `Check-in: baseline` at the front of the phase, whose job is `runbooks/check-in.md` run once,
   end to end, both substeps. The runbook itself is unchanged, a failing inherited suite included.
-  Where the phase has a STEP that takes the repository on, the check-in follows that STEP rather
-  than preceding it — it has nothing to reconcile against until the repo is registered.
+  It goes ahead of the scaffold STEP, so the suite is measured on the code as you took it on,
+  before the method has written a README section or a licence notice into it.
 
   Nothing ran that suite before the project started building on top of it. STEP-1 writes documents
   and runs nothing, which is correct when there is no code yet; but a project whose architecture

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -416,7 +416,8 @@ a literal `~` folder under the workspace root and report it as an ordinary clone
 somebody meant to call that.
 
 **Templates and guidance text, with nothing to undo.** Three edits to
-`templates/architecture-sessions/*.md`, one to `METHOD.md` §3, and four documentation fixes. None
+`templates/architecture-sessions/*.md`, one to `METHOD.md` §3, one to
+`templates/planning-session.md`, and four documentation fixes. None
 of them rewrites anything you already produced; they affect work you do after pulling them.
 
 - **The go-ahead is now conditional.** Each session file's closing paragraph opens "If you were sent
@@ -445,6 +446,18 @@ of them rewrites anything you already produced; they affect work you do after pu
   changes reviews you run from now on. If you have **already run session 1.14** on a project that
   has code, the three rules are worth one pass at your next check-in, which reconciles the docs
   against the code anyway.
+- **The planning session asks whether you are building on somebody else's code.** Before it
+  proposes the STEP list it puts one question to you — is any of the code this phase builds on
+  code this project did not write, that no check-in has yet run over? — and if you say yes, it
+  puts a check-in titled `Check-in: baseline` at the front of the phase, running
+  `runbooks/check-in.md` end to end, both substeps. That is the **first** point in the method
+  where a codebase you took on gets its tests run: the architecture STEP writes documents and
+  runs nothing, so until then nothing had. The runbook is unchanged. Nothing to undo — this
+  changes planning sessions you run from now on. **On an existing project**, answer the question
+  the way it is written: if a check-in has already swept that code, say so and no baseline is
+  added; if it genuinely has never been run, you get one. Either way it is the same runbook, so a
+  deliberate check-in at your next sensible breakpoint does the same work if you would rather not
+  wait for the next planning run.
 - **Lifting a document into `architecture/` now names all three header fields.** `inputs/README.md`
   told you to add the `Version` / `Status` header and omitted the **Version Log**, which `check.sh`
   check 4 also requires of every numbered architecture doc — so a lifted spec could fail the check
@@ -470,7 +483,8 @@ of them rewrites anything you already produced; they affect work you do after pu
   it is worth re-running the sweep once by hand.
 
 Pull `templates/architecture-sessions/*.md`, `METHOD.md` §3, §4 and §6, `inputs/README.md`,
-`templates/architecture-doc-template.md`, and `runbooks/check-in.md` as a group. Nothing else in this group is affected: these files
+`templates/architecture-doc-template.md`, `templates/planning-session.md`, and
+`runbooks/check-in.md` as a group. Nothing else in this group is affected: these files
 change no script behavior and touch no project state.
 
 
@@ -583,7 +597,7 @@ apply each area as a coherent review-required group, as with the legacy migratio
 **Milestone-relative planning STEP-shape.**
 
 - *Process docs* (`templates/planning-session.md`): the implementation planning session's STEP
-  sequence (work-item 2, plus work-item 1's "first STEP is scaffold" line) is now milestone-relative —
+  sequence work-item, plus the repo-scaffolding work-item's "first STEP is scaffold" line, is now milestone-relative —
   build or extend what the milestone needs, in dependency order, given what already exists, with the
   scaffold → data → capabilities → integration shape kept as the worked example for a first run. Adopt
   the reworded work-items. No `status.sh` / `check.sh` change.

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -86,7 +86,7 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    **No — create it.** The usual case on a first run. **If the path already holds files this
    project did not put there, stop and settle that with the user rather than scaffolding into
    it.** Otherwise the first implementation STEP is almost always *"scaffold the repos and the
-   skeleton"*: create each new code repo from
+   skeleton"* — unless item 2 puts a baseline check-in ahead of it: create each new code repo from
    `templates/repo-readme-template.md`, wire up the chosen stack, CI, and the environment/secrets
    baseline from the Environments architecture doc, plus any interface contract artifact placeholders or repo-local contract files
    named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each repo as its
@@ -122,10 +122,29 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    scaffolding STEP to inherit the work.
    Confirm the repo list with the user: which are new, which already exist, and name any you
    could not reach.
-2. **The implementation STEP sequence.** Propose all the target phase's STEPs in dependency order —
-   **build or extend what this milestone needs, given what already exists.** On a first run
-   nothing is built yet, so scaffolding and the core data layer come first and you build
-   outward from there; that's the usual case, and the typical shape is:
+2. **Inherited code.** Item 1 has established which repos already existed. Settle the part it does
+   not answer, by asking rather than working it out: **is any of the code this phase builds on
+   code this project did not write, that no check-in has yet run over?** The user knows — whether
+   a repo was taken on rather than created, whether the project was set up around a codebase that
+   was already there, and what has been run over it since. Don't reach for
+   `registries/repos.yml` to answer it; how a repo arrived is not what decides this, and on the
+   path where this session is what takes a repo on, nothing has been recorded yet anyway. On an
+   ordinary first run nothing is built and the answer is no; ask anyway.
+
+   **If the answer is yes, that code gets a baseline check-in before anything is built on it.**
+   STEP-1 writes documents and runs nothing, so the architecture describes a baseline nobody has
+   checked. Title the row `Check-in: baseline` — the `Check-in` prefix per item 4 — and give it
+   the ordinary job: `runbooks/check-in.md`, once, end to end, **both** substeps. Nothing about
+   that runbook changes here, a failing inherited suite included.
+
+   Place it at the front of this phase's STEPs, **except that it follows the STEP that takes the
+   inherited repo on**, where this phase has one — the check-in reconciles documents against a
+   repo the project has registered, so it cannot usefully run before that has happened.
+3. **The implementation STEP sequence.** Propose all the target phase's STEPs in dependency order —
+   **build or extend what this milestone needs, given what already exists.** On an ordinary first
+   run nothing is built yet, so scaffolding and the core data layer come first and you build
+   outward from there; that's the usual case, and the typical shape is (item 2's baseline
+   check-in, where there is one, slots in at the front):
    - **Scaffold** — repos, skeleton, CI, local run + the env/secrets baseline.
    - **Core data layer** — the data model from `architecture/*-data-model.md` made real (schema,
      migrations, access layer).
@@ -133,11 +152,12 @@ STEP's PLAN with its owner rather than silently replacing its index row.
      against the data layer and component boundaries.
    - **Integration / end-to-end** — wire the capabilities together; the launch-criteria
      path from the phase plan works end to end.
-   On a **re-run**, or a later phase whose scaffold and core data layer already exist, start
+   On a **re-run**, a later phase whose scaffold and core data layer already exist, or a first run
+   against a codebase that was already there, start
    from what's built and plan the STEPs that **extend** it, rather than re-scaffolding or
    rebuilding what's already there. Adjust to the actual project. Each STEP gets a
    global STEP number (continuing from STEP-1).
-3. **Interleave check-in STEPs.** About **every 20 STEPs** (the project's cadence, adjustable), add a **Check-in STEP**
+4. **Interleave check-in STEPs.** About **every 20 STEPs** (the project's cadence, adjustable), add a **Check-in STEP**
    that runs `runbooks/check-in.md` (doc-drift reconciliation, conditional-session coverage,
    accepted-risk review, and a full test run). Place each at a sensible breakpoint — after a
    capability lands, not mid-feature — rather than mechanically on a fixed count. Title each
@@ -145,7 +165,7 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    it — `METHOD.md` §5. For a
    target phase with only a handful of STEPs, one check-in near the end (or none) is fine; use
    judgment.
-4. **Outline each STEP — briefly.** For each STEP (including the check-ins), a short outline:
+5. **Outline each STEP — briefly.** For each STEP (including the check-ins), a short outline:
    what it delivers and how it depends on the others. Roughly **2–3 sentences each** — a
    guideline, not a rule. Don't write the detailed plan, the substeps, or the definition of
    done here; those come when the STEP is started.

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -137,9 +137,8 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    the ordinary job: `runbooks/check-in.md`, once, end to end, **both** substeps. Nothing about
    that runbook changes here, a failing inherited suite included.
 
-   Place it at the front of this phase's STEPs, **except that it follows the STEP that takes the
-   inherited repo on**, where this phase has one — the check-in reconciles documents against a
-   repo the project has registered, so it cannot usefully run before that has happened.
+   Place it at the **front** of this phase's STEPs — ahead of the scaffold STEP, so the suite is
+   measured on the code as you took it on, before this project has written anything into it.
 3. **The implementation STEP sequence.** Propose all the target phase's STEPs in dependency order —
    **build or extend what this milestone needs, given what already exists.** On an ordinary first
    run nothing is built yet, so scaffolding and the core data layer come first and you build

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -86,7 +86,8 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    **No — create it.** The usual case on a first run. **If the path already holds files this
    project did not put there, stop and settle that with the user rather than scaffolding into
    it.** Otherwise the first implementation STEP is almost always *"scaffold the repos and the
-   skeleton"* — unless item 2 puts a baseline check-in ahead of it: create each new code repo from
+   skeleton"*. Where **Inherited code** below has put a baseline check-in ahead of it, that
+   check-in goes first and this STEP follows it. Scaffolding means: create each new code repo from
    `templates/repo-readme-template.md`, wire up the chosen stack, CI, and the environment/secrets
    baseline from the Environments architecture doc, plus any interface contract artifact placeholders or repo-local contract files
    named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each repo as its
@@ -133,17 +134,17 @@ STEP's PLAN with its owner rather than silently replacing its index row.
 
    **If the answer is yes, that code gets a baseline check-in before anything is built on it.**
    STEP-1 writes documents and runs nothing, so the architecture describes a baseline nobody has
-   checked. Title the row `Check-in: baseline` — the `Check-in` prefix per item 4 — and give it
-   the ordinary job: `runbooks/check-in.md`, once, end to end, **both** substeps. Nothing about
-   that runbook changes here, a failing inherited suite included.
+   checked. Title the row `Check-in: baseline` — the same `Check-in` prefix the periodic check-ins
+   below use — and give it the ordinary job: `runbooks/check-in.md`, once, end to end, **both**
+   substeps. Nothing about that runbook changes here, a failing inherited suite included.
 
    Place it at the **front** of this phase's STEPs — ahead of the scaffold STEP, so the suite is
    measured on the code as you took it on, before this project has written anything into it.
 3. **The implementation STEP sequence.** Propose all the target phase's STEPs in dependency order —
    **build or extend what this milestone needs, given what already exists.** On an ordinary first
    run nothing is built yet, so scaffolding and the core data layer come first and you build
-   outward from there; that's the usual case, and the typical shape is (item 2's baseline
-   check-in, where there is one, slots in at the front):
+   outward from there; that's the usual case, and the typical shape is (a baseline check-in from
+   **Inherited code**, where there is one, slots in at the front):
    - **Scaffold** — repos, skeleton, CI, local run + the env/secrets baseline.
    - **Core data layer** — the data model from `architecture/*-data-model.md` made real (schema,
      migrations, access layer).


### PR DESCRIPTION
## What this changes

The architecture STEP writes documents and runs nothing. That is right when there is no code yet — but a project whose architecture names a repository that **already exists** registers it where it sits rather than scaffolding into it, and then finished its architecture holding a full set of documents describing a baseline **nobody had checked against a green build**, and started adding features on it.

The implementation planning session now asks, before it proposes the STEP sequence:

> is any of the code this phase builds on code this project did not write, that no check-in has yet run over?

If yes, it puts a check-in titled `Check-in: baseline` at the front of the phase — `runbooks/check-in.md`, once, end to end, both substeps. That runbook is **not touched by this PR**.

Where the phase has a STEP that takes the repository on, the check-in follows that STEP rather than preceding it: it has nothing to reconcile against until the repo is registered.

## Why it asks rather than works it out

Reading the registry's record of how each repo arrived was the obvious implementation and it does not work. On the path where the planning session is itself what takes the repository on, that row is written later — by the STEP this session is in the middle of outlining — so nothing is recorded at the moment the decision has to be made. A project can also be set up around a codebase that was already there. The rule that nothing decides from how a repo arrived is unchanged.

The question also carries its own stop, so there is no second rule to keep in step with it: it asks about code *no check-in has run over yet*, which both prevents re-baselining on a later phase and still catches a repository taken on in phase 3.

## Files

| File | Change |
|---|---|
| `templates/planning-session.md` | New work-item 2, *Inherited code*; list renumbered 2→3, 3→4, 4→5; three small consistency fixes in the neighbouring items |
| `CHANGELOG.md` | Entry under `[Unreleased]` → `### Changed` |
| `UPDATING-THROUGHSTONE.md` | Bullet in the templates/guidance subsection, its counting sentence, its pull-as-a-group list, and one positional cross-reference made name-based so it survives the renumbering |

## Verification

- Full local suite green before and after: **16/16**.
- One review round (fresh-reader contradiction check) found a blocking defect in the first draft and it is fixed here: the draft gated the check-in on whether the roadmap already held *any* check-in row. That fired on a `Planned` row that had never run, and suppressed the baseline for a repository taken on in a later phase because an unrelated earlier check-in sat in the index — the exact hole this closes, left open on every phase after the first. Folding the condition into the question removed the second rule, and with it a third independently-worded copy of what counts as a check-in row.
- The same round corrected two overclaims in the prose: a periodic check-in *does* eventually run an inherited suite, so this is the **first** point the method runs it, not the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
