### PR TITLE
Say proprietary for the licence and private for the visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,29 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **Seven documents still glued `private` and `proprietary` into one word, and two of them
+  described a wizard question that no longer exists.** 1.8 split the two deliberately —
+  `private` is who can see the repository, `proprietary` is what the code is licensed under, and
+  they are independent, since a private repo can carry MIT and a public repo can be proprietary.
+  That cleanup reached `init.sh`'s tokens, flags and on-screen labels but not the prose around
+  them. `templates/licenses/README.md` and the root `README.md` both told you `init.sh` asks
+  whether the project is *open source or private/proprietary*; it asks *Open source* or
+  *Proprietary*, and prints a line saying visibility is a separate question asked later, so those
+  two were describing a prompt the wizard does not show. The remaining five were the fused pair
+  used as the name of the licensing posture, in the licence banners of `METHOD.md` and the docs
+  hub's `README.md`, twice more in the two files above, and in one `init.sh` comment. All seven
+  now say `proprietary` where they mean the licence and `private` only where they mean
+  visibility. Nothing changed about what is licensed, what the wizard does, or what any project
+  already records in `.throughstone/project-license`.
+- **A repo the method did not create could be read as needing an `.env.example`.** The planning
+  session's scaffolding sentence scoped its `.gitignore` to "each new code repo" and, in the same
+  breath, `templates/env-example.txt` to "each repo" — two items in one sentence, scoped two ways,
+  which reads as a distinction someone meant. The branch it sits in only ever handles repos being
+  created, and the branch beside it already refuses `.env.example` outright, so nothing was
+  actually writing into somebody's existing repository; what was wrong was a sentence that said
+  otherwise. It now says "each new code repo" for both. The two lines carrying it were the widest
+  in the file at 130 and 124 columns, which is the reason it survived this long, and they are
+  rewrapped to the file's own width.
 - **The method now has a rule for the one thing it can do to a repo that cannot be undone.**
   `METHOD.md` §7 sets out what the method does to a repo — stamps a README, applies the project's
   licensing posture, writes a registry row — and every one of those writes a file, which the next

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -5,7 +5,7 @@
 > Built with **Throughstone** — this file and the other scaffold files (`templates/`,
 > `runbooks/`, `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause; the full text is
 > retained as `LICENSE-THROUGHSTONE` in this docs hub. Your own application code is under the
-> open-source license you chose at setup or remains private/proprietary. For open-source
+> open-source license you chose at setup or remains proprietary. For open-source
 > projects, the docs hub's `LICENSE` is the canonical project-license file copied into each
 > application-code repo when that repo is created. The durable selection is recorded separately
 > in `.throughstone/project-license`, so a missing license file cannot silently change it.

--- a/Code/{{PROJECT}}-docs/README.md
+++ b/Code/{{PROJECT}}-docs/README.md
@@ -37,7 +37,7 @@ the sibling `prompts/` repo is *history* (how it was built, STEP by STEP).
 > Built with **Throughstone**. The scaffold files (`METHOD.md`, `templates/`, `runbooks/`,
 > `scripts/`) are © 2026 Mark A. Herschberg under BSD-3-Clause — full text in
 > `LICENSE-THROUGHSTONE`. Your application code and project docs are yours, under the
-> open-source license you chose at setup or kept private/proprietary. For open-source projects,
+> open-source license you chose at setup or kept proprietary. For open-source projects,
 > this repo's `LICENSE` is the canonical project-license file copied unchanged into each
 > application-code repo when it is created. `.throughstone/project-license` records the durable
 > selection independently, and the repo-scaffolding helper validates the two before copying.

--- a/Code/{{PROJECT}}-docs/templates/licenses/README.md
+++ b/Code/{{PROJECT}}-docs/templates/licenses/README.md
@@ -4,13 +4,13 @@ Source text for the open-source license that `init.sh` stamps into your project 
 Each file uses two placeholders that `init.sh` fills in: `{{YEAR}}` and `{{HOLDER}}` (the
 copyright holder).
 
-`init.sh` first asks whether the project is **open source** or **private/proprietary**.
+`init.sh` first asks whether the project is **open source** or **proprietary**.
 Open source then picks one of the three permissive licenses and writes the filled text to
 `LICENSE` in the bootstrap repos. The docs hub's copy is canonical and is copied unchanged
 into each application-code repo when that repo is created later. The selection is also recorded
 as a validated token in `.throughstone/project-license`; the propagation helper fails if an
-open-source selection's canonical `LICENSE` is missing. Private projects record `Proprietary`
-and do not get a project `LICENSE` file.
+open-source selection's canonical `LICENSE` is missing. A proprietary project records
+`Proprietary` and gets no project `LICENSE` file.
 
 | File | License | When `init.sh` uses it |
 |------|---------|------------------------|

--- a/Code/{{PROJECT}}-docs/templates/planning-session.md
+++ b/Code/{{PROJECT}}-docs/templates/planning-session.md
@@ -89,9 +89,10 @@ STEP's PLAN with its owner rather than silently replacing its index row.
    skeleton"*. Where **Inherited code** below has put a baseline check-in ahead of it, that
    check-in goes first and this STEP follows it. Scaffolding means: create each new code repo from
    `templates/repo-readme-template.md`, wire up the chosen stack, CI, and the environment/secrets
-   baseline from the Environments architecture doc, plus any interface contract artifact placeholders or repo-local contract files
-   named in the Interface Contracts architecture doc — including copying `templates/env-example.txt` into each repo as its
-   `.env.example`, and adding a **stack-appropriate `.gitignore`** to each new code repo
+   baseline from the Environments architecture doc, plus any interface contract artifact
+   placeholders or repo-local contract files named in the Interface Contracts architecture doc —
+   including copying `templates/env-example.txt` into each new code repo as its `.env.example`,
+   and adding a **stack-appropriate `.gitignore`** to each new code repo
    (language/build artifacts — `node_modules/`, `__pycache__/`, `target/`, `dist/`, … — plus
    the `.env` / `.secrets/` secret-file block so local secrets never get committed). Apply the
    project-license posture too: run

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ reports, fixes, and ideas are genuinely welcome. A few starting points:
 
 This Throughstone template is released under the [BSD 3-Clause License](LICENSE) — use
 it freely. `init.sh` asks whether **your** project is open source (MIT, BSD-3, or Apache-2.0)
-or private/proprietary. Open-source projects get the selected project `LICENSE`; private
+or proprietary. Open-source projects get the selected project `LICENSE`; proprietary
 projects get no project license file. The selected license in the docs hub is the source copied
 into application-code repos when they are created later. The durable selection is recorded in
 the docs hub's `.throughstone/project-license`, so deleting or losing the canonical `LICENSE`

--- a/init.sh
+++ b/init.sh
@@ -1095,7 +1095,7 @@ done
 
 # Relocate the scaffold's BSD license into the docs hub (retained as attribution per BSD-3,
 # next to the method files it covers — not deleted). Open-source project licenses are stamped
-# separately into each repo in step 6; private projects get no project LICENSE.
+# separately into each repo in step 6; proprietary projects get no project LICENSE.
 [ -f "$ROOT/LICENSE" ] && mv "$ROOT/LICENSE" "$DOCS/LICENSE-THROUGHSTONE"
 # LICENSE-THROUGHSTONE follows retained scaffold material. In multi-repo mode prompts/ is its
 # own repo and contains Throughstone-authored seed content, so retain the scaffold notice there


### PR DESCRIPTION
## What this changes

Two small documentation defects, both found while reviewing #208 and both left out of it as
out of scope.

### 1. `private` and `proprietary` were still glued together in seven places

1.8 deliberately split these: **`private` is who can see the repository, `proprietary` is what
the code is licensed under.** They are independent — a private repo can carry MIT, a public repo
can be proprietary. The split exists because they were once confusable in exactly the way that
matters: the licence question called its own answer "Private / proprietary", a later question
offered "1) Private" for visibility, and a reader who took the first for the second answered it
and got a project licensed to nobody (`init.sh:190-201` records this).

That cleanup reached `init.sh`'s tokens, flags and on-screen labels. It never reached the prose.

**Two of the seven were factually wrong, not just stale.** `templates/licenses/README.md` and the
root `README.md` both said `init.sh` asks whether the project is *"open source or
private/proprietary"*. It doesn't. The prompt reads:

```
  1) Open source  (a LICENSE file is created and anyone may reuse the code)
  2) Proprietary  (no LICENSE file is created; nobody is granted reuse rights)
  Not the same as who can see the repository — that is asked separately, later.
```

They were describing a question the wizard does not ask.

| File | Was | Now |
|---|---|---|
| `Code/{{PROJECT}}-docs/METHOD.md:8` | `remains private/proprietary` | `remains proprietary` |
| `Code/{{PROJECT}}-docs/README.md:40` | `kept private/proprietary` | `kept proprietary` |
| `templates/licenses/README.md:7` | `**open source** or **private/proprietary**` | `**open source** or **proprietary**` |
| `templates/licenses/README.md:12` | `Private projects record ...` | `A proprietary project records ...` |
| `README.md:577` | `or private/proprietary` | `or proprietary` |
| `README.md:578` | `private projects get no project license file` | `proprietary projects ...` |
| `init.sh:1098` | `private projects get no project LICENSE` | `proprietary projects ...` |

`METHOD.md` is the one that had started to grate: its banner fused the pair about 530 lines above
the §7 paragraph landed in #208, which now states that licence and visibility are independent in
both directions.

The `init.sh` change is **a comment**. Nothing executable moved, and no project's recorded posture
changes — `.throughstone/project-license` has always held `Proprietary`.

Left alone deliberately: `CHANGELOG.md:596`, `UPDATING-THROUGHSTONE.md:181`, `init.sh:195` and
three lines in `tests/init-license-validation.sh` all quote the old label on purpose, to explain
the rename. Also left alone: every `private` that correctly means visibility
(`splitting-repos.md`, `README.md:170-172`, the new §7 text) or means something else entirely
(language access modifiers in `coding-standards/`, "private tokens" in the security checklists).

### 2. `.env.example` was scoped loosely in a sentence whose neighbour was tight

The planning session's scaffolding sentence scoped a `.gitignore` to "each **new code** repo" and,
in the same breath, `templates/env-example.txt` to "each repo". Two items scoped two ways in one
sentence reads as a distinction somebody meant.

**Nothing was actually writing into a repo the method did not create.** The branch containing the
sentence only ever handles repos being created, and the branch beside it already refuses it
outright: *"**No stack wiring, no CI, no `.env.example`, no `.gitignore` block and no project
`LICENSE`** go into it."* What was wrong was a sentence that said otherwise. It now says "each new
code repo" for both.

The two lines carrying it ran **130 and 124 columns** against a file median of 90 — the widest in
the file, and the likeliest reason this survived a backout and a review round unread. They are
rewrapped to the file's own width; that is why the diff on this file is larger than the three-word
change it contains.

`56695c1` made this exact fix once; `ac6623d` reverted it as collateral with the rest of that
workstream.

## Type of change
- [x] Bug fix
- [x] Documentation / wording
- [x] New or updated template / coding-standard

## Checklist
- [x] Shell changed (one comment in `init.sh`): `bash -n` OK, `shellcheck -S warning` clean
- [x] Full suite green: **16/16 PASS** (`for t in tests/*.sh; do env -u CI "$t"; done`, 225s).
      `./doctor.sh check` → `0 fail(s), 2 warning(s)` / `RESULT: OK`; `./doctor.sh links` → 104
      scoped links resolve.
- [x] **Throwaway `init.sh` smoke test run**, since a template and the wizard both changed: exit 0,
      generated project carries the corrected wording, no posture conflation left anywhere in it,
      zero unresolved `{{PROJECT}}` placeholders, clean initial commit.
- [x] `{{PROJECT}}` placeholder convention intact
- [x] The publishing rule from #208 is untouched — still present exactly once in each of its three
      files

## Note

`Code/{{PROJECT}}-docs/README.md` has diverged: `c815347` on `main` rewrote lines ~44-46, four
lines below the line touched here. Line 40 itself is identical on both branches, but that file may
want an eye at the `repo-record` → `main` merge.

Targets `repo-record`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
