### PR TITLE
Point the check-in cadence at the project's own setting

### DIFF
--- a/ARTIFACT-TRAIL.md
+++ b/ARTIFACT-TRAIL.md
@@ -180,9 +180,10 @@ and
 
 ## 6. Check-In Reports
 
-Every 10-20 STEPs, a check-in STEP runs a deliberate sweep. It compares architecture docs
-against code in both directions, re-evaluates conditional architecture sessions, reviews
-accepted risks and debt, and runs the full test suite.
+About every N STEPs — where N is the project's check-in cadence, the `CHECK-IN-CADENCE`
+value in `Code/<project>-docs/overview.md`, recommended 20 — a check-in STEP runs a deliberate
+sweep. It compares architecture docs against code in both directions, re-evaluates conditional
+architecture sessions, reviews accepted risks and debt, and runs the full test suite.
 
 Completed check-in reports live directly under `Code/<project>-docs/reports/`. The STEP folder
 in `prompts/` keeps the thin PLAN and any execution notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,22 @@ any project built with it.
   ordinary forward work, and only a genuinely risky shortfall becomes a `registries/risks.yml` row.
 
 ### Changed
+- **Five documents said how often to run a check-in; the project's own setting says it.** The
+  cadence has been a per-project setting since 1.7 — `<!-- CHECK-IN-CADENCE: N -->` in
+  `overview.md`, read by `scripts/status.sh`, which flags a heads-up 5 STEPs before the target and
+  overdue 5 after — but six passages across five shipped documents still stated a bare number
+  instead of naming it. A project that set its cadence to 10 was told 10 by the helper and 20 by
+  every document its agent planned from, and nothing detected the disagreement. `ARTIFACT-TRAIL.md` was worse than the
+  others: it said *"Every 10-20 STEPs"*, a third figure matching neither the default nor the window
+  the helper reports. All six now name the setting and give **20** as the recommended starting
+  point, so a reader with no project in front of them still has a number: `ARTIFACT-TRAIL.md`
+  §6, `AGENTS.md`'s check-in rule, `METHOD.md` §5's opening sentence and §10 rule 7,
+  `templates/planning-session.md`'s *Interleave check-in STEPs* item, and
+  `runbooks/check-in.md`'s "How to run" note. **The hedge is deliberate and survives every one of
+  them**: the cadence advises and never gates (§10 rule 7), so *about* every N STEPs is the
+  meaning, and a sentence that read as a hard trigger would be a regression even with the right
+  number. Nothing else changes — no new field, no new check, and `status.sh`'s own behaviour and
+  its fallback to 20 are untouched.
 - **STEP-1 takes the same branch in every repository it writes into.** STEP-1 work takes the
   `step-0001-architecture` branch in **every** repository it writes into — previously the docs hub
   and `prompts/` in a multi-repo project, or the root repo in mono-repo-for-now, which left a

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -197,7 +197,8 @@ durable content almost always belongs in `Code/{{PROJECT}}-docs/`.
 - **Document code as you write it.** Every class, function, and method gets a docstring;
   comment the *why* of non-obvious logic (see
   `Code/{{PROJECT}}-docs/coding-standards/README.md`).
-- **Suggest a check-in about every 20 STEPs (the project's cadence, adjustable).** When about that
+- **Suggest a check-in on the project's cadence** — the `CHECK-IN-CADENCE` value in
+  `Code/{{PROJECT}}-docs/overview.md`, recommended **20**. When about that
   many STEPs have passed since the last check-in, proactively propose inserting a **Check-in STEP** that runs
   `Code/{{PROJECT}}-docs/runbooks/check-in.md` (doc-drift reconciliation both ways,
   conditional-session coverage, accepted-risk review, and a full test run). See `Code/{{PROJECT}}-docs/METHOD.md`

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -388,8 +388,9 @@ dedicated final verification substep; choose deliberately in the PLAN. A code-ch
 without tests needs a stated reason, not silence.
 
 ### Check-in STEPs
-About **every 20 STEPs** (the project's cadence, adjustable), the roadmap includes a **Check-in STEP** — a full STEP whose
-job is to run `runbooks/check-in.md`: reconcile the architecture docs against the code in
+About every **N** STEPs (where **N** is the project's check-in cadence — the `CHECK-IN-CADENCE`
+value in `overview.md`, recommended **20**), the roadmap includes a **Check-in STEP** — a full STEP
+whose job is to run `runbooks/check-in.md`: reconcile the architecture docs against the code in
 **both directions** (stale doc → fix the doc/write an ADR; code drifted from a still-correct
 doc → file a bug), re-evaluate every available conditional architecture session, review the
 accepted risks/debt in `registries/risks.yml`, and **run the full test suite**. The
@@ -743,7 +744,8 @@ due.
    then archive it (§5) and mark it `Done`. **A Check-in STEP is the exception**: its two substeps
    are fixed and `runbooks/check-in.md` is their prompt, so *"run the check-in"* runs both, end to
    end. Nothing else is invoked whole.
-7. **~20 STEPs (the project's cadence) since the last check-in?** → **propose** a **Check-in
+7. **About N STEPs since the last check-in, where N is the project's check-in cadence (the
+   `CHECK-IN-CADENCE` value in `overview.md`, recommended 20)?** → **propose** a **Check-in
    STEP** at the next sensible breakpoint (§5; `runbooks/check-in.md`) — and then go on with
    whatever the rules above answered. **This rule never becomes the next action**, and it is
    deliberately not a gate: the check-in belongs at a breakpoint, and a rule that fired the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -499,6 +499,21 @@ root. `AGENTS.md` described that same old order and is corrected too — it is a
 process-docs group above, so pulling that group picks it up. Review the three like the other
 process docs; nothing of yours is rewritten.
 
+**If you changed your check-in cadence, the docs now agree with you.** The cadence has been a
+per-project setting since 1.7 — `<!-- CHECK-IN-CADENCE: N -->` in your `overview.md`, read by
+`scripts/status.sh` — but five passages in the documents your agent plans from still stated a
+bare **20** rather than naming the setting, so a project that set 10 was told 10 by the helper and
+20 by the docs. They now name the setting and give 20 as the recommendation: `METHOD.md` §5's opening
+sentence and §10 rule 7, `AGENTS.md`'s check-in rule, `templates/planning-session.md`'s
+*Interleave check-in STEPs* item, and `runbooks/check-in.md`'s "How to run" note. **All four
+files are already in the process-docs group at step 1 of the fast path** — pull that group and you
+have this. **Nothing of yours is rewritten and no behaviour changes**: `status.sh` read your setting
+before this release and reads it the same way now, its fallback to 20 when the line is absent is
+unchanged, and the check-in remains a proposal rather than a gate. If you are still on the
+default there is nothing to notice; if you are not, the prose stops contradicting your
+`overview.md`. Worth one look while you are there: if your `overview.md` predates the marker
+entirely, add the line so the number you want is the number the helper uses.
+
 **One thing this guide does not do for you.** `adr/README.md` is *Project state* under §2 —
 never auto-updated — so the ADR duplicate-number scan fixed in this release stays broken in your
 copy until you carry the fix across by hand. Open your `adr/README.md`, find the scan command, and

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -1,7 +1,8 @@
 # Runbook — Periodic Check-In
 
-> **How to run:** A check-in is its own **STEP** (see `METHOD.md` §5). About **every
-> 20 STEPs** (the project's cadence, adjustable) the roadmap should include a *Check-in STEP* whose job is to run this
+> **How to run:** A check-in is its own **STEP** (see `METHOD.md` §5). About every **N**
+> STEPs — where **N** is the project's check-in cadence, the `CHECK-IN-CADENCE` value in
+> `overview.md`, recommended **20** — the roadmap should include a *Check-in STEP* whose job is to run this
 > runbook — the agent proposes one at a sensible breakpoint (e.g. after a capability lands,
 > not mid-feature). When you run that STEP, tell the agent *"run the check-in"* and it
 > follows this file **end to end** — both substeps, in one go. That is a **deliberate exception**

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -157,7 +157,8 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    from what's built and plan the STEPs that **extend** it, rather than re-scaffolding or
    rebuilding what's already there. Adjust to the actual project. Each STEP gets a
    global STEP number (continuing from STEP-1).
-4. **Interleave check-in STEPs.** About **every 20 STEPs** (the project's cadence, adjustable), add a **Check-in STEP**
+4. **Interleave check-in STEPs.** About every **N** STEPs (where **N** is the project's check-in
+   cadence — the `CHECK-IN-CADENCE` value in `overview.md`, recommended **20**), add a **Check-in STEP**
    that runs `runbooks/check-in.md` (doc-drift reconciliation, conditional-session coverage,
    accepted-risk review, and a full test run). Place each at a sensible breakpoint — after a
    capability lands, not mid-feature — rather than mechanically on a fixed count. Title each


### PR DESCRIPTION
## The problem

The check-in cadence is a per-project setting and has been since 1.7:
`<!-- CHECK-IN-CADENCE: N -->` in `overview.md`, read by `scripts/status.sh`, which flags a
heads-up 5 STEPs before the target and overdue 5 after.

Six passages across five shipped documents stated a bare number instead of naming that setting.
So a project that set its cadence to 10 was told **10 by the helper and 20 by every document its
agent planned from**, and nothing detected the disagreement.

`ARTIFACT-TRAIL.md` was the worst of them: *"Every 10-20 STEPs"* is a third figure, matching
neither the default nor the window the helper actually reports, and it was the only site carrying
no hedge at all.

## The fix

Six one-clause edits. Each names the setting **and** keeps 20 as the stated default, so a reader
with no project in front of them still has a recommended starting point.

| Site | Was |
|---|---|
| `ARTIFACT-TRAIL.md` §6 | "Every 10-20 STEPs" |
| `AGENTS.md`'s check-in rule | "about every 20 STEPs (the project's cadence, adjustable)" |
| `METHOD.md` §5's opening sentence | same, and contradicted by its own body twelve lines below |
| `METHOD.md` §10 rule 7 | "~20 STEPs (the project's cadence)" |
| `templates/planning-session.md`, *Interleave check-in STEPs* | "About every 20 STEPs" |
| `runbooks/check-in.md`'s "How to run" note | same, split across a line break and a `>` marker |

Plus a `CHANGELOG` entry and an `UPDATING` bullet.

**The hedge is deliberate and survives every edit.** The cadence advises and never gates (§10
rule 7), so *about* every N STEPs is the meaning; a sentence that read as a hard trigger would be
a regression even with the right number.

## What is deliberately untouched

- `status.sh`'s behaviour and printed strings, and its fallback to 20.
- `METHOD.md` §5's **body** sentence — `tests/doc-contract.sh` rebuilds it character for character
  from `status.sh`'s own cadence/due/over values.
- `check.sh`'s cadence-marker messages: they describe that fallback, which stays 20, and are true.
- `templates/overview-template.md`'s marker line.
- Past `CHANGELOG`/`UPDATING` entries quoting the old wording — dated record.
- `brand/site/index.html` and `docs/index.html`: they already say "On a cadence you set", and
  `docs/` is the live public site.

No new field, no new check, no script change, no section renumbering.

## Verification

- Full suite green locally on the final tree: **16/16**, each script printing its own PASS.
- The `check-in.md` site is invisible to a plain grep — the phrase straddles a line break *and* a
  blockquote marker — so it was confirmed by flattening first:
  `tr -s ' \t\n>' ' ' < runbooks/check-in.md | grep -o 'About .*'`
- A flattened sweep over every tracked `.md` finds no bare cadence literal left in live prose. The
  only two remaining hits are dated record: the 1.7 migration note, and this PR's own CHANGELOG
  entry quoting the old `ARTIFACT-TRAIL.md` text.
- `ARTIFACT-TRAIL.md` is scaffold-only (`init.sh` deletes it from a generated project), which is
  why the `UPDATING` entry names only the four docs-hub files an upgrader actually has — all
  already in the 1.8 fast path's process-docs group.

## Note for the forward merge

Base line only. `origin/retcon` is byte-identical to the merge-base at all six sites (verified by
content, not line number), so this merges forward without a conflict. A parallel edit on `retcon`
would have turned every one of them into a two-sided conflict — and its `planning-session.md`
numbers that work item 3 rather than 4, so the cross-references here cite it by title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
