### PR TITLE
Scope the solo-to-team remote setup to repos that have no remote yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,9 +320,9 @@ any project built with it.
   than about our connection to it. A registry row and its Architecture Overview entry are treated as
   **one** thing that drifts — re-run the registration, never edit either by hand — and the check-in
   now says plainly that licensing is settled once for the whole project and never re-asked per
-  repository. **`runbooks/collaboration.md` §9's solo-to-team remote setup is scoped to
-  repositories the method created**: as written it would have created a second remote for a
-  repository someone else owns and pushed their history into it.
+  repository. **`runbooks/collaboration.md` §9's solo-to-team remote setup is scoped to repos
+  that have no remote yet**: as written it would have created a second remote for a repository
+  that already had one and pushed its history there.
   Three read-only sweeps — the check-in's full test run, the dependency audit, and the incident
   runbook's hunt for similar issues — asked for "all repos" and now ask for every repo you can
   reach, with the unreachable ones named. The failure that guards against is not missing a

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -314,9 +314,9 @@ differently:
   rather than by editing either side; and the licensing question is never re-asked per repo,
   because that posture lives in one project-wide file.
 - **`runbooks/collaboration.md` §9 no longer stands up a remote for every repo.** Going solo to
-  team, the create-a-remote-and-push-your-history step is now scoped to repos Throughstone
-  created. As it stood, following it literally would have created a second remote for a
-  repository someone else owns and pushed their history into it. Recording a remote a repo
+  team, the create-a-remote-and-push-your-history step is now scoped to repos that have no
+  remote yet. As it stood, following it literally would have created a second remote for a
+  repository that already had one and pushed its history there. Recording a remote a repo
   already has is unchanged, and every repo that has one still gets its `remote:` field.
 - **The planning session no longer decides a repo exists by reading its README.** Its
   repo-scaffolding step used to count a repo as already there only if it had a registry row

--- a/Code/{{PROJECT}}-docs/runbooks/collaboration.md
+++ b/Code/{{PROJECT}}-docs/runbooks/collaboration.md
@@ -270,10 +270,10 @@ flow (§6). The transition is mostly mechanical:
 
 1. **Stand up the shared remotes — and push your existing history to them first.** A solo
    dev has been committing locally with no remote, so the order matters: (a) create the remote
-   for `prompts/`, the docs hub, and each code repo **Throughstone created**, then **`git push`
-   your existing history to each** — otherwise newcomers clone empty repos and the STEP-number
-   registry of record is gone. **A repo Throughstone did not create gets neither** — never
-   create a remote for it and never push its history (`register-repo.md`); (b) add the
+   for `prompts/`, the docs hub, and every code repo **that has no remote yet**, then
+   **`git push` your existing history to each** — otherwise newcomers clone empty repos and the
+   STEP-number registry of record is gone. **A repo that already has a remote keeps the one it
+   has** — never create a second and never repoint it (`register-repo.md`); (b) add the
    `remote:` fields in `registries/repos.yml`, for every repo that has one; (c) have each new
    contributor run `Code/{{PROJECT}}-docs/scripts/setup-workspace.sh`, from the workspace root,
    to clone them. Number reservation (§2) relies on this shared `prompts/` remote.


### PR DESCRIPTION
Going solo to team, section 9 scoped the create-a-remote-and-push-your-history step to
repositories Throughstone created, and told you that anything else "gets neither".

That describes a category the method no longer has. It is left over from an abandoned
design where some repositories sat in the workspace without being part of the project. A
repository is either part of the project or it is not, and one that is gets backed up like
any other — a remote, or a bus-factor warning until someone decides otherwise.

The old rule was aimed at something real, though: unqualified, the step would create a
second remote for a repository that already had one and push its history there. That is a
defect about **repositories that already have a remote**, not about how they arrived. An
adopted repo that has never been pushed anywhere needs a remote; a created repo that got
one in week one must not be given a second.

So the step asks that question directly now: the remote is created for every code repo
with no remote yet, and one that already has a remote keeps it — never a second, never
repointed. Those are the registration runbook's own words for the same field, which makes
the pointer at the end of that clause accurate for the first time.

**Unchanged:** the create-then-push order (the split runbook cites section 9 for it),
clause (b), and the mono-repo paragraph.

**Release notes:** both entries are corrected rather than removed. Neither has shipped, but
the clause still differs from 1.7.1 — which created a remote for every code repo
unconditionally — so both stay and now describe the scope that is actually shipping.

**Verification:** all 16 tests pass locally. No test covers this prose, so the
cross-references were checked by hand: the split runbook's two citations of section 9 both
still read true, and nothing else in the scaffold frames remote handling by how a repo
arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
