### PR TITLE
Fail the check-in, and clone nothing, when a registry row cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,9 @@ any project built with it.
   checks that belong to the periodic check-in rather than to every run — today, one. Check 10 reads
   `registries/repos.yml` and makes two mechanical checks and only those two. **A row with no
   `location:` fails the run**, because nothing can find that repo and guessing a path is worse than
-  asking. **A repo that no recorded remote covers is a warning**, because as far as the project knows
+  asking — **and so does a row the doctor cannot read**: it finds a row by its `- name:` line, counts
+  the list's entries apart from that, and fails when the two disagree rather than pass over a repo
+  it never saw. **A repo that no recorded remote covers is a warning**, because as far as the project knows
   that work lives on exactly one laptop. A row is covered by its own `remote:`, or by the root
   repository's when it lives inside it — in a mono-repo-for-now project the row whose `location` is
   `.` is the one real repository and the folder rows below it are backed up by whatever backs it up,
@@ -403,6 +405,13 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **The workspace setup no longer clones from a registry it cannot fully read.**
+  `scripts/setup-workspace.sh` finds a row by its `- name:` line, so a row written any other way —
+  starting on a bare `-`, or with another field first — was not read, and its fields landed on the
+  row above it: that repo was never cloned and nothing said so, or one repo's remote was cloned into
+  another repo's location. It now counts the list's entries apart from the rows it reads, and when
+  the two disagree it clones nothing and says to fix the row; the workspace's pointer files are
+  still written.
 - **A broken link in an imported document no longer keeps the link check red for good.**
   `./doctor.sh links` checked every Markdown file in the docs hub except `templates/`, and that
   included `inputs/` — the documents brought in from outside the method, which it keeps as they

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -386,14 +386,14 @@ has is on your machine, nothing about these three changes for you.
 you pass the new **`--check-in`** flag. A plain `./doctor.sh check` prints the section as
 `skipped`, and CI never passes the flag, so nothing about the registry can fail a build on a push.
 `runbooks/check-in.md` is what passes it: the check-in's mechanical pass now runs
-`Code/<project>-docs/scripts/check.sh --check-in` from the workspace root. There are two findings
+`Code/<project>-docs/scripts/check.sh --check-in` from the workspace root. It checks two things
 and only two:
 
 - **A row with no `location:` fails the run.** Nothing can find that repo without one. Ask whoever
   knows where it lives and write the path in; do not guess one. **So does a row the doctor cannot
   read** — one that does not start with its `- name:` line, which leaves its fields on the row
-  above; the doctor counts the list's entries to know it read them all. This is the only registry
-  finding that can turn a check-in red, and a 1.7 registry cannot produce it unless a row was
+  above; the doctor counts the list's entries to know it read them all. These are the only registry
+  findings that can turn a check-in red, and a 1.7 registry cannot produce either unless a row was
   hand-edited.
 - **A repo that no recorded remote covers is a warning**, named row by row: as far as the project
   knows, that repo's work lives on exactly one laptop. **Most 1.7 projects will see this at their

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -390,8 +390,11 @@ you pass the new **`--check-in`** flag. A plain `./doctor.sh check` prints the s
 and only two:
 
 - **A row with no `location:` fails the run.** Nothing can find that repo without one. Ask whoever
-  knows where it lives and write the path in; do not guess one. This is the only registry finding
-  that can turn a check-in red, and a 1.7 registry cannot produce it unless a row was hand-edited.
+  knows where it lives and write the path in; do not guess one. **So does a row the doctor cannot
+  read** — one that does not start with its `- name:` line, which leaves its fields on the row
+  above; the doctor counts the list's entries to know it read them all. This is the only registry
+  finding that can turn a check-in red, and a 1.7 registry cannot produce it unless a row was
+  hand-edited.
 - **A repo that no recorded remote covers is a warning**, named row by row: as far as the project
   knows, that repo's work lives on exactly one laptop. **Most 1.7 projects will see this at their
   first check-in after upgrading**, because a 1.7 registry ships two rows with no `remote:`, and
@@ -456,6 +459,12 @@ needs undoing first: repos already cloned are left alone, the pointer files are 
 and the run now finishes whatever happens to the clones. Its closing line says how many repos did not
 arrive, so fix the `remote:` or `location:` in `registries/repos.yml` — or clone that one repo by
 hand — and re-run to pick it up.
+
+**Multi-repo only: the same script now clones nothing from a registry with a row it cannot read.**
+It reads a row only from its `- name:` line. A row that starts any other way used to be passed over
+without a word, its fields landing on the row above — so one repo never arrived, or another repo's
+remote was cloned into its folder. The run now says so instead; fix that row and run it again. A 1.7
+registry cannot produce this unless a row was hand-edited.
 
 **A `location:` that points outside the workspace root stops working, and 1.7 told you it was
 allowed.** 1.7's `registries/repos.yml` header said a `location:` MAY point outside the `Code/*`

--- a/Code/{{PROJECT}}-docs/runbooks/check-in.md
+++ b/Code/{{PROJECT}}-docs/runbooks/check-in.md
@@ -74,7 +74,8 @@ with its current version/status).
 comparison above — the rows against the repos that actually exist.
 
 - **A row with no `location:`** fails the run. Ask the human where that repo lives and write it
-  into the row; don't guess a path.
+  into the row; don't guess a path. **So does a row the doctor cannot read** — one that does not
+  start with its `- name:` line; show the human that row.
 - **A row with no `remote:` recorded** is a warning: as far as the project knows, that repo's
   work lives on exactly one laptop. If the repo already has a remote, record the URL. If it has
   none, give it one — **created private**, widening being a separate decision made deliberately

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -437,7 +437,7 @@ if [ "$CHECK_IN" -eq 1 ]; then
         have = 0
       }
       /^[[:space:]]*#/ { next }
-      /^[[:space:]]*-([[:space:]]|$)/ { entries++ }
+      /^[[:space:]]*-[[:space:]]/ || /^[[:space:]]*-$/ { entries++ }
       /^[[:space:]]*-[[:space:]]*name:/ { stash(); name = val($0); loc = ""; rem = ""; have = 1; next }
       /^[[:space:]]*location:/ { loc = val($0) }
       /^[[:space:]]*remote:/   { rem = val($0) }

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -16,8 +16,8 @@
 #   7. (multi-repo only) No stray files at the workspace root
 #   8. Architecture-session template numbers match the STEP-index seed
 #   9. Conditional-session templates expose the metadata generic review gates require
-#  10. (--check-in only) Every registries/repos.yml row has a location, and any repo no
-#      recorded remote covers is flagged as a bus-factor risk
+#  10. (--check-in only) Every registries/repos.yml row can be read and has a location, and
+#      any repo no recorded remote covers is flagged as a bus-factor risk
 #
 # The registry changes on the rare path — a repo created, adopted or split out — so it is not
 # validated on every run. Pass --check-in; runbooks/check-in.md is what does.
@@ -424,7 +424,10 @@ if [ "$CHECK_IN" -eq 1 ]; then
   else
     # Walk each `- name:` block and report the rows missing a location, and the rows no
     # recorded remote covers. Comment lines are skipped, so the example row at the bottom is not
-    # counted. A row is found by its `- name:` line, so a row without one is not a row at all.
+    # counted. A row is found by its `- name:` line, so a row written any other way is not read,
+    # and its fields land on the row above it. Every list entry is therefore counted apart from
+    # the walk, under the same comment rule, and a registry whose two counts disagree fails: the
+    # other findings may then name the wrong repo, and nothing can say where the unread one lives.
     reg_flat="$(awk '
       function val(t) { sub(/^[^:]*:[[:space:]]*"?/, "", t); sub(/"?[[:space:]]*$/, "", t); return t }
       function stash() {
@@ -434,11 +437,13 @@ if [ "$CHECK_IN" -eq 1 ]; then
         have = 0
       }
       /^[[:space:]]*#/ { next }
+      /^[[:space:]]*-([[:space:]]|$)/ { entries++ }
       /^[[:space:]]*-[[:space:]]*name:/ { stash(); name = val($0); loc = ""; rem = ""; have = 1; next }
       /^[[:space:]]*location:/ { loc = val($0) }
       /^[[:space:]]*remote:/   { rem = val($0) }
       END {
         stash()
+        print "count\t" (n + 0) "\t" (entries + 0)
         for (i = 1; i <= n; i++) {
           if (locs[i] == "") print "location\t" names[i]
           # Covered by its own remote, or by the remote of a row at "." that contains it.
@@ -449,10 +454,15 @@ if [ "$CHECK_IN" -eq 1 ]; then
       }
     ' "$REPOS_REGISTRY")"
 
-    rows="$(awk '/^[[:space:]]*#/ { next } /^[[:space:]]*-[[:space:]]*name:/ { n++ } END { print n + 0 }' "$REPOS_REGISTRY")"
+    rows="$(printf '%s\n' "$reg_flat" | awk -F'\t' '$1 == "count" { print $2 }')"
+    entries="$(printf '%s\n' "$reg_flat" | awk -F'\t' '$1 == "count" { print $3 }')"
     no_loc="$(printf '%s\n' "$reg_flat" | awk -F'\t' '$1 == "location" { print $2 }')"
     no_rem="$(printf '%s\n' "$reg_flat" | awk -F'\t' '$1 == "remote"   { print $2 " (" $3 ")" }')"
 
+    if [ "$rows" != "$entries" ]; then
+      fail "read $rows of $entries row(s) — a row is read only from its - name: line"
+      hint "start every row with its - name: line, then run the check again; until the two numbers match, the other findings here may name the wrong repo."
+    fi
     if [ -n "$no_loc" ]; then
       fail "row(s) with no location: $(printf '%s' "$no_loc" | tr '\n' ' ')"
       hint "give every row a location: — the workspace-relative path the repo lives at; without one, nothing can find the repo."
@@ -461,7 +471,7 @@ if [ "$CHECK_IN" -eq 1 ]; then
       warn "repo(s) with no remote: $(printf '%s' "$no_rem" | tr '\n' ' ')"
       hint "a repo with no remote lives on one machine — a bus factor of one. Record the URL in remote: if it already has one; if not, create one — private, widening is a separate decision — or accept the risk deliberately."
     fi
-    [ -z "$no_loc" ] && [ -z "$no_rem" ] && pass "$rows row(s): all have a location, and a recorded remote covers every one"
+    [ "$rows" = "$entries" ] && [ -z "$no_loc" ] && [ -z "$no_rem" ] && pass "$rows row(s): all have a location, and a recorded remote covers every one"
   fi
 else
   hdr "10. Repo registry ($DOCS_REL/registries/repos.yml)"

--- a/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
+++ b/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
@@ -86,7 +86,22 @@ mkdir -p "$ROOT/.throughstone"
 # than aborting the run.
 REG="$DOCS_DIR/registries/repos.yml"
 missing=0
-if [ -f "$REG" ]; then
+# A row is found by its `- name:` line, so a row written any other way is not read, and its fields
+# land on the row above it: that repo never arrives, or one repo's remote is cloned into another
+# repo's location. So every list entry is also counted on its own, under the same comment rule, and
+# when the two counts disagree nothing is cloned. The awk succeeds only on that disagreement; a
+# registry it cannot read goes on to the clone step, whose parse is not fatal either.
+if [ ! -f "$REG" ]; then
+  echo "No $DOCS_REL/registries/repos.yml — skipping clone step."
+elif awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*-([[:space:]]|$)/ { entries++ }
+    /^[[:space:]]*-[[:space:]]*name:/ { rows++ }
+    END { exit (entries == rows) }
+  ' "$REG" 2>/dev/null; then
+  echo "Not cloning: a row in $DOCS_REL/registries/repos.yml does not start with its - name: line, so"
+  echo "one repo could land at another's location. Fix that row, then re-run this script."
+else
   echo "Cloning sibling repos with remotes from $DOCS_REL/registries/repos.yml ..."
   # Parse repos.yml block-aware: pair each repo's own location with its own remote.
   # The registry is the multi-repo inventory, and remote: is optional. Walking each `- name:`
@@ -135,8 +150,6 @@ if [ -f "$REG" ]; then
     /^[[:space:]]*remote:/   { rem=$0; sub(/^[^:]*:[[:space:]]*"?/,"",rem); sub(/"?[[:space:]]*$/,"",rem) }
     END { if (loc != "" && rem != "") print loc "|" rem }
   ' "$REG")
-else
-  echo "No $DOCS_REL/registries/repos.yml — skipping clone step."
 fi
 
 echo "Done. Open this folder in your agent; it will discover the context via the pointers."

--- a/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
+++ b/Code/{{PROJECT}}-docs/scripts/setup-workspace.sh
@@ -83,7 +83,8 @@ mkdir -p "$ROOT/.throughstone"
 # Nothing in this step is allowed to be fatal. A contributor who cannot reach one repository —
 # or whose registry names a path this workspace has no business writing to — must still end up
 # with a usable workspace, so every repo that does not arrive is reported and counted rather
-# than aborting the run.
+# than aborting the run. A registry with a row that cannot be read is the one exception to the
+# count: it is reported once, and nothing in it is cloned.
 REG="$DOCS_DIR/registries/repos.yml"
 missing=0
 # A row is found by its `- name:` line, so a row written any other way is not read, and its fields
@@ -95,7 +96,7 @@ if [ ! -f "$REG" ]; then
   echo "No $DOCS_REL/registries/repos.yml — skipping clone step."
 elif awk '
     /^[[:space:]]*#/ { next }
-    /^[[:space:]]*-([[:space:]]|$)/ { entries++ }
+    /^[[:space:]]*-[[:space:]]/ || /^[[:space:]]*-$/ { entries++ }
     /^[[:space:]]*-[[:space:]]*name:/ { rows++ }
     END { exit (entries == rows) }
   ' "$REG" 2>/dev/null; then

--- a/tests/check-repo-registry.sh
+++ b/tests/check-repo-registry.sh
@@ -15,15 +15,16 @@
 # what a FAIL means — so it is asserted beside the section, never instead of it. A missing
 # remote is a WARN and leaves the exit code at 0, so $? alone would not see that finding at all.
 #
-# Pinned on purpose, so a red assertion is known to be real: the two hint sentences, which are
-# the check's only actionable advice and one of which carries an ordering decision — push first,
-# record the URL after — and the row count in the pass line. Names are listed in registry order
-# and asserted as they fall out; a walk that reorders them shows up here.
+# Pinned on purpose, so a red assertion is known to be real: the hint sentences, which are the
+# check's only actionable advice, and the row counts in the pass line and in the failure for a
+# row the check did not read. Names are listed in registry order and asserted as they fall out; a
+# walk that reorders them shows up here.
 #
 # Deliberately absent, and not an oversight to fill in: anything asserting the registry's shape
-# — the check reads two fields and does not police the file, so a malformed row is fixed by
-# whoever just edited it — and the no-registry branch, which has no logic in it and reports a
-# conspicuous state to someone already reading the output. This file grows only if the check does.
+# beyond whether every row was read — the check reads two fields and does not police the file, so
+# a malformed row is fixed by whoever just edited it — and the no-registry branch, which has no
+# logic in it and reports a conspicuous state to someone already reading the output. This file
+# grows only if the check does.
 
 set -uo pipefail
 export LC_ALL=C
@@ -243,6 +244,49 @@ expect "2 row(s): all have a location, and a recorded remote covers every one" "
 refute "registry-multi-parked" "a row commented out by hand is not read"
 refute "registry-multi-api" "the example row repos.yml ships is not read"
 clean "commented rows are not counted"
+
+# --- 6. A row the check did not read fails --------------------------------------
+# A row is found by its `- name:` line, so a row written any other way is not read, and its
+# fields land on the row above it. Every list entry is counted apart from that walk, and a
+# registry whose two counts disagree fails. Each registry below holds two repos and is read as
+# fewer; the third, where only one row is out of order, is the shape a check for zero rows or a
+# bare `-` would still pass.
+unread() {
+  local label="$1" pin="$2"
+  cat > "$(registry_of "$multi")"
+  doctor "$multi" --check-in
+  expect "[FAIL] $pin" "$label"
+  expect "start every row with its - name: line" "$label hint"
+  refute "all have a location" "$label"
+  result FAIL "$label"
+  [ "$DOC_STATUS" -eq 1 ] || bad "$label — expected exit 1, got $DOC_STATUS"
+}
+
+unread "every row starts with its location" "read 0 of 2 row(s)" <<'YAML'
+repos:
+  - location: "Code/alpha/"
+    name: "alpha"
+  - location: "Code/beta/"
+    name: "beta"
+YAML
+
+unread "the second row starts on a bare dash" "read 1 of 2 row(s)" <<'YAML'
+repos:
+  - name: "alpha"
+    location: "Code/alpha/"
+  -
+    name: "beta"
+    location: "Code/beta/"
+YAML
+
+unread "only the second row is out of order" "read 1 of 2 row(s)" <<'YAML'
+repos:
+  - name: "alpha"
+    location: "Code/alpha/"
+    remote: "git@example.com:TEAM/alpha.git"
+  - location: "Code/beta/"
+    name: "beta"
+YAML
 
 if [ "$failures" -ne 0 ]; then
   printf 'check.sh repo registry check: %d FAILURE(S)\n' "$failures" >&2

--- a/tests/check-repo-registry.sh
+++ b/tests/check-repo-registry.sh
@@ -224,11 +224,14 @@ clean "default run"
 
 # --- 5. A commented row is not a row --------------------------------------------
 # repos.yml ships a fully formed example row inside a comment block, and someone editing the
-# file comments rows in and out. Neither is a repo the project has. The block appended here is
-# missing everything the check looks for, so a reader that stopped anchoring its patterns to
-# the start of the line would report it — and the count would move off the two real rows.
+# file comments rows in and out. Neither is a repo the project has. Every pattern the check
+# matches is anchored to the start of the line, so the comment skip in front of them is a second
+# guard: the block appended here is reported only by a reader that has lost both, and the count
+# would move off the two real rows. A value that mentions `- name:` is not a row either, and it
+# is what a row pattern that has lost its anchor alone trips on.
 set_field "$multi" "prompts" location "prompts/"
 set_field "$multi" "registry-multi-docs" remote "git@example.com:TEAM/registry-multi-docs.git"
+set_field "$multi" "prompts" description "A value that mentions - name: is not a row"
 cat >> "$(registry_of "$multi")" <<'YAML'
 
   # Parked while we decide whether to split this out:

--- a/tests/setup-workspace-resilience.sh
+++ b/tests/setup-workspace-resilience.sh
@@ -18,7 +18,9 @@
 # directory — whenever the path happened to be writable. Those cases
 # assert the absence of a clone, not just the presence of a message. One case is the other side
 # of the same rule: a repo that cannot move is reached through a symlink at a workspace-relative
-# location, and that must still be left alone.
+# location, and that must still be left alone. Another is about which row a clone belongs to: a
+# registry with a row the parser cannot read clones nothing, since that row's fields sit under
+# the row above it.
 #
 # Assertions read the output as well as the exit status: after this change almost everything
 # exits 0, so a test that only looked at $? could not tell a clone from a refusal.
@@ -522,6 +524,35 @@ run_setup "$tw"
 assert_assembled "vendored location" "$tw"
 assert_cloned "vendored location" "$tw/vendor/partner-lib"
 assert_not_out "vendored location" "did not arrive"
+
+# A row is read from its `- name:` line. This registry's second row starts on a bare `-`, so it is
+# not read, and its fields overwrite the first row's: the first repo would never arrive and nothing
+# would say so, and a row out of order the same way pairs one repo's remote with another's location.
+# When the list's entries and the rows read disagree, nothing is cloned — assert both locations
+# stay empty, not just the message.
+echo "A registry row that does not start with its - name: line ..."
+tw="$(teammate unreadrow "$MULTI_DOCS")"
+add_row "$tw" <<EOF
+
+  - name: "multi-api"
+    location: "Code/multi-api/"
+    type: service
+    added_as: created
+    remote: "$REACHABLE"
+    description: "A row the parser reads."
+  -
+    name: "multi-web"
+    location: "Code/multi-web/"
+    type: app
+    added_as: created
+    remote: "$REACHABLE"
+    description: "A row that starts on a bare dash."
+EOF
+run_setup "$tw"
+assert_assembled "unread row" "$tw"
+assert_out "unread row" "does not start with its - name: line"
+assert_not_cloned "unread row" "$tw/Code/multi-api"
+assert_not_cloned "unread row" "$tw/Code/multi-web"
 
 # --- Part 3. The ordinary paths still work --------------------------------------------------
 


### PR DESCRIPTION
## Summary

`registries/repos.yml` lists a project's repos, one row per repo, and both scripts that read it find a row by its `- name:` line. A row written any other way — `location:` first, or a bare `-` on its own line — was not read, and its fields landed on the row above it:

| Registry | Doctor before (`check.sh --check-in`) | Doctor now |
|---|---|---|
| two rows, each starting `- location:` | `[PASS] 0 row(s): all have a location, and a recorded remote covers every one` | `[FAIL] read 0 of 2 row(s) — a row is read only from its - name: line` |
| second row starts on a bare `-` | `[WARN] repo(s) with no remote: alpha (Code/beta/)` | `[FAIL] read 1 of 2 row(s) …` |
| only the second row reordered | `[PASS] 1 row(s): …` | `[FAIL] read 1 of 2 row(s) …` |

The setup helper had the same blind spot. With the second row reordered it paired `Code/alpha` with beta's remote, so it would clone beta into alpha's folder and report `exists: Code/alpha` on every later run. With a bare `-` it silently skipped the first repo.

## What changed

- **Doctor, check 10.** Every list entry is counted apart from the rows the walk reads, under the same comment rule as the registry header's rule 3. When the two counts disagree, the check-in fails and the pass line is withheld. The other findings still print, and the hint says they may name the wrong repo.
- **Setup helper.** The same count runs before the clone step. When the counts disagree it clones nothing, and says a row does not start with its `- name:` line and should be fixed before a re-run. The pointer files and `doctor.sh` are still written, and the run still exits 0.
- **Tests.** `tests/check-repo-registry.sh` gains the three registries above. Its commented-row case now also carries a value that mentions `- name:`, which is what catches a row pattern that has lost its `^` anchor. `tests/setup-workspace-resilience.sh` gains a bare-`-` registry and asserts that neither location is cloned.
- **Docs.** `runbooks/check-in.md` gains one sentence. The 1.8 changelog and migration text about check 10 are amended rather than duplicated, because check 10 is new in this release. The helper change gets its own `Fixed` entry and migration paragraph, because its row walk shipped in 1.7.1. Nothing is asked of upgraders, so the migration section's running count and fast path are unchanged.

## Proof by mutation

Each mutation ran in its own clone of this branch, against the test that guards it.

| Mutation | Test | Result |
|---|---|---|
| `check.sh` reverted to the base | `check-repo-registry.sh` | fails, 14 assertions — each of the three registries fails its own |
| `^` dropped from the row pattern | `check-repo-registry.sh` | fails, 5 — the value that mentions `- name:` becomes a row |
| `^` dropped from the new entry pattern | `check-repo-registry.sh` | fails, 4 |
| the entry pattern's bare-`-` rule removed | `check-repo-registry.sh` | fails, 4 |
| the helper's bare-`-` rule removed | `setup-workspace-resilience.sh` | fails, 2 |
| pass-line guard removed | `check-repo-registry.sh` | fails, 2 — the clean pass line comes back |
| the new failure made a no-op | `check-repo-registry.sh` | fails, 9 |
| comment-skip rule deleted | `check-repo-registry.sh` | passes — see below |
| `setup-workspace.sh` reverted to the base | `setup-workspace-resilience.sh` | fails, 2 — no message, and a repo is cloned |
| the helper's count guard forced off | `setup-workspace-resilience.sh` | fails, 2 |

At the base, dropping the `^` from the row pattern passed the test. Only dropping it together with the comment skip failed it, with 20 failures. The value that mentions `- name:` is what now catches the lost anchor on its own.

One mutation cannot be caught: deleting the comment-skip rule on its own. Every pattern behind it is anchored to the start of the line, so none of them can match a line whose first non-blank character is `#`, and no fixture can tell the rule is gone.

## Test plan

- [x] Every mutation above run in its own clone of the branch
- [x] Whole suite locally: 16 of 16 pass, the same count as at the base
- [ ] CI: one `PASS` line per `tests/*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
