### PR TITLE
Create a repo's first remote private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -445,8 +445,22 @@ any project built with it.
   deliberately later, the words `runbooks/splitting-repos.md` already uses at the step that gives
   a new repo its remote. The sentence is written into `METHOD.md` §7,
   `templates/planning-session.md` and `templates/repo-readme-template.md`, in the same words in
-  each. No tooling changed: nothing gained a field, a flag or a check. It is doctrine rather than
+  each. Nothing gained a field, a flag or a check. It is doctrine rather than
   machinery, and the instruction it names comes from the user, ahead of the run.
+- **That rule now reaches the two places that could actually make a repo public.** Stating it in
+  `METHOD.md` and the templates left out the registration runbook, which is where a repository is
+  brought into a project, and the check-in, which is where the doctor reports that a repo has no
+  remote and somebody acts on it. Both told you to push a repo somewhere, neither said anything
+  about visibility, and they are the pages open at the moment a remote gets created. All three now
+  say that **a remote created for a repo that has none is created private**, widening being a
+  separate decision made deliberately later. The registration runbook adds what a public answer has
+  to come from; the doctor's fix line and the check-in keep the short form, because the moment they
+  describe is a repository being stood up rather than one being published. The doctor's line also
+  stops conflating two situations it never told apart: it reads the registry file and not git, so
+  a row with no `remote:` can mean the repo has one that nobody wrote down — record it — or that it
+  has none — create it, private, or accept the risk deliberately. Unchanged in force, and now
+  saying what it always scoped to: the registry's `remote:` field is still never created and never
+  repointed *by registration*, which records what is there.
 - **A project that has finished its architecture STEP is no longer sent back into it — forever.**
   `./doctor.sh status` answers "what do I do next?" by walking `METHOD.md` §10's rules in order and
   stopping at the first match. The rule about open STEP-1 substeps sat above the point where the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -344,14 +344,26 @@ took on one that already existed. Where a repo is being stood up, create it **pr
 lives in `METHOD.md` §7 and in the two templates that touch a repo as it is brought in,
 `templates/planning-session.md` and `templates/repo-readme-template.md`; all three travel with
 item 1's group above, so pull them together — the rule is only as good as the least-updated of
-them — and there is no new step to take. **No tooling changed with it**: nothing in your project
-records a visibility decision, no check tests for one, and no script behaves differently. What
+them — and there is no new step to take. **Nothing of yours changes with it**: nothing in your
+project records a visibility decision, and no check tests for one. What
 changes is that an agent working in your project finds the rule stated rather than having to
 arrive at it. **One thing to check:** if you are not sure how a repo of yours came to be public,
 this is a cheap moment to look — one glance at each repo's host page. 1.7 asked you to choose
 visibility deliberately but never said what a public answer had to come from, and setting a repo
 private again governs only what happens next: it retrieves nothing already cloned, cached, or
 crawled.
+
+**And the rule now reaches the two pages that are open when a remote gets created.** Stating it in
+`METHOD.md` and the templates left out `runbooks/register-repo.md`, where a repository is brought
+into a project, and `runbooks/check-in.md`, where the doctor reports a repo with no remote and
+somebody acts on it. Both told you to push the repo somewhere and neither mentioned visibility.
+All three now say a remote created for a repo that has none is created **private**. The doctor's
+own fix line changes with them, and it stops conflating two situations: it reads
+`registries/repos.yml` and not git, so a row with no `remote:` may mean the repo has one nobody
+recorded — write it in — or that it has none — create it, private, or accept the risk deliberately.
+All three files are in item 1's group above; **nothing else of yours changes**, and the registry's
+`remote:` field is still never created and never repointed by registration, which records what is
+already there.
 
 **Three read-only sweeps stop over-promising.** The check-in's full test run, the dependency
 audit and the incident runbook's hunt for similar issues each asked for "all repos"; they now ask
@@ -373,8 +385,10 @@ and only two:
 - **A repo that no recorded remote covers is a warning**, named row by row: as far as the project
   knows, that repo's work lives on exactly one laptop. **Most 1.7 projects will see this at their
   first check-in after upgrading**, because a 1.7 registry ships two rows with no `remote:`, and
-  `init.sh` fills one in only if your bootstrap actually created remotes. Push the repo somewhere and *then* record the URL — the field
-  records that a remote exists, it does not prove anything was pushed to it — or decide that
+  `init.sh` fills one in only if your bootstrap actually created remotes. Record the URL if the repo
+  already has a remote; if it has none, create one — **private**, widening being a separate decision
+  made deliberately later — then push and record the URL, because the field records that a remote
+  exists and does not prove anything was pushed to it. Or decide that
   local-only is still fine. **Nothing records that decision**, so the warning comes back every
   check-in. That is the design, not a defect: a `[WARN]` is for deciding about, not for reflexively
   clearing, while a `[FAIL]` gets fixed.

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -76,10 +76,12 @@ comparison above — the rows against the repos that actually exist.
 - **A row with no `location:`** fails the run. Ask the human where that repo lives and write it
   into the row; don't guess a path.
 - **A row with no `remote:` recorded** is a warning: as far as the project knows, that repo's
-  work lives on exactly one laptop. Push it to a git host and *then* record the URL — the row
-  records that a remote exists, it does not prove anything was pushed to it — or decide here
-  that local-only is still fine, because a project may legitimately start local for a while.
-  **Nothing records that decision**: the warning returns every check-in, which is the point. In
+  work lives on exactly one laptop. If the repo already has a remote, record the URL. If it has
+  none, give it one — **created private**, widening being a separate decision made deliberately
+  later — then push to it and record the URL, because the row records that a remote exists and
+  does not prove anything was pushed to it. Or decide here that local-only is still fine, because
+  a project may legitimately start local for a while. **Nothing records that decision**: the
+  warning returns every check-in, which is the point. In
   the mono-repo-for-now layout only the workspace-root row is ever named — the folder rows live
   inside that one repository, so whatever backs the root up backs them up too.
 

--- a/Code/{{PROJECT}}-docs/runbooks/register-repo.md
+++ b/Code/{{PROJECT}}-docs/runbooks/register-repo.md
@@ -33,9 +33,15 @@ The goal is that the **result** is the same however a repo arrived.
    teammate reproduces the whole workspace from this file; a repo that genuinely cannot move stays
    where it is, with a symlink at that workspace-relative path pointing at the real checkout.
 
-   **`remote:` is recorded if the repo has one** — never created, never repointed. Put nothing
-   after a `- name:`, `location:` or `remote:` value: the readers take the rest of the line as part
-   of it, so a trailing `# note` ends up inside the name, the path or the clone URL.
+   **`remote:` is recorded if the repo has one** — registration records what is there; it never
+   creates a remote and never repoints one. Put nothing after a `- name:`, `location:` or
+   `remote:` value: the readers take the rest of the line as part of it, so a trailing `# note`
+   ends up inside the name, the path or the clone URL.
+
+   **A remote created for a repo that has none is created private** — widening is a separate
+   decision, made deliberately later. Making a repo public takes an explicit instruction from the
+   user naming that repo (`METHOD.md` §7): a licence, a public sibling repo, a remote, or a
+   project that calls itself open source is not that instruction, and neither is silence.
 
    **A repo split out of another is `added_as: created`** — the method made it — with the split
    history in its `provenance:` block, written by

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -442,7 +442,7 @@ if [ "$CHECK_IN" -eq 1 ]; then
         for (i = 1; i <= n; i++) {
           if (locs[i] == "") print "location\t" names[i]
           # Covered by its own remote, or by the remote of a row at "." that contains it.
-          # The location travels with the name: the fix is to push that repo, and a name alone
+          # The location travels with the name: the fix acts on that repo, and a name alone
           # does not say where it is.
           if (rems[i] == "" && !(root && locs[i] != ".")) print "remote\t" names[i] "\t" locs[i]
         }
@@ -459,7 +459,7 @@ if [ "$CHECK_IN" -eq 1 ]; then
     fi
     if [ -n "$no_rem" ]; then
       warn "repo(s) with no remote: $(printf '%s' "$no_rem" | tr '\n' ' ')"
-      hint "a repo with no remote lives on one machine — a bus factor of one. Push it somewhere and record the URL in remote:, or accept the risk deliberately."
+      hint "a repo with no remote lives on one machine — a bus factor of one. Record the URL in remote: if it already has one; if not, create one — private, widening is a separate decision — or accept the risk deliberately."
     fi
     [ -z "$no_loc" ] && [ -z "$no_rem" ] && pass "$rows row(s): all have a location, and a recorded remote covers every one"
   fi

--- a/tests/check-repo-registry.sh
+++ b/tests/check-repo-registry.sh
@@ -161,7 +161,7 @@ mono="$(bootstrap "registry-mono" mono bsd-3)"         || exit 1
 doctor "$multi" --check-in
 note "multi greenfield: $(printf '%s\n' "$SEC" | grep -E '^  \[' | head -1)"
 expect "[WARN] repo(s) with no remote: registry-multi-docs (Code/registry-multi-docs/) prompts (prompts/)" "multi greenfield"
-expect "Push it somewhere and record the URL in remote:" "multi greenfield hint"
+expect "private, widening is a separate decision" "multi greenfield hint"
 refute "[FAIL]" "multi greenfield"
 result OK "multi greenfield"
 [ "$DOC_STATUS" -eq 0 ] || bad "multi greenfield — a WARN must not change the exit code, got $DOC_STATUS"


### PR DESCRIPTION
The rule that a repository is made public only on an explicit instruction landed in `METHOD.md`
and the two templates that touch a repo as it is brought in. It did not land in either of the two
pages that are actually open at the moment a remote gets created: **the registration runbook**,
where a repository is brought into the project, and **the check-in**, where the doctor reports a
repo with no remote and somebody acts on it.

Both told you to push the repo somewhere. Neither said anything about visibility. An agent
following either could have created a public repository nobody asked for — the one act here that
cannot be taken back.

All three now say a remote created for a repo that has none is created **private**, widening being
a separate decision made deliberately later.

### They deliberately do not say the same amount

The registration runbook carries the full rule, because it is where somebody is deciding. The
check-in and the doctor's fix line carry the short form only: the moment they describe is a repo
being *stood up*, not one being *published*, and the longer rule says of itself that it governs the
act of publishing rather than the visibility a repo already carries.

### The doctor was conflating two situations

The check reads `registries/repos.yml` and never looks at git, so an empty `remote:` means either
*a repo whose remote nobody wrote down* or *a repo with none at all* — and the fix line prescribed
the same act for both. It now splits on that and on nothing else. It never asks how the repository
arrived, because that was never what the question turned on.

### One clarifier

`remote:`'s rule read *"recorded if the repo has one — never created, never repointed"*, two lines
above where the new paragraph says a remote can be created. Both were always true — registration
records what is there; creating one is a deliberate act elsewhere, which is why the split runbook
creates a remote and this runbook then records it. The sentence now says which it scopes to.
Unchanged in force.

### Verification

16/16 locally. **The test pin was proved non-vacuous**: run against the unmodified script it fails
(`expected check 10 to report: private, widening is a separate decision`), and `check.sh` was
restored byte-for-byte afterwards. The old pin was a substring that would have survived an
append-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
