### PR TITLE
Add STEP-close honesty, phantom-close, pre-flight, and trunk-hygiene guards from downstream field experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,28 @@ any project built with it.
 > remains v1.7.1.
 
 ### Added
+- **Five process failure guards against phantom closes, stranded trunks, and unverified work.**
+  Scaffold templates, runbooks, and method documentation now enforce five durable process disciplines
+  earned from field failure modes:
+  - **Guard ① (Honesty gate):** A STEP or substep cannot close as `Done` if any required deliverable
+    or test is recorded as `Unverified`; row status must derive from the latest findings and inherit
+    the evidence verdict (`templates/step-plan-template.md`, `templates/substep-prompt-template.md`,
+    `templates/step-index-seed.md`, `METHOD.md` §1, §5).
+  - **Guard ② (Phantom-close detection):** Claimed branches, commits, and cited artifacts must be
+    verified against disk before a STEP or substep is marked `Done` (`templates/step-plan-template.md`,
+    `METHOD.md` §5, §10).
+  - **Guard ③ (Runtime pre-flight substep):** STEPs executing against an active runtime (E2E, staging,
+    device/emulator, deployment) must reserve substep 0 as a pre-flight to prove credentials (by
+    placeholder name) and host toolchain readiness before authoring functional journeys
+    (`templates/planning-session.md`, `templates/substep-prompt-template.md`, `METHOD.md` §5).
+  - **Guard ④ (Commit-per-substep discipline):** Executors must commit each completed substep's
+    deliverables immediately on the STEP branch instead of accumulating uncommitted work across repos
+    that strands the shared trunk (`runbooks/collaboration.md` §1, §8, `templates/substep-prompt-template.md`,
+    `prompts/README.md`).
+  - **Guard ⑤ (Stranded-trunk recovery recipe):** A structured recovery procedure for safely reconciling,
+    committing, merging, and switching when a dirty `STEP-index.md` on a STEP branch blocks `git switch main`
+    and halts reservation on the shared trunk (`runbooks/collaboration.md` §2, `prompts/README.md`).
+
 - **A runbook for splitting a repository** — `runbooks/splitting-repos.md`. The method used to say
   splitting was "standard git," which is not something you can act on: the recipe you find
   elsewhere makes the extracted repo *new*, with its history rewritten by `git filter-repo`, a

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -385,6 +385,9 @@ and make the STEP's final test command or CI gate explicit. Tests may run per su
 dedicated final verification substep; choose deliberately in the PLAN. A code-changing substep
 without tests needs a stated reason, not silence.
 
+### Closing a STEP
+When closing a STEP or substep, its status may only be flipped to **Done** when the evidence file's own wording supports it. The index row's status must be derived from the latest findings, not from earlier optimism. Furthermore, claimed commits and artifacts must be verified against disk before a STEP or substep is marked `Done` — a claimed commit must be verifiable (e.g., via `git rev-parse`, run URL, or file existence) before it counts.
+
 ### Check-in STEPs
 About **every 20 STEPs** (the project's cadence, adjustable), the roadmap includes a **Check-in STEP** — a full STEP whose
 job is to run `runbooks/check-in.md`: reconcile the architecture docs against the code in
@@ -713,7 +716,7 @@ Resolve the next action top-down against the index — the first rule that match
 6. **A STEP is `In progress`?** → open its PLAN in `Upcoming Prompts/` and run only the
    explicitly requested substep: *"run substep N.M"*. If the user says only *"run STEP N"*,
    identify the lowest open substep and wait for that explicit substep command. When the last
-   substep is done, run the STEP's review,
+   substep is done, run the STEP's review (ensuring commits and cited artifacts are verified against disk),
    then archive it (§5) and mark it `Done`.
 7. **~20 STEPs (the project's cadence) since the last check-in?** → propose a **Check-in STEP** at the next
    sensible breakpoint (§5; `runbooks/check-in.md`).

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -385,6 +385,8 @@ and make the STEP's final test command or CI gate explicit. Tests may run per su
 dedicated final verification substep; choose deliberately in the PLAN. A code-changing substep
 without tests needs a stated reason, not silence.
 
+**Runtime pre-flight rule:** For any STEP executing against a runtime (e.g. E2E, integration against staging, device/emulator, deployment), the STEP's first substep (substep 0) must be reserved as a **pre-flight**. This pre-flight proves required credentials (by placeholder name) and host toolchain readiness with evidence before any remaining substeps are authored. See the planning-session template for details.
+
 ### Closing a STEP
 When closing a STEP or substep, its status may only be flipped to **Done** when the evidence file's own wording supports it. The index row's status must be derived from the latest findings, not from earlier optimism. Furthermore, claimed commits and artifacts must be verified against disk before a STEP or substep is marked `Done` — a claimed commit must be verifiable (e.g., via `git rev-parse`, run URL, or file existence) before it counts.
 

--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -37,6 +37,7 @@ step-NNNN-short-name        e.g. step-0042-payment-webhooks
   one logical STEP stays recognizable across repos.
 - This holds **even when you're solo.** It costs nothing alone and means the workflow is
   identical the day a second contributor arrives — no mode switch.
+- **Commit per completed substep.** As you complete each substep, commit its deliverables on the STEP branch with a message naming the substep (e.g., "STEP-42.1: ..."). Do not save up the whole STEP's work for one multi-repo close — an uncommitted close spanning multiple repos will strand your shared trunk and block the next STEP reservation entirely.
 - Branch lifetime, PR gates, and how the branch merges are **standard practice** — the method
   only fixes the name and the cross-repo consistency.
 
@@ -101,6 +102,14 @@ or it's invisible to everyone else's overlap check.
 > (`templates/planning-session.md`) lays down all of a phase's STEP numbers in one batch
 > after STEP-1. The reserve-then-push dance only matters for **ad-hoc STEPs** added later
 > (bugs, inserted work) — which is exactly when two people might grab a number at once.
+
+### Recovering a stranded close
+If you violate the commit-per-substep discipline and leave `prompts/STEP-index.md` dirty on a `step-NNNN` branch, `git switch main` will refuse to switch branches, blocking the next STEP reservation entirely. (For a worked example, see mine-flow's STEP-45, where an uncommitted close stranded the trunk and was successfully recovered this way before reserving STEPs 47-49.) Do not blindly stash or discard. To recover safely:
+1. **Preserve and reconcile:** Keep the uncommitted files. Re-truth the index row and substep summary against actual evidence (apply the Unverified honesty gate — if a deliverable failed, mark it Unverified, never Done).
+2. **Review:** Run `git diff --check` to catch whitespace or format damage, and run the duplicate STEP-number scan to ensure no collisions were introduced.
+3. **Commit locally:** Commit the reconciled changes on your current `step-NNNN` branch.
+4. **Merge and switch:** Push the branch, merge it, then `git switch main` and fast-forward your local trunk.
+5. **Reserve:** Now you can safely allocate the next STEP number on the shared trunk.
 
 ## 3. The shared coordination surface is the index row
 While a STEP is in flight its PLAN and substep prompts live in `Upcoming Prompts/`, which is
@@ -259,6 +268,7 @@ repos it touches — that single record is what keeps the history coherent acros
 - Its **PLAN lists the repos it touches and the order they merge in** (cross-repo
   sequencing). Reference commits / PRs / tags where ordering matters.
 - It uses the **same `step-NNNN` branch name in each repo** (§1).
+- **It must not accumulate an uncommitted close across repos.** Commit each completed substep's deliverables immediately on the STEP branches. If you leave a final cross-repo close uncommitted, your dirty `prompts/STEP-index.md` on the STEP branch will prevent switching to trunk, completely blocking the next STEP reservation.
 - If it creates a new repo, **register it** (`register-repo.md`) — your row only (§5).
 
 ## 9. Going from solo to team

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -136,6 +136,7 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    from what's built and plan the STEPs that **extend** it, rather than re-scaffolding or
    rebuilding what's already there. Adjust to the actual project. Each STEP gets a
    global STEP number (continuing from STEP-1).
+   **Runtime pre-flight rule:** Any STEP whose substeps must *execute* against a runtime (E2E, integration against staging, device/emulator, deployment) must reserve its **first substep as a pre-flight** (substep 0). This pre-flight proves, with recorded evidence, that required credentials exist (name them by placeholder, never value), the host toolchain can build/run the target, and the baseline gates pass. The STEP's remaining substeps are authored *after* the pre-flight verdict, and any unprovable surface is scoped as Unverified-with-reason rather than assumed.
 3. **Interleave check-in STEPs.** About **every 20 STEPs** (the project's cadence, adjustable), add a **Check-in STEP**
    that runs `runbooks/check-in.md` (doc-drift reconciliation, conditional-session coverage,
    accepted-risk review, and a full test run). Place each at a sensible breakpoint — after a

--- a/Code/{{PROJECT}}-docs/templates/step-index-seed.md
+++ b/Code/{{PROJECT}}-docs/templates/step-index-seed.md
@@ -4,7 +4,7 @@ The living roadmap. Every STEP, its status, and a one-line scope. **This is the 
 place to look to understand where the project is.** Keep it current as STEPs are planned,
 worked, and completed.
 
-> Status values: **Planned** · **In progress** · **Done** (archived to `prompts/`) ·
+> Status values: **Planned** · **In progress** · **Done** (archived to `prompts/`; requires positive verification, unverified required deliverables cannot close a row as Done) ·
 > **Deferred** (consciously not needed now; keep a revisit trigger) ·
 > **Abandoned** (reserved but won't be built — keep the row so the number is never reused).
 > Those five are the STEP states. A **substep** row uses the same values plus **N/A** (this area

--- a/Code/{{PROJECT}}-docs/templates/step-plan-template.md
+++ b/Code/{{PROJECT}}-docs/templates/step-plan-template.md
@@ -122,6 +122,8 @@
 - [ ] All tests named in the STEP test plan pass at the end of this STEP — ideally the full
       suite (unit + integration/API/e2e/security as applicable). <!-- the default bar; narrow
       or widen with a stated reason -->
+- [ ] Substep status table reconciled against each substep's evidence file; no substep marked `Done` if a required deliverable is recorded `Unverified`.
+- [ ] Disk verification: for each projected repo, the branch exists (or was merged), commits exist and are pushed, and cited artifacts/reports exist at their cited paths. A row whose cited evidence does not exist on disk cannot close the STEP.
 - [ ] STEP review passed; prompts/STEP-index.md updated; STEP archived to prompts/.
       <!-- For a Check-in STEP, the completed report is saved under reports/, not in the
            archived STEP folder. -->

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
@@ -144,6 +144,6 @@ Leaving the doc stale is a defect, not a follow-up.
 - [ ] Findings/evidence file recorded truthfully; substep status inherits the evidence verdict (no `Unverified` items claimed as a pass).
 
 ## Next
-When this substep is done, update its status in the STEP PLAN, then tell the user the next
+When this substep is done, commit its deliverables on the STEP branch (with a message naming the substep), update its status in the STEP PLAN, then tell the user the next
 action: the next open substep — *"run substep N.M"*, in a **fresh chat** — or, if this was
 the last substep, the STEP's review. (`METHOD.md` §10.)

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
@@ -91,6 +91,7 @@
 - **Run timing:** either run the relevant tests before marking this substep done, or confirm
   that the STEP PLAN assigns them to a later final verification substep. Tests that are deferred
   this way still must pass before the STEP is Done.
+- **Honesty at close:** an unrunnable or unrun verification must be reported in the findings/evidence file as **Unverified with reason**, never claimed as a pass. The substep's status inherits the evidence's verdict.
 
 ## Keeping the docs true  (always)
 <!-- The architecture docs are the source of truth for the design. Implementation drifts
@@ -139,6 +140,7 @@ Leaving the doc stale is a defect, not a follow-up.
       (`runbooks/register-repo.md`).
 - [ ] Any accepted risk or deferred technical debt created or changed by this substep is
       recorded in `registries/risks.yml` or explicitly marked not applicable.
+- [ ] Findings/evidence file recorded truthfully; substep status inherits the evidence verdict (no `Unverified` items claimed as a pass).
 
 ## Next
 When this substep is done, update its status in the STEP PLAN, then tell the user the next

--- a/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
+++ b/Code/{{PROJECT}}-docs/templates/substep-prompt-template.md
@@ -92,6 +92,7 @@
   that the STEP PLAN assigns them to a later final verification substep. Tests that are deferred
   this way still must pass before the STEP is Done.
 - **Honesty at close:** an unrunnable or unrun verification must be reported in the findings/evidence file as **Unverified with reason**, never claimed as a pass. The substep's status inherits the evidence's verdict.
+- **Runtime pre-flight:** if this substep executes against a runtime (e.g. E2E, staging, device/emulator, deployment), it must explicitly state its runtime preconditions. If those prerequisites are unmet (e.g. credentials missing, toolchain broken), the execution must be skipped and reported as **Unverified with reason**.
 
 ## Keeping the docs true  (always)
 <!-- The architecture docs are the source of truth for the design. Implementation drifts

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -111,7 +111,7 @@ teammate will need later.
    pull, renumber, push again. Before every push, even on a clean merge, scan for a duplicate
    (`grep -oE '^\|[[:space:]]*STEP-[0-9]+' prompts/STEP-index.md | grep -oE 'STEP-[0-9]+' | sort | uniq -d`); two appended rows merge
    with no conflict into a silent duplicate. (Solo with no remote, this is just a local edit.)
-   See `Code/{{PROJECT}}-docs/runbooks/collaboration.md`.
+   If your `prompts/` trunk switch is blocked by uncommitted changes (a stranded close), see the recovery recipe in `Code/{{PROJECT}}-docs/runbooks/collaboration.md`.
 2. **Confirm scope** with the user before writing anything — a STEP is a real commitment.
    Ask clarifying questions where the planned work, dependencies, repo ownership, or order
    are uncertain. When there are real alternatives, present appropriate options with short
@@ -155,7 +155,7 @@ teammate will need later.
    present the PLAN and substep list to the user and **stop for approval** before running any
    substep. Do not continue from planning into execution unless the user explicitly asks for a
    specific substep, e.g. `run substep N.1`.
-7. **On completion:** run the STEP's review — your team's standard **PR / code review** (the
+7. **On completion:** (Note that commits are created per substep on the STEP branch as work proceeds; archiving is the final bookkeeping.) Run the STEP's review — your team's standard **PR / code review** (the
    method doesn't redefine it), plus the doc-drift check — then **gather the STEP's files
    (PLAN + any substep prompts + review) from `Upcoming Prompts/` into a new `step-NNNN/` folder**
    in the phase folder in this repo and mark it **Done** in the index. (If this is the phase's


### PR DESCRIPTION
Five process guards, all additive to existing templates and runbooks, earned the hard way by a downstream project (mine-flow) built on Throughstone in production. Each guard below names the real failure mode, the guard, and where it lands.

1. **Unverified-vs-Done honesty gate.** An executing agent closed a STEP with 15/15 substeps `Done` while 14 staging journeys had never executed (`markTestSkipped('Unverified: staging credentials absent')`) and every design-review item was Unverified — the record lied, and nothing mechanical caught it. The guard: a STEP or substep may only flip to `Done` when its evidence file's own wording supports it; an unrunnable or unrun verification must be reported as **Unverified with reason**, never claimed as success; row status derives from the latest findings and inherits the evidence verdict. Lands in `templates/step-plan-template.md`, `templates/substep-prompt-template.md`, `templates/step-index-seed.md`, `METHOD.md`.

2. **Phantom-close detection.** Claimed branches, commits, and cited artifacts/reports must be verified against disk (branch exists or was merged, commits exist and are pushed, cited artifacts exist at their cited paths) before a STEP or substep is marked `Done`. Lands in `templates/step-plan-template.md`, `METHOD.md`.

3. **Credential/host-toolchain pre-flight substep.** A STEP whose substeps execute against a runtime (E2E, staging, device/emulator, deployment) reserves substep 0 as a pre-flight proving credentials (by placeholder name only) and host toolchain readiness before functional journeys are authored — the failure it prevents is authoring a wall of journey tests that all skip. Lands in `templates/planning-session.md`, `templates/substep-prompt-template.md`, `METHOD.md`.

4. **Commit-per-substep discipline.** Executors commit each completed substep's deliverables immediately on the STEP branch (message naming the substep) instead of accumulating an uncommitted close across multiple repos — a real failure mode where a multi-repo uncommitted close made `git switch main` impossible and blocked STEP reservation entirely until manual recovery. Lands in `runbooks/collaboration.md`, `templates/substep-prompt-template.md`, `prompts/README.md`.

5. **Stranded-trunk recovery recipe.** A structured procedure for when a dirty `STEP-index.md` on a STEP branch blocks `git switch main`: preserve the changes (never stash/discard blindly), reconcile the row against real evidence, commit on the branch, merge/push, switch to trunk, fast-forward, then reserve. Lands in `runbooks/collaboration.md`, `prompts/README.md`.

## Validation

Smoke-tested on this branch: `init.sh` run non-interactively in a scratch project in both multi-repo and mono-repo layouts → exit 0; the generated projects' `check.sh` → exit 0 (13/13 structural checks, 0 failures, 0 warnings); all 16 guard markers verified present 1:1 in the generated output; no unresolved `{{PROJECT}}`/`{{PROJECT_DESCRIPTION}}`/`{{TRUNK_BRANCH}}` placeholders. A CHANGELOG entry under `[Unreleased] → Added` names all five guards.

## Notes

- All changes are additive to existing rules — no existing semantics are rewritten.
- mine-flow, the downstream project that earned these failure modes, intends to adopt the guards via `UPDATING-THROUGHSTONE.md` manual mode in a future update pass.
