### PR TITLE
Stop link-checking imported documents in inputs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,16 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **A broken link in an imported document no longer keeps the link check red for good.**
+  `./doctor.sh links` checked every Markdown file in the docs hub except `templates/`, and that
+  included `inputs/` — the documents brought in from outside the method, which it keeps as they
+  arrived and, once superseded, moves to `inputs/archive/` rather than editing. A copied spec with
+  a relative link to a path the workspace does not have failed the check, nothing the method
+  allows could clear it, and moving the file to the archive changed nothing. `scripts/links.sh`
+  now skips `inputs/` and everything under it, and its printed scope says so; a link *to* an input
+  from a file it does check is still checked. `AGENTS.md`, `ONBOARDING.md`, `inputs/README.md` and
+  `runbooks/splitting-repos.md` each gain a sentence saying imported documents are not
+  link-checked.
 - **Seven documents still glued `private` and `proprietary` into one word, and two of them
   described a wizard question that no longer exists.** 1.8 split the two deliberately —
   `private` is who can see the repository, `proprietary` is what the code is licensed under, and

--- a/Code/{{PROJECT}}-docs/AGENTS.md
+++ b/Code/{{PROJECT}}-docs/AGENTS.md
@@ -140,6 +140,8 @@ README and CI scaffolding, and writes `LICENSING.md` to make those scopes explic
 then clones the siblings). From the workspace root, `./doctor.sh status`, `./doctor.sh check`, and
 `./doctor.sh links` are thin shortcuts to `Code/{{PROJECT}}-docs/scripts/status.sh`,
 `Code/{{PROJECT}}-docs/scripts/check.sh`, and `Code/{{PROJECT}}-docs/scripts/links.sh`.
+`./doctor.sh links` does not check `Code/{{PROJECT}}-docs/inputs/`: imported documents are kept
+as they arrived, broken links included.
 New human or agent contributor joining an existing project? Read
 `Code/{{PROJECT}}-docs/ONBOARDING.md` for the ordered setup and first-contribution STEP path.
 It covers later contributor onboarding; initial project bootstrap still starts from `./init.sh`.

--- a/Code/{{PROJECT}}-docs/ONBOARDING.md
+++ b/Code/{{PROJECT}}-docs/ONBOARDING.md
@@ -94,6 +94,9 @@ Then run the local checks from the workspace root:
 ./doctor.sh links
 ```
 
+`./doctor.sh links` does not check `Code/<project>-docs/inputs/`: imported documents are kept as
+they arrived, broken links included.
+
 Use `./doctor.sh status` as the source of the next action. It reads the project state from
 disk and applies the next-action resolver from `METHOD.md`. Confirm its result against
 `prompts/STEP-index.md`, and if a STEP is already in progress, read its PLAN in

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -175,6 +175,16 @@ swept by the check-in either way — `runbooks/check-in.md`'s conditional-sessio
 enumerates every conditional template and asks for a current disposition each time, without
 consulting the STEP-1 row.
 
+**The link checker no longer reads `inputs/`, and there is nothing for you to do.** A document
+copied into `inputs/` or `inputs/archive/` with a relative link to a path your workspace does not
+have used to fail `./doctor.sh links` for good: the method keeps inputs as they arrived, so there
+was nothing you were allowed to fix, and moving the file to the archive changed nothing.
+`scripts/links.sh` now skips that folder and everything under it, as it already skipped
+`templates/`, so a link check that was red only for that reason goes green with nothing of yours
+changed. A link *to* an input from a doc it does check is still checked. `AGENTS.md`,
+`ONBOARDING.md` §4, `inputs/README.md` and `runbooks/splitting-repos.md` each gain one sentence
+saying so.
+
 **`private` and `proprietary` now mean two different things, and if you script `init.sh` there is
 one rename.** `private` refers to repository visibility and nothing else; `proprietary` is the
 licence posture. They were the same word in two unrelated questions — the licence question offered

--- a/Code/{{PROJECT}}-docs/inputs/README.md
+++ b/Code/{{PROJECT}}-docs/inputs/README.md
@@ -66,6 +66,8 @@ Two things keep this from rotting:
 - These are **your source materials, not method output** — unlike `../architecture/` (*what*
   the system is) and `../adr/` (*why*), nothing here is versioned or rewritten by the sessions (a
   superseded input is *moved* to `inputs/archive/`, never edited in place — see Lifecycle above).
+  For the same reason `./doctor.sh links` does not check this folder: a broken link in an input
+  stays as it arrived.
 - `inputs-index.md` (the live-vs-superseded ledger) and this `README.md` are **guidance, not
   inputs** — a session never treats them as source documents.
 - The folder is **durable and not STEP-1-only**: a later phase, a V2, or a check-in can add

--- a/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
+++ b/Code/{{PROJECT}}-docs/runbooks/splitting-repos.md
@@ -333,8 +333,9 @@ special here, which is why it gets no steps of its own below.
    boundary decision, and step 9's build-and-test is what fails if it was not made.
    **This step is not optional and is the easiest one to skip:** the hub's link checker
    resolves link targets into the code repos, so a *correct* split makes hub links dangle —
-   `scripts/links.sh` fails on a finished split and passes on an unfinished one. Step 7 is what
-   makes step 9 satisfiable.
+   `scripts/links.sh` fails on a finished split and passes on an unfinished one. It does not
+   check the hub's `inputs/`, whose imported documents are kept as they arrived: a hit in one of
+   them is history you keep, not a repoint. Step 7 is what makes step 9 satisfiable.
 8. **Register it** — run the register action (`runbooks/register-repo.md`), which writes the row
    and the Architecture Overview entry. **Add a `provenance:` block to that row before
    the action commits**, so the registration stays one commit: the repo it came from, today's

--- a/Code/{{PROJECT}}-docs/scripts/links.sh
+++ b/Code/{{PROJECT}}-docs/scripts/links.sh
@@ -3,9 +3,10 @@
 # links.sh — read-only stale-link checker for durable Throughstone documentation.
 #
 # Scope is intentionally narrow: root pointer/readme/artifact-tour files and durable docs-hub Markdown.
-# It skips prompts/, Upcoming Prompts/, templates/, app repos, links outside the local
+# It skips prompts/, Upcoming Prompts/, templates/, inputs/, app repos, links outside the local
 # workspace, and all external URLs so the result stays useful as a cheap check-in/CI guard
-# instead of becoming a noisy site crawler.
+# instead of becoming a noisy site crawler. inputs/ holds imported documents, which are kept as
+# they arrived, so a broken link inside one is not something anyone may fix.
 #
 # Usage:  from anywhere — Code/<project>-docs/scripts/links.sh
 # Exit:   non-zero if any scoped Markdown file links to a missing local path or anchor.
@@ -63,12 +64,9 @@ def scoped_markdown_files():
         candidate = root / name
         if candidate.is_file():
             files.append(candidate)
-    template_dir = docs_dir / "templates"
+    skipped_dirs = (docs_dir / "templates", docs_dir / "inputs")
     for candidate in sorted(docs_dir.rglob("*.md")):
-        try:
-            candidate.relative_to(template_dir)
-            continue
-        except ValueError:
+        if not any(skipped in candidate.parents for skipped in skipped_dirs):
             files.append(candidate)
     return files
 
@@ -399,7 +397,7 @@ print(f"Throughstone links — {root}")
 print()
 print("Scope:")
 print("  root AGENTS.md / CLAUDE.md / README.md / ARTIFACT-TRAIL.md when present")
-print(f"  {rel(docs_dir)}/**/*.md except templates/")
+print(f"  {rel(docs_dir)}/**/*.md except templates/ and inputs/")
 print("  prompts/, Upcoming Prompts/, app repos, external URLs, and paths outside the workspace are skipped")
 print()
 

--- a/tests/links.sh
+++ b/tests/links.sh
@@ -22,6 +22,7 @@ fixture="$TMP_ROOT/workspace"
 mkdir -p "$fixture/Code/acme-docs/scripts" \
   "$fixture/Code/acme-docs/runbooks" \
   "$fixture/Code/acme-docs/templates" \
+  "$fixture/Code/acme-docs/inputs/archive" \
   "$fixture/prompts" \
   "$fixture/Upcoming Prompts"
 
@@ -90,6 +91,22 @@ cat > "$fixture/Code/acme-docs/templates/generated.md" <<'TEMPLATE'
 
 This generated-context link should not be checked here: [future file](future-output.md).
 TEMPLATE
+
+# Imported documents are kept as they arrived, so a broken link in one must not fail the run. Each
+# link climbs out of inputs/ and lands on a missing path inside the workspace; one above the
+# workspace root is skipped anyway and would prove nothing. A superseded input is moved to
+# inputs/archive/, so that file stops a skip that covers only the top of inputs/.
+cat > "$fixture/Code/acme-docs/inputs/imported.md" <<'INPUT'
+# Imported Spec
+
+See [the service spec](../../../src/spec.md).
+INPUT
+
+cat > "$fixture/Code/acme-docs/inputs/archive/retired.md" <<'ARCHIVED'
+# Retired Spec
+
+See [the old service spec](../../../../src/spec.md).
+ARCHIVED
 
 cat > "$fixture/prompts/legacy.md" <<'PROMPTS'
 [legacy missing](missing.md)


### PR DESCRIPTION
## Summary

- `./doctor.sh links` checked every Markdown file in the docs hub except `templates/`. A document copied into `inputs/`, or moved to `inputs/archive/`, with a relative link to a path the workspace does not have failed the check for good. The method keeps inputs as they arrived, so there was no allowed way to clear the failure.
- `scripts/links.sh` now skips `inputs/` and everything under it. The change is made in three places: the code, the header comment and the printed scope line. A link *to* an input from a file the checker reads is still checked.
- `AGENTS.md`, `ONBOARDING.md` §4, `inputs/README.md` and `runbooks/splitting-repos.md` each gain one sentence saying imported documents are not link-checked. In the splitting runbook, the sentence also says that a grep hit inside an imported document is history you keep, not a line to repoint.
- Release notes: a `CHANGELOG.md` entry under Fixed, and an `UPDATING-THROUGHSTONE.md` paragraph in the 1.8 migration section. That paragraph says there is nothing to do, so the section's running count stays the same.

## Before and after

On `repo-record`, in a scaffold copy with `inputs/imported.md` linking to `../../../src/spec.md`:

```
  [FAIL] Code/{{PROJECT}}-docs/inputs/imported.md:3 links to missing file: ../../../src/spec.md
  RESULT: FAIL
```

It exits 1, and still fails after the file is moved to `inputs/archive/`. On this branch, with that file plus a second one in `inputs/archive/`:

```
  Code/{{PROJECT}}-docs/**/*.md except templates/ and inputs/
  [PASS] 104 scoped local link(s) resolve
  RESULT: OK
```

It exits 0. A broken link added to `architecture/` in the same copy still fails.

## Test plan (proved by mutation)

`tests/links.sh` gains two fixture files, `Code/acme-docs/inputs/imported.md` and `Code/acme-docs/inputs/archive/retired.md`. Each links to a missing path inside the workspace, and both come before the clean-run `RESULT: OK` assertion. Each run below used a local clone of this branch:

- [x] Unchanged: `links.sh: PASS`, exit 0
- [x] `links.sh` restored from `repo-record`: exit 1
- [x] Skip only the files directly in `inputs/`: exit 1 (the archive file catches it)
- [x] Skip only `inputs/archive/`: exit 1 (the top-level file catches it)
- [x] Full suite locally: all 16 `tests/*.sh` pass
- [x] CI: one `PASS` line for each of the 16 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
