### PR TITLE
Require an explicit instruction before a repo is made public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,27 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **The method now has a rule for the one thing it can do to a repo that cannot be undone.**
+  `METHOD.md` §7 sets out what the method does to a repo — stamps a README, applies the project's
+  licensing posture, writes a registry row — and every one of those writes a file, which the next
+  commit can take back. Publishing one is the exception, and §7 did not mention repository
+  visibility at all; the nearest thing to a rule was a note in `templates/planning-session.md`
+  telling you to choose private or public deliberately rather than infer it from the license,
+  which is how to choose and not whose choice it is. **Making a repo public takes an explicit
+  instruction from the user naming that repo** — a license, a public sibling repo, a remote, or a
+  project that calls itself open source is not that instruction, and neither is silence. It is
+  absolute because publishing cannot be taken back: a repo that goes public exposes its whole
+  history at once — the key that was committed and removed a week later, the customer name in a
+  fixture — and forks, mirrors and crawlers have it before anyone notices, while setting the repo
+  private again recovers none of it. The rule reads the same for every repo however it arrived:
+  not one wording for a repo the method created and another for one it adopted, and nothing
+  consults `added_as:` to pick between them. A default applies at one moment and no other — when a
+  repo is being stood up: create it **private**, widening being a separate decision made
+  deliberately later, the words `runbooks/splitting-repos.md` already uses at the step that gives
+  a new repo its remote. The sentence is written into `METHOD.md` §7,
+  `templates/planning-session.md` and `templates/repo-readme-template.md`, in the same words in
+  each. No tooling changed: nothing gained a field, a flag or a check. It is doctrine rather than
+  machinery, and the instruction it names comes from the user, ahead of the run.
 - **A project that has finished its architecture STEP is no longer sent back into it — forever.**
   `./doctor.sh status` answers "what do I do next?" by walking `METHOD.md` §10's rules in order and
   stopping at the first match. The rule about open STEP-1 substeps sat above the point where the

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -534,6 +534,19 @@ adds an `ARCHITECTURE.md` at its root for its internal design. **Licensing follo
 `.throughstone/project-license` and applied per repo by `scripts/apply-project-license.sh` when the
 repo is brought in.
 
+**Making a repo public takes an explicit instruction from the user naming that repo** — a license,
+a public sibling repo, a remote, or a project that calls itself open source is not that
+instruction, and neither is silence. It reads the same for every repo in the project, whatever its
+history, and an instruction naming one repo does not carry to the next. It governs the act of
+publishing, not the visibility a repo already carries: a license says what may be done with the
+code, never who may read it. Where a repo is being stood up for the first time, create it
+**private** — widening is a separate decision, made deliberately later.
+
+The rule takes no exceptions because publishing cannot be taken back. Most of what goes wrong in
+this section ends in a file, and a file can be corrected; a repository that goes public hands its
+whole history — every commit, every key committed once and removed a week later — to forks, caches
+and crawlers before anyone notices.
+
 **Where a repo lives — always inside the workspace.** A repo's `registries/repos.yml`
 `location:` is **a path relative to the workspace root, identical on every machine; it never
 begins with `/` or `~`, and no segment of it is `..`.** Usually that is a `Code/*`

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -336,6 +336,23 @@ differently:
   Nothing of yours is rewritten, and a first run on a fresh project behaves exactly as it did in
   1.7.
 
+**The rule for making a repo public is now written down, and there is nothing of yours to
+change.** A repo goes public only on an explicit instruction from you that names that repo — a
+license, a public sibling repo, a remote, or a project that calls itself open source is not that
+instruction, and neither is silence. It reads the same whether Throughstone created the repo or
+took on one that already existed. Where a repo is being stood up, create it **private** — widening is a separate decision, made deliberately later. The rule
+lives in `METHOD.md` §7 and in the two templates that touch a repo as it is brought in,
+`templates/planning-session.md` and `templates/repo-readme-template.md`; all three travel with
+item 1's group above, so pull them together — the rule is only as good as the least-updated of
+them — and there is no new step to take. **No tooling changed with it**: nothing in your project
+records a visibility decision, no check tests for one, and no script behaves differently. What
+changes is that an agent working in your project finds the rule stated rather than having to
+arrive at it. **One thing to check:** if you are not sure how a repo of yours came to be public,
+this is a cheap moment to look — one glance at each repo's host page. 1.7 asked you to choose
+visibility deliberately but never said what a public answer had to come from, and setting a repo
+private again governs only what happens next: it retrieves nothing already cloned, cached, or
+crawled.
+
 **Three read-only sweeps stop over-promising.** The check-in's full test run, the dependency
 audit and the incident runbook's hunt for similar issues each asked for "all repos"; they now ask
 for every repo you can reach, and for the ones you can't to be named. What that guards against is

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -101,9 +101,10 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    `LICENSE` is created. It also copies `LICENSE-THROUGHSTONE`, because the standard repo README
    and CI starter are retained Throughstone-authored scaffold material, and writes
    `LICENSING.md` to make clear that notice is not the application-code license. Repository
-   visibility is separate: when adding a remote for each code repo, choose private or public
-   deliberately rather than inferring it from the license. Publishing a proprietary repo makes
-   its source visible without granting open-source reuse rights, so call that out explicitly.
+   visibility is decided on its own, not read off the license. Where a new code repo is given a
+   remote, create it **private** — widening is a separate decision, made deliberately later
+   under the rule at the end of this item, and when it comes up, say plainly that publishing a
+   proprietary repo makes its source visible without granting open-source reuse rights.
    **Each repo's README isn't just stamped — its role one-liner and Overview get filled in**
    (what the repo is and the slice of the system it owns); a repo isn't scaffolded until it can
    explain itself.
@@ -123,6 +124,11 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    scaffolding STEP to inherit the work.
    Confirm the repo list with the user: which are new, which already exist, and name any you
    could not reach.
+   The rule works the same for every repo on that list, new or already there.
+   **Making a repo public takes an explicit instruction from the user naming that repo** — a
+   license, a public sibling repo, a remote, or a project that calls itself open source is not
+   that instruction, and neither is silence. Publishing cannot be taken back: a later
+   visibility change does not recall what was already copied.
 2. **Inherited code.** Item 1 has established which repos already existed. Settle the part it does
    not answer, by asking rather than working it out: **is any of the code this phase builds on
    code this project did not write, that no check-in has yet run over?** The user knows — whether

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -4,6 +4,12 @@
 > defines it, e.g. `{{PROJECT}}-docs/architecture/*-architecture-overview.md`.)
 
 <!--
+  **Making a repo public takes an explicit instruction from the user naming that repo** — a
+  license, a public sibling repo, a remote, or a project that calls itself open source is not
+  that instruction, and neither is silence. The rule does not change at the divider below.
+  Publishing cannot be walked back: a repo made private again does not un-publish what has
+  already been cloned, forked, and cached.
+
   Stamp a copy of this into each code repo **as Throughstone creates it** — every created repo,
   including in a multi-repo design, must carry one. Keep the section headings consistent across
   all repos so the project reads uniformly. Sections that don't apply can be dropped (e.g. no
@@ -23,8 +29,9 @@
 
   ---- A repo that already exists: augment, don't stamp ----
 
-  Everything above is for a repo Throughstone creates. For a repo that already has a README,
-  **never stamp this file over it, and never create a second README.** Add one section instead:
+  The stamping, CI, and licensing instructions above are for a repo Throughstone creates. For a
+  repo that already has a README, **never stamp this file over it, and never create a second
+  README.** Add one section instead:
 
       ## Role in <project>
 


### PR DESCRIPTION
## What this changes

`METHOD.md` §7 said what the method does to a repository — README, licensing posture, location,
registry row — and every one of those writes a file that the next commit can correct. It said
nothing about repository visibility, the one thing here that cannot be corrected afterwards. The
nearest thing to a rule was a line in `templates/planning-session.md` telling an agent to choose
private or public deliberately rather than infer it from the license: advice on *how* to choose,
silent on whose choice it is and on what a public answer has to come from.

This writes one sentence into `METHOD.md` §7 and the two templates that touch a repo as it is
brought in, plus a CHANGELOG entry and a 1.8 migration entry. Prose only — no field, no flag, no
check, no test, no code path.

### The canonical string

A later change wires `scripts/check.sh` and `runbooks/check-in.md` to quote this. Verbatim:

```
**Making a repo public takes an explicit instruction from the user naming that repo** — a license, a public sibling repo, a remote, or a project that calls itself open source is not that instruction, and neither is silence.
```

223 characters, 225 bytes, one U+2014 em dash. Two mechanical notes for whoever wires it up:

- **It contains no apostrophe, double quote, backtick, `$`, backslash, `!`, `&`, `/` or `%`.**
  Verified to round-trip byte-identical through a single-quoted `awk` program, which is how this
  repo's `check.sh` would carry it.
- **Match it as a fixed string, never as a regex.** The leading `**` is an empty subexpression:
  `grep` on this shell (a ugrep wrapper) fails it with `error at position 4`, exit 2. `grep -F`
  and `index()` are fine. It is also *wrapped* differently in each of the three files, since the
  indentation differs (0 / 3 / 2 spaces), so a searcher must normalize whitespace rather than look
  for one contiguous byte run.

The sentence is identical in all three files — verified by collapsing whitespace and confirming it
appears exactly once in each.

### Why this wording

The rule reads the same for a repo the method created and one it adopted; nothing consults
`added_as:` to pick between two wordings. It governs the *act* of publishing, not the visibility a
repo already carries, so it never orders a change to a repo that is already public. A private
default still applies at the one moment it can — when a repo is being stood up — in the words
`runbooks/splitting-repos.md` already uses at the step that gives a new repo its remote.

The earlier draft of this sentence ended "and private wherever no answer has been given". That
clause gaps onto the subject *Nothing*, so a literal read is "nothing is private" — the inverse of
the rule — and applied to an already-public repo it would order a visibility change nobody asked
for. It also listed "a remote being created", which scopes the rule to repo creation. Both are
gone.

No claim is made that `init.sh` enforces the private default. `REMOTE_VISIBILITY=private`
(init.sh:799) is read at init.sh:1390 only inside `if [ "$REMOTE_PROVIDER" = "github" ]`; the
`manual` path attaches a remote the user already made and never reads it.

### Placement

- **`METHOD.md` §7** — two paragraphs under the created/adopted and licensing-posture sentences the
  rule says not to infer visibility from, and above the registry-mechanics run. Paragraphs only: no
  new `## N.` heading and no renumbering, so `tests/doc-contract.sh`'s 1..N ordering check and the
  §-number citations across the tree are untouched.
- **`templates/planning-session.md`** — at the end of item 1, in the block both branches reach, not
  in the create branch. Item 1 *routes*: an agent handling a repo that already exists takes the
  "**Yes — it is registered instead of scaffolded**" branch and never reads the create branch, so a
  rule placed there would be unreachable for exactly the case it has to govern. The earlier
  advisory sentence was repaired in place so it defers to the rule instead of standing as a weaker
  rival; the canonical sentence still appears exactly once in the file.
- **`templates/repo-readme-template.md`** — the first paragraph inside the HTML instruction comment,
  never in the README body that lands in real repos. This required one extra repair: the divider
  sentence read "Everything above is for a repo Throughstone creates", which would have scoped the
  new rule to created repos — the exact defect the rule exists to prevent. It now names what is
  actually above it: "The stamping, CI, and licensing instructions above...".

## Type of change
- [x] Documentation / wording
- [x] New or updated template / coding-standard

## Checklist
- [x] No shell changed, so `bash -n` / `shellcheck` do not apply
- [x] Full suite green: **16/16 PASS** (`for t in tests/*.sh; do env -u CI "$t"; done`, 245s).
      Baseline on the same machine at `e9712b3` was 16/16, 212s.
      `./doctor.sh check` → `0 fail(s), 2 warning(s)` / `RESULT: OK` (both warnings pre-existing —
      the absent `prompts/STEP-index.md`). `./doctor.sh links` → 104 scoped links resolve.
- [x] **Throwaway `init.sh` smoke test run**, since two of the three files are templates:
      `./init.sh --non-interactive --slug=smoke-test --license=proprietary --layout=multi
      --collab=solo --remotes=no` exited 0; the generated project carries the rule exactly once in
      each of `METHOD.md`, `templates/planning-session.md` and `templates/repo-readme-template.md`,
      with zero unresolved `{{PROJECT}}` placeholders and a clean initial commit.
- [x] `{{PROJECT}}` placeholder convention intact — no new placeholder token introduced
- [x] `METHOD.md` updated; no `README.md` or `prompts/` change is implied

## Notes

Commit 56695c1 wrote this rule once before; ac6623d backed out the whole in-place-repo workstream
three days later and took it along as collateral rather than on its merits. It has been absent from
every branch since and never reached a release. `git branch --contains 56695c1` lists main, retcon
and repo-record because that backout was a forward revert — reachability is not evidence the text
is present.

Only the publishing rule returns here. The second rule that commit carried — an adopted repo's
remote and visibility are its own — is deliberately not part of this change.

Targets `repo-record`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
