### PR TITLE
Guard the six documents that say how often to run a check-in

### DIFF
--- a/tests/doc-contract.sh
+++ b/tests/doc-contract.sh
@@ -209,6 +209,29 @@ cad_line="$(grep -F 'CHECK-IN-CADENCE:' "$OVERVIEW_TPL" | head -1 || true)"
 [ -n "$cad_line" ] || fail "templates/overview-template.md no longer seeds a CHECK-IN-CADENCE marker"
 printf '%s\n' "$cad_line" | grep -qE "$cad_re" || fail "the CHECK-IN-CADENCE marker seeded in templates/overview-template.md is not one status.sh can read: $cad_line"
 
+# The cadence is a per-project setting, and five documents tell an author how often to run a
+# check-in. Each must point at the setting rather than restate a number: a project that changes
+# its cadence is otherwise told one figure by status.sh and another by every document its agent
+# plans from, and nothing else detects the disagreement. These files carried a bare 20 (and, in
+# ARTIFACT-TRAIL.md, a bare "10-20") until the wording was fixed; no other check covers them.
+#
+# The second assertion pins the literal that actually drifted rather than every possible number,
+# because METHOD.md legitimately says "heads-up 5 STEPs before" in the sentence checked above.
+# It earns its place: reverting METHOD.md's wording leaves CHECK-IN-CADENCE in the section body,
+# so the first assertion alone passes on a file that has regressed. It flattens '>' as well as
+# whitespace because check-in.md's phrase straddles a line break inside a blockquote; today the
+# marker falls before the number so plain whitespace flattening would also match, but where the
+# line wraps is not a property anyone maintains.
+for f in "$METHOD" "$AGENTS" "$CHECKIN" "$DOCS/templates/planning-session.md" "$ROOT/ARTIFACT-TRAIL.md"; do
+  rel="${f#"$ROOT/"}"
+  [ -f "$f" ] || fail "$rel is missing; the check-in cadence wording cannot be checked"
+  contains "$f" 'CHECK-IN-CADENCE' \
+    || fail "$rel tells an author how often to run a check-in without naming the CHECK-IN-CADENCE setting, so a project that changed its cadence would be told a different number here than status.sh reports"
+  case "$(tr -s ' \t\n>' ' ' < "$f")" in
+    *"20 STEPs"*) fail "$rel states the cadence as a bare \"20 STEPs\" instead of pointing at the CHECK-IN-CADENCE setting" ;;
+  esac
+done
+
 # --- 6. Index-row titles the resolver keys on ---------------------------------
 # Two next-action behaviours are triggered by how a human titles a row in prompts/STEP-index.md:
 # status.sh measures the check-in cadence from the last Done STEP whose Title begins "Check-in",


### PR DESCRIPTION
## Why

PR #203 rewrote five documents so they name the `CHECK-IN-CADENCE` setting instead of restating a
bare number. **Nothing in `tests/` referenced that wording on any branch**, so the six-file list
was the entire contract — every one of them could revert to "about every 20 STEPs" tomorrow with
the suite green. That is how the defect shipped in the first place.

`tests/doc-contract.sh` already checks the *arithmetic* of the cadence: it rebuilds METHOD.md §5's
window sentence from `status.sh`'s own `cadence`/`due`/`over` values. This adds the missing half
beside it.

## What it asserts

For each of the five files — `METHOD.md`, `AGENTS.md`, `runbooks/check-in.md`,
`templates/planning-session.md`, `ARTIFACT-TRAIL.md`:

1. it names `CHECK-IN-CADENCE`, and
2. it does not state the cadence as a bare `"20 STEPs"`.

## Both assertions earn their place

Established by running the guard against the **pre-fix content of each file, one at a time**:

| File | Caught by |
|---|---|
| `ARTIFACT-TRAIL.md` | assertion 1 |
| `AGENTS.md` | assertion 1 |
| `runbooks/check-in.md` | assertion 1 |
| `templates/planning-session.md` | assertion 1 |
| `METHOD.md` | **assertion 2 only** |

METHOD.md is the interesting one: reverting §5's opening sentence leaves `CHECK-IN-CADENCE`
present in the section body further down, so the presence check alone **passes on a file that has
regressed**. Without assertion 2 the guard would have a hole exactly where the original defect was.

## Two deliberate limits

- **It pins the literal that drifted, not every number.** METHOD.md legitimately says "heads-up
  **5 STEPs before**" inside the sentence the block above pins character for character, and
  `ARTIFACT-TRAIL.md` has headings like "## 2. STEP Roadmap" — so a general rule against a digit
  beside "STEPs" fails on day one. Measured, not assumed.
- **It flattens `>` along with whitespace** because `check-in.md`'s phrase sits in a blockquote.
  Today the marker falls *before* the number, so plain whitespace flattening would match too; this
  is insurance against a re-wrap, not a load-bearing trick. (I initially believed it was
  load-bearing and checked — it isn't, and the comment in the file says so.)

## No CHANGELOG entry, deliberately

Following **PR #198** — the PR that created this file and wired the suite into CI — which added
none. `init.sh:1054` removes `tests/` from every generated project, so nothing here is visible to
a user of the scaffold or pullable by one. Flagging it rather than skipping it silently.

## Verification

Full suite green locally: **16/16**, each script printing its own PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
