### PR TITLE
Print the help again when doctor.sh is run with no arguments

### DIFF
--- a/Code/{{PROJECT}}-docs/scripts/doctor.sh
+++ b/Code/{{PROJECT}}-docs/scripts/doctor.sh
@@ -53,7 +53,8 @@ run_helper() {
 cmd="${1:-help}"
 case "$cmd" in
   -h|--help|help)
-    shift
+    # A bare ./doctor.sh arrives here through the default above, with nothing to shift.
+    [ "$#" -eq 0 ] || shift
     # Trailing arguments after help are the same usage error as an unknown command; printing the
     # help text and exiting 0 told the caller their argument was understood.
     if [ "$#" -gt 0 ]; then

--- a/tests/doctor-dispatcher.sh
+++ b/tests/doctor-dispatcher.sh
@@ -56,19 +56,22 @@ assert_contains "$help_output" "status"
 assert_contains "$help_output" "check"
 assert_contains "$help_output" "links"
 
-# A bare ./doctor.sh is help: the same text on stdout, and exit 0.
-set +e
-bare_output="$("$fixture/doctor.sh" 2>/dev/null)"
-bare_status=$?
-set -e
-[ "$bare_status" -eq 0 ] || {
-  printf 'FAIL: expected bare doctor.sh to exit 0, got %s\n' "$bare_status" >&2
-  exit 1
-}
-[ "$bare_output" = "$help_output" ] || {
-  printf 'FAIL: expected bare doctor.sh to print the help text on stdout, got:\n%s\n' "$bare_output" >&2
-  exit 1
-}
+# A bare call is help: the same text on stdout, and exit 0. Check it at the root wrapper and at
+# the hub dispatcher itself, which the root wrapper setup-workspace.sh writes also execs.
+for entry in doctor.sh Code/acme-docs/scripts/doctor.sh; do
+  set +e
+  bare_output="$("$fixture/$entry" 2>/dev/null)"
+  bare_status=$?
+  set -e
+  [ "$bare_status" -eq 0 ] || {
+    printf 'FAIL: expected bare %s to exit 0, got %s\n' "$entry" "$bare_status" >&2
+    exit 1
+  }
+  [ "$bare_output" = "$help_output" ] || {
+    printf 'FAIL: expected bare %s to print the help text on stdout, got:\n%s\n' "$entry" "$bare_output" >&2
+    exit 1
+  }
+done
 
 # The implemented commands should be thin pass-throughs to the docs-hub helpers.
 output="$("$fixture/doctor.sh" status alpha beta)"

--- a/tests/doctor-dispatcher.sh
+++ b/tests/doctor-dispatcher.sh
@@ -21,9 +21,9 @@ assert_contains() {
 }
 
 # Build a minimal generated-workspace shape with fake helper scripts. The dispatcher test
-# cares that doctor.sh finds and execs the right helper while forwarding any extra arguments;
-# status.sh and check.sh behavior is covered by their own tests (tests/status-*.sh,
-# tests/check-repo-registry.sh).
+# cares that doctor.sh finds and execs the right helper, forwarding any extra arguments and
+# handing back its exit code; status.sh and check.sh behavior is covered by their own tests
+# (tests/status-*.sh, tests/check-repo-registry.sh).
 fixture="$TMP_ROOT/workspace"
 mkdir -p "$fixture/Code/acme-docs/scripts"
 cp -p "$ROOT/doctor.sh" "$fixture/doctor.sh"
@@ -39,6 +39,7 @@ chmod +x "$fixture/Code/acme-docs/scripts/status.sh"
 cat > "$fixture/Code/acme-docs/scripts/check.sh" <<'CHECK'
 #!/usr/bin/env bash
 printf 'check helper: %s\n' "$*"
+exit "${FAKE_CHECK_EXIT:-0}"
 CHECK
 chmod +x "$fixture/Code/acme-docs/scripts/check.sh"
 
@@ -55,6 +56,20 @@ assert_contains "$help_output" "status"
 assert_contains "$help_output" "check"
 assert_contains "$help_output" "links"
 
+# A bare ./doctor.sh is help: the same text on stdout, and exit 0.
+set +e
+bare_output="$("$fixture/doctor.sh" 2>/dev/null)"
+bare_status=$?
+set -e
+[ "$bare_status" -eq 0 ] || {
+  printf 'FAIL: expected bare doctor.sh to exit 0, got %s\n' "$bare_status" >&2
+  exit 1
+}
+[ "$bare_output" = "$help_output" ] || {
+  printf 'FAIL: expected bare doctor.sh to print the help text on stdout, got:\n%s\n' "$bare_output" >&2
+  exit 1
+}
+
 # The implemented commands should be thin pass-throughs to the docs-hub helpers.
 output="$("$fixture/doctor.sh" status alpha beta)"
 assert_contains "$output" "status helper: alpha beta"
@@ -64,6 +79,17 @@ assert_contains "$output" "check helper: --verbose"
 
 output="$("$fixture/doctor.sh" links --sample)"
 assert_contains "$output" "links helper: --sample"
+
+# A helper's exit code is the caller's verdict — check.sh exits non-zero on a FAIL — so the
+# dispatcher must hand it back unchanged.
+set +e
+FAKE_CHECK_EXIT=3 "$fixture/doctor.sh" check > /dev/null
+check_status=$?
+set -e
+[ "$check_status" -eq 3 ] || {
+  printf 'FAIL: expected doctor.sh check to return the helper exit code 3, got %s\n' "$check_status" >&2
+  exit 1
+}
 
 # Multi-repo workspace roots are per-machine and not committed, so setup-workspace.sh must
 # regenerate the root dispatcher for later developers' machines.
@@ -89,5 +115,16 @@ set -e
   exit 1
 }
 assert_contains "$unknown_output" "unknown command: nope"
+
+# Help takes no arguments; a trailing one is the same usage error as an unknown command.
+set +e
+help_extra_output="$("$fixture/doctor.sh" help extra 2>&1)"
+help_extra_status=$?
+set -e
+[ "$help_extra_status" -eq 2 ] || {
+  printf 'FAIL: expected help with a trailing argument to exit 2, got %s\n' "$help_extra_status" >&2
+  exit 1
+}
+assert_contains "$help_extra_output" "doctor.sh: unknown command: extra"
 
 echo "doctor.sh dispatcher: PASS"


### PR DESCRIPTION
## What was wrong

A bare `./doctor.sh` — the first command a new contributor types at the workspace root — printed
nothing and exited 1. The dispatcher defaults its command to `help`, but the help arm then ran
`shift` on an empty argument list, and under `set -euo pipefail` that exits before the usage text
prints. `./doctor.sh help` was unaffected, and 1.7.1 printed the help; the break came in on this
line with the change that made `help` reject a trailing argument.

The dispatcher's test could not have caught it, and could not catch a dispatcher that swallows a
helper's exit code either: it read stdout only, and every fake helper exited 0.

## What changed

- **`Code/{{PROJECT}}-docs/scripts/doctor.sh`** — the help arm shifts only when there is a command
  word to shift. A bare call prints the same help on stdout as `./doctor.sh help` and exits 0;
  `./doctor.sh help extra` still exits 2 with `doctor.sh: unknown command: extra`. The
  workspace-root `doctor.sh` and the wrapper `setup-workspace.sh` writes only `exec` this
  dispatcher, so they get the fix unedited.
- **`tests/doctor-dispatcher.sh`** — three new assertions:
  - a bare call exits 0 and its stdout is identical to the help text, both through the root
    wrapper and at the hub dispatcher that every root wrapper execs;
  - `help extra` exits 2 with its message (nothing pinned it before);
  - a helper's exit code reaches the caller: the fake `check.sh` exits with a code taken from the
    environment, and `./doctor.sh check` must return that code.

## Release notes

None. Against 1.7.1 nothing changes for anyone: a bare `./doctor.sh` printed the help then and
prints it at release. The 1.8 notes already say every valid invocation is untouched — false on this
line until now, true after it.

## Proof

**Each new assertion fails against the code it guards.** Every case ran in a fresh local clone of
this branch, with the dispatcher changed there and left uncommitted, running
`env -u CI tests/doctor-dispatcher.sh`:

1. Dispatcher as on `repo-record` (unfixed) → `FAIL: expected bare doctor.sh to exit 0, got 1`.
   The test as on `repo-record` passes against it.
2. The help arm's shift replaced with `set --` (a bare call still prints help, but `help extra`
   exits 0) → `FAIL: expected help with a trailing argument to exit 2, got 0`. The old test passes.
3. `exec "$script" "$@"` replaced with `"$script" "$@" || true; return 0` →
   `FAIL: expected doctor.sh check to return the helper exit code 3, got 0`. The old test passes.
4. The help default moved into the root wrapper (`exec "$script" "${@:-help}"`) and the hub's
   guard reverted to a bare `shift` → `FAIL: expected bare Code/acme-docs/scripts/doctor.sh to
   exit 0, got 1`. A bare call through the root wrapper still works there, so an assertion made
   only through it passes — but the root wrapper `setup-workspace.sh` writes has no such default,
   so a multi project on a second machine would be broken again.
5. This branch unchanged → `doctor.sh dispatcher: PASS`.

**By hand, in freshly generated projects** (mono, and multi before and after running
`setup-workspace.sh`, which rewrites the root wrapper): a bare `./doctor.sh` at the workspace root
exits 0, writes nothing to stderr, and prints stdout byte-identical to `./doctor.sh help`;
`./doctor.sh help extra` exits 2.

**Suite:** all 16 `tests/*.sh` pass locally (`env -u CI`); the branch's CI run logs one `PASS` line for each of the 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
