### PR TITLE
Warn when a doctor check finds nothing to inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,21 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **A doctor check that read nothing no longer passes.** Four of the checks `scripts/check.sh` runs
+  every time read rows out of a table or templates out of a folder, and each printed a clean PASS
+  when it found nothing there. Emptying `prompts/STEP-index.md` and `adr/README.md` passed the
+  duplicate-STEP, duplicate-ADR and status checks and ended the run `0 fail(s), 0 warning(s)`, where
+  deleting the same two files warned four times; renaming the STEP table's `Status` header passed
+  the status check over a STEP-1 marked `Bogus`, which with the header intact fails; and removing
+  `templates/architecture-sessions/` passed the conditional-template check as having nothing to
+  check. Each of those now warns. The status check counts STEP rows apart from the header it reads
+  their statuses under, so a header renamed in one phase table of several is caught too, as
+  `read the status of 1 of 2 STEP row(s)`. **Where nothing is a normal state, it still passes** — a
+  project with no ADR yet, whose registry table is still there, or one that deleted its optional
+  conditional templates on purpose — so a fresh project still ends `0 fail(s), 0 warning(s)`. The
+  STEP, ADR and status checks' pass lines now say how many rows they read, as
+  `all statuses valid (1 STEP row(s), 14 substep row(s))`, so a zero shows even where it is
+  allowed. The new findings are warnings: a run that exited 0 before still does.
 - **The workspace setup no longer clones from a registry it cannot fully read.**
   `scripts/setup-workspace.sh` finds a row by its `- name:` line, so a row written any other way —
   starting on a bare `-`, or with another field first — was not read, and its fields landed on the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -185,6 +185,17 @@ changed. A link *to* an input from a doc it does check is still checked. `AGENTS
 `ONBOARDING.md` §4, `inputs/README.md` and `runbooks/splitting-repos.md` each gain one sentence
 saying so.
 
+**A doctor check that read nothing now warns instead of passing, and there is nothing for you to do
+unless it warns.** `./doctor.sh check` used to pass its duplicate-STEP, duplicate-ADR, status and
+conditional-template checks when they found nothing to read — an emptied `prompts/STEP-index.md` or
+`adr/README.md`, a STEP table whose `Status` header had been renamed, or a missing
+`templates/architecture-sessions/` folder. `scripts/check.sh` now prints a `[WARN]` for each. A
+project whose files are intact sees no new warning: no ADR yet still passes, and so do conditional
+templates you deleted on purpose. If one of the new warnings does appear, it is describing something
+that was already wrong — usually a file, folder or table header that git history can restore.
+Warnings never change the doctor's exit code, so no CI run turns red. If anything of yours reads the
+doctor's pass lines word for word, three of them now end in a row count in parentheses.
+
 **`private` and `proprietary` now mean two different things, and if you script `init.sh` there is
 one rename.** `private` refers to repository visibility and nothing else; `proprietary` is the
 licence posture. They were the same word in two unrelated questions — the licence question offered

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -124,8 +124,8 @@ if [ -f "$ADR_INDEX" ]; then
     maxn="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE '[0-9]+' | sed 's/^0*//' | sort -n | tail -1)"
     hint "renumber the later duplicate to $(printf 'ADR-%04d' "$((maxn + 1))") and rename its file to match — never reuse a number. See $DOCS_REL/adr/README.md and $DOCS_REL/runbooks/collaboration.md §6."
   elif [ "$adr_rows" -eq 0 ] && ! grep -qE '^\|[[:space:]]*ADR[[:space:]]*\|' "$ADR_INDEX"; then
-    # No ADR row is how every project starts, so the count alone cannot tell a new registry from
-    # an emptied one. The table header can: it ships with the file and stays while the table is empty.
+    # No ADR row is how every project starts, so the count alone cannot tell a new registry
+    # from an emptied one. The table header can: it ships with the file and stays when empty.
     warn "found no ADR rows and no registry table in $DOCS_REL/adr/README.md — nothing to check"
     hint "the registry table stays even with no ADRs in it: restore its header row, | ADR | Title | Status | Date |, from git history."
   else
@@ -146,8 +146,8 @@ if [ -f "$INDEX" ]; then
   # use N/A because only substeps can be structurally inapplicable.
   #
   # A STEP row under a header with no Status column is never validated, so STEP rows are also
-  # counted by their own shape — the one the duplicate-number check reads — and fewer statuses
-  # read than STEP rows present is a warning, not a pass.
+  # counted by their own shape — the one the duplicate-number check reads — and one that no
+  # Status column covers is a warning, not a pass.
   scan="$(awk -F'|' '
     function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
     {
@@ -165,11 +165,10 @@ if [ -f "$INDEX" ]; then
       if (ishdr && issub)  tablekind = "SUB"
       if (ishdr) { inrow = 1; subtable = issub; next }
       if (!inrow || statuscol == 0) next
-      sc = trim($statuscol)
-      if (sc ~ /^:?-+:?$/) next                                         # separator row
       stepread += steprow
+      sc = trim($statuscol)
+      if (sc == "" || sc ~ /^:?-+:?$/) next                            # blank or separator row
       subread += subtable
-      if (sc == "") next                                                # blank status cell
       if (sc != "Planned" && sc != "In progress" && sc != "Done" && sc != "Deferred" && sc != "Abandoned" && sc != "N/A")
         print trim($2) " -> \"" sc "\""
       else if (sc == "N/A" && tablekind != "SUB")

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -7,15 +7,18 @@
 # Safe to run anytime — intended for the periodic check-in (runbooks/check-in.md) and for CI.
 #
 # Checks:
-#   1. No duplicate STEP numbers in prompts/STEP-index.md
-#   2. No duplicate ADR numbers in adr/README.md
-#   3. STEP / substep statuses are from the allowed set
+#   1. No duplicate STEP numbers in prompts/STEP-index.md — warns when it has no STEP row
+#   2. No duplicate ADR numbers in adr/README.md — warns when it holds neither an ADR row nor a
+#      registry table
+#   3. STEP / substep statuses are from the allowed set — warns on no STEP row, or on a STEP
+#      row under no Status column
 #   4. Every architecture/NN-*.md carries Version / Status / Version Log
 #   5. The ADR registry and the ADR files on disk match (both directions)
 #   6. overview.md does not carry legacy local user preferences
 #   7. (multi-repo only) No stray files at the workspace root
 #   8. Architecture-session template numbers match the STEP-index seed
-#   9. Conditional-session templates expose the metadata generic review gates require
+#   9. Conditional-session templates expose the metadata generic review gates require — none
+#      passes; a missing templates/architecture-sessions/ folder warns
 #  10. (--check-in only) Every registries/repos.yml row can be read and has a location, and
 #      any repo no recorded remote covers is flagged as a bus-factor risk
 #
@@ -81,7 +84,9 @@ hdr "1. Duplicate STEP numbers (prompts/STEP-index.md)"
 if [ -f "$INDEX" ]; then
   # Invariant: STEP numbers are durable IDs. prompts/STEP-index.md is authoritative, and
   # duplicates catch accidental reuse after planning, branching, or folder creation.
-  dups="$(grep -oE '^\|[[:space:]]*STEP-[0-9]+' "$INDEX" | grep -oE 'STEP-[0-9]+' | sort | uniq -d)"
+  step_ids="$(grep -oE '^\|[[:space:]]*STEP-[0-9]+' "$INDEX" | grep -oE 'STEP-[0-9]+')"
+  step_rows="$(printf '%s\n' "$step_ids" | grep -c .)"
+  dups="$(printf '%s\n' "$step_ids" | sort | uniq -d)"
   if [ -n "$dups" ]; then
     fail "duplicate STEP number(s): $(echo "$dups" | tr '\n' ' ')"
     for d in $dups; do
@@ -90,8 +95,13 @@ if [ -f "$INDEX" ]; then
     done
     maxn="$(grep -oE '^\|[[:space:]]*STEP-[0-9]+' "$INDEX" | grep -oE '[0-9]+' | sort -n | tail -1)"
     hint "renumber the duplicate (the one reserved later) to STEP-$((maxn + 1)) — never reuse or delete a number; mark a row Abandoned if it won't be built. See $DOCS_REL/runbooks/collaboration.md §2."
+  elif [ "$step_rows" -eq 0 ]; then
+    # init.sh reserves STEP-1 and a STEP number is never deleted, so an index with no STEP row
+    # has lost its table. A pass here would vouch for rows nobody read.
+    warn "found no STEP rows in prompts/STEP-index.md — nothing to check"
+    hint "a STEP row starts at the left margin with its number, as in | STEP-1 |. Restore the table from git history; a number is never deleted, only marked Abandoned."
   else
-    pass "no duplicate STEP numbers"
+    pass "no duplicate STEP numbers ($step_rows STEP row(s))"
   fi
 else
   warn "no prompts/STEP-index.md yet (project not initialized?) — skipping STEP checks"
@@ -102,7 +112,9 @@ hdr "2. Duplicate ADR numbers ($DOCS_REL/adr/README.md)"
 if [ -f "$ADR_INDEX" ]; then
   # Invariant: ADR numbers are durable decision IDs. adr/README.md is the registry authority,
   # and duplicates catch copy/paste rows or renumbering drift before files are reconciled.
-  dups="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE 'ADR-[0-9]+' | sort | uniq -d)"
+  adr_ids="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE 'ADR-[0-9]+')"
+  adr_rows="$(printf '%s\n' "$adr_ids" | grep -c .)"
+  dups="$(printf '%s\n' "$adr_ids" | sort | uniq -d)"
   if [ -n "$dups" ]; then
     fail "duplicate ADR number(s): $(echo "$dups" | tr '\n' ' ')"
     for d in $dups; do
@@ -111,8 +123,13 @@ if [ -f "$ADR_INDEX" ]; then
     done
     maxn="$(grep -oE '^\|[[:space:]]*ADR-[0-9]+' "$ADR_INDEX" | grep -oE '[0-9]+' | sed 's/^0*//' | sort -n | tail -1)"
     hint "renumber the later duplicate to $(printf 'ADR-%04d' "$((maxn + 1))") and rename its file to match — never reuse a number. See $DOCS_REL/adr/README.md and $DOCS_REL/runbooks/collaboration.md §6."
+  elif [ "$adr_rows" -eq 0 ] && ! grep -qE '^\|[[:space:]]*ADR[[:space:]]*\|' "$ADR_INDEX"; then
+    # No ADR row is how every project starts, so the count alone cannot tell a new registry from
+    # an emptied one. The table header can: it ships with the file and stays while the table is empty.
+    warn "found no ADR rows and no registry table in $DOCS_REL/adr/README.md — nothing to check"
+    hint "the registry table stays even with no ADRs in it: restore its header row, | ADR | Title | Status | Date |, from git history."
   else
-    pass "no duplicate ADR numbers"
+    pass "no duplicate ADR numbers ($adr_rows ADR row(s))"
   fi
 else
   warn "no $DOCS_REL/adr/README.md — skipping ADR-number check"
@@ -127,10 +144,16 @@ if [ -f "$INDEX" ]; then
   # Find each table's Status column from its header row, then validate that cell in data rows.
   # The parser depends on Markdown table headers, not fixed column positions; STEP rows may not
   # use N/A because only substeps can be structurally inapplicable.
-  bad="$(awk -F'|' '
+  #
+  # A STEP row under a header with no Status column is never validated, so STEP rows are also
+  # counted by their own shape — the one the duplicate-number check reads — and fewer statuses
+  # read than STEP rows present is a warning, not a pass.
+  scan="$(awk -F'|' '
     function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
     {
       if ($0 !~ /^[[:space:]]*\|/) { inrow = 0; statuscol = 0; next }   # left a table
+      steprow = ($0 ~ /^\|[[:space:]]*STEP-[0-9]+/)
+      steprows += steprow
       ishdr = 0; isstep = 0; issub = 0
       for (i = 1; i <= NF; i++) {
         c = trim($i)
@@ -140,22 +163,36 @@ if [ -f "$INDEX" ]; then
       }
       if (ishdr && isstep) tablekind = "STEP"
       if (ishdr && issub)  tablekind = "SUB"
-      if (ishdr) { inrow = 1; next }
+      if (ishdr) { inrow = 1; subtable = issub; next }
       if (!inrow || statuscol == 0) next
       sc = trim($statuscol)
-      if (sc == "" || sc ~ /^:?-+:?$/) next                            # blank or separator row
+      if (sc ~ /^:?-+:?$/) next                                         # separator row
+      stepread += steprow
+      subread += subtable
+      if (sc == "") next                                                # blank status cell
       if (sc != "Planned" && sc != "In progress" && sc != "Done" && sc != "Deferred" && sc != "Abandoned" && sc != "N/A")
         print trim($2) " -> \"" sc "\""
       else if (sc == "N/A" && tablekind != "SUB")
         print trim($2) " -> \"N/A\" (only substeps may use N/A)"
     }
+    END { print "count\t" (stepread + 0) "\t" (steprows + 0) "\t" (subread + 0) }
   ' "$INDEX")"
+  step_read="$(printf '%s\n' "$scan" | awk -F'\t' '$1 == "count" { print $2 }')"
+  step_seen="$(printf '%s\n' "$scan" | awk -F'\t' '$1 == "count" { print $3 }')"
+  sub_read="$(printf '%s\n' "$scan"  | awk -F'\t' '$1 == "count" { print $4 }')"
+  bad="$(printf '%s\n' "$scan" | awk -F'\t' '$1 != "count"')"
   if [ -n "$bad" ]; then
     fail "invalid status value(s):"
     while IFS= read -r line; do printf '         %s\n' "$line"; done <<< "$bad"
     hint "use exactly one of: Planned · In progress · Done · Deferred · Abandoned (a substep may also be N/A). See $DOCS_REL/METHOD.md §1."
-  else
-    pass "all statuses valid"
+  fi
+  if [ "${step_seen:-0}" -eq 0 ]; then
+    warn "found no STEP rows in prompts/STEP-index.md — no STEP status checked"
+  elif [ "${step_read:-0}" -lt "$step_seen" ]; then
+    warn "read the status of ${step_read:-0} of $step_seen STEP row(s) — a status is read only under a header row with a Status column"
+    hint "give every STEP table the header row in $DOCS_REL/templates/step-index-seed.md; a STEP row under a renamed or missing header is not checked."
+  elif [ -z "$bad" ]; then
+    pass "all statuses valid ($step_read STEP row(s), $sub_read substep row(s))"
   fi
 else
   warn "no prompts/STEP-index.md yet — skipping status check"
@@ -373,7 +410,11 @@ hdr "9. Conditional-session template contract"
 # tooling still needs a common metadata contract: applicability, invocation, outputs, next
 # action, active PLAN handling, architecture index updates, and substep completion language.
 conditional_templates=("$SESSION_TEMPLATE_DIR"/conditional-*.md)
-if [ ${#conditional_templates[@]} -eq 0 ]; then
+# Conditional templates are optional and a project may delete them, so having none passes. The
+# folder they live in is not optional — it holds the numbered sessions too — so its absence warns.
+if [ ! -d "$SESSION_TEMPLATE_DIR" ]; then
+  warn "no $DOCS_REL/templates/architecture-sessions/ folder — skipping conditional-session check"
+elif [ ${#conditional_templates[@]} -eq 0 ]; then
   pass "no conditional-session templates found (nothing to check)"
 else
   conditional_ok=1

--- a/tests/check-nothing-to-inspect.sh
+++ b/tests/check-nothing-to-inspect.sh
@@ -112,18 +112,19 @@ edit() {
 base="$(bootstrap)" || exit 1
 
 # --- 1. A fresh project ---------------------------------------------------------
-# Nothing is wrong, so nothing warns: one STEP row, fourteen substep rows, no ADR yet and three
-# conditional templates. The counts are pinned because a count is what shows a zero in a pass
-# line, and a check that had stopped reading would print a zero.
+# Nothing is wrong, so nothing warns: one STEP row, no ADR yet, and a substep row per numbered
+# session. The counts are asserted because a count is what shows a zero in a pass line, and a
+# check that had stopped reading would print one. The substep count is taken from the index by
+# row number rather than written down, so adding a session template does not break this case.
 doctor "$base"
 look "Duplicate STEP numbers"
 expect "[PASS] no duplicate STEP numbers (1 STEP row(s))" "fresh project"
 look "Duplicate ADR numbers"
 expect "[PASS] no duplicate ADR numbers (0 ADR row(s))" "fresh project: no ADR yet passes"
+subs="$(grep -cE '^\| 1\.[0-9]+ \|' "$base/prompts/STEP-index.md")"
+[ "$subs" -gt 0 ] || bad "fixture: the generated index has no STEP-1 substep rows to count"
 look "Statuses valid"
-expect "[PASS] all statuses valid (1 STEP row(s), 14 substep row(s))" "fresh project"
-look "Conditional-session template contract"
-expect "[PASS] all 3 conditional template(s)" "fresh project"
+expect "[PASS] all statuses valid (1 STEP row(s), $subs substep row(s))" "fresh project"
 case "$DOC_OUT" in
   *"0 fail(s), 0 warning(s)"*) ;;
   *) bad "fresh project — expected 0 fail(s), 0 warning(s)" ;;
@@ -140,6 +141,7 @@ doctor "$c"
 look "Statuses valid"
 expect "[FAIL] invalid status value(s):" "bad status, header intact"
 expect 'STEP-1 -> "Bogus"' "bad status, header intact"
+refute "[PASS]" "bad status, header intact"
 [ "$DOC_STATUS" -eq 1 ] || bad "bad status, header intact — expected exit 1, got $DOC_STATUS"
 
 edit "$idx" 's/^(\| STEP \| Title \| Owner \| )Status( \|)/${1}State$2/' "renaming the STEP table's Status header"
@@ -165,34 +167,47 @@ look "Statuses valid"
 expect "[WARN] read the status of 1 of 2 STEP row(s)" "renamed header in one phase table of two"
 refute "[PASS]" "renamed header in one phase table of two"
 
-# --- 3. An emptied STEP index ----------------------------------------------------
+# --- 3. An index with no STEP row ------------------------------------------------
 # init.sh reserves STEP-1 and a STEP number is never deleted, so an index with no STEP row has
-# lost its table. Both checks that read the index warn, as both do when the file is deleted, and
-# a warning leaves the exit code alone.
-c="$(fixture empty-index)"
+# lost it. Both checks that read the index warn, as both do when the file is deleted, and a
+# warning leaves the exit code alone. The row goes first, with the rest of the file kept — its
+# header, prose and substep table — so the warning is shown to key on the row and not on an
+# empty file; then the file is emptied outright.
+no_step_row() {
+  doctor "$c"
+  look "Duplicate STEP numbers"
+  expect "[WARN] found no STEP rows in prompts/STEP-index.md" "$1"
+  expect "a STEP row starts at the left margin" "$1 hint"
+  refute "[PASS]" "$1"
+  look "Statuses valid"
+  expect "[WARN] found no STEP rows in prompts/STEP-index.md" "$1"
+  refute "[PASS]" "$1"
+  [ "$DOC_STATUS" -eq 0 ] || bad "$1 — a WARN must not change the exit code, got $DOC_STATUS"
+}
+c="$(fixture no-step-row)"
+edit "$c/prompts/STEP-index.md" '$_ = "" if /^\| STEP-1 \|/' "deleting the STEP-1 row"
+no_step_row "STEP-1 row deleted"
 : > "$c/prompts/STEP-index.md"
-doctor "$c"
-look "Duplicate STEP numbers"
-expect "[WARN] found no STEP rows in prompts/STEP-index.md" "emptied STEP index"
-expect "a STEP row starts at the left margin" "emptied STEP index hint"
-refute "[PASS]" "emptied STEP index"
-look "Statuses valid"
-expect "[WARN] found no STEP rows in prompts/STEP-index.md" "emptied STEP index"
-refute "[PASS]" "emptied STEP index"
-[ "$DOC_STATUS" -eq 0 ] || bad "emptied STEP index — a WARN must not change the exit code, got $DOC_STATUS"
+no_step_row "emptied STEP index"
 
-# --- 4. An emptied ADR registry ---------------------------------------------------
+# --- 4. An ADR registry with no table --------------------------------------------
 # No ADR row is also how every project starts (case 1), so the row count cannot tell the two
-# apart. The registry table can: it ships with the file and stays while it is empty. The control
-# is a registry that lost its table but still holds a row — the check read that row, so it passes.
-c="$(fixture empty-adr)"
+# apart. The registry table can: it ships with the file and stays while it is empty. The table
+# goes first, with the prose around it kept, then the file is emptied outright. The control is a
+# registry that lost its table but still holds a row — the check read that row, so it passes.
+no_adr_table() {
+  doctor "$c"
+  look "Duplicate ADR numbers"
+  expect "[WARN] found no ADR rows and no registry table" "$1"
+  expect "| ADR | Title | Status | Date |" "$1 hint"
+  refute "[PASS]" "$1"
+}
+c="$(fixture no-adr-table)"
 adr="$c/Code/$SLUG-docs/adr/README.md"
+edit "$adr" '$_ = "" if /^\|/' "deleting the ADR registry table"
+no_adr_table "ADR registry table deleted"
 : > "$adr"
-doctor "$c"
-look "Duplicate ADR numbers"
-expect "[WARN] found no ADR rows and no registry table" "emptied ADR registry"
-expect "| ADR | Title | Status | Date |" "emptied ADR registry hint"
-refute "[PASS]" "emptied ADR registry"
+no_adr_table "emptied ADR registry"
 
 printf '| ADR-0001 | A decision | Accepted | 2026-01-15 |\n' > "$adr"
 doctor "$c"

--- a/tests/check-nothing-to-inspect.sh
+++ b/tests/check-nothing-to-inspect.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for the every-run doctor checks that read rows out of a table, or templates
+# out of a folder, when there is nothing there to read: scripts/check.sh's duplicate-STEP,
+# duplicate-ADR, status and conditional-template checks.
+#
+# The defect under test is a clean PASS from a check that read nothing — an emptied STEP index or
+# ADR registry, a STEP table whose Status header was renamed, a missing session-templates folder.
+# So every case refutes its section's PASS as well as expecting the WARN: the WARN alone could be
+# printed beside a PASS that still vouches for rows nobody read.
+#
+# Half of the rule is staying quiet. Some zeros are how a project starts — no ADR yet — or a
+# choice a project may make — deleting the optional conditional templates — and a doctor that
+# warned on those would teach people to ignore it. So the fresh project is asserted clean, with
+# the row counts its pass lines print, and the deliberate deletion is asserted to pass.
+#
+# Findings are read out of each check's own section, found by its title rather than its number,
+# with their severity marker. Every case breaks its own copy of one generated project.
+
+set -uo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-check-nothing-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+SLUG="inspect"
+failures=0
+bad() { printf 'FAIL: %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+# copy_template DEST — build a template fixture from HEAD, then overlay current worktree
+# changes. Archiving rather than copying the live tree leaves ignored maintainer files behind,
+# so the fixture is the shape a user downloads; the overlay keeps uncommitted edits under test.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+# bootstrap — generate the project every case copies, and echo its workspace root. The checks
+# under test read the same files in either layout.
+bootstrap() {
+  local work="$TMP_ROOT/$SLUG"
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$SLUG" \
+      --desc="Nothing-to-inspect check test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout=multi \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$SLUG.init.out" 2>&1 || {
+    bad "init.sh failed"
+    sed -n '1,40p' "$TMP_ROOT/$SLUG.init.out" >&2
+    return 1
+  }
+  printf '%s\n' "$work"
+}
+
+# fixture LABEL — a fresh copy of the generated project for one case to break. The doctor finds
+# its root from its own path, so the copy is a project in its own right.
+fixture() {
+  cp -R "$base" "$TMP_ROOT/case-$1"
+  printf '%s\n' "$TMP_ROOT/case-$1"
+}
+
+# doctor WORK — run the project's doctor. DOC_OUT is the whole run and DOC_STATUS its exit status.
+doctor() {
+  DOC_OUT="$(bash "$1/Code/$SLUG-docs/scripts/check.sh" 2>&1)"
+  DOC_STATUS=$?
+}
+
+# look TITLE — select one check's section of the last run, from its heading to the next one, so
+# a finding another check printed cannot satisfy an assertion about this one.
+look() {
+  SEC_TITLE="$1"
+  SEC="$(printf '%s\n' "$DOC_OUT" | awk -v t="$1" '/^[0-9]+\. / || /^Summary$/ { f = (index($0, t) > 0); next } f')"
+  [ -n "$SEC" ] || bad "the doctor printed no \"$1\" section, or an empty one"
+}
+
+has()    { case "$SEC" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+expect() { has "$1" || bad "$2 — expected \"$SEC_TITLE\" to report: $1"; }
+refute() { has "$1" && bad "$2 — \"$SEC_TITLE\" should NOT report: $1"; return 0; }
+
+# edit FILE PERL WHAT — apply a perl substitution and require that it changed the file. A pattern
+# that stopped matching the generated file would leave it as it was, and the case would pass for
+# the wrong reason.
+edit() {
+  cp "$1" "$TMP_ROOT/before"
+  perl -pi -e "$2" "$1"
+  cmp -s "$TMP_ROOT/before" "$1" && bad "fixture: $3 changed nothing"
+  return 0
+}
+
+base="$(bootstrap)" || exit 1
+
+# --- 1. A fresh project ---------------------------------------------------------
+# Nothing is wrong, so nothing warns: one STEP row, fourteen substep rows, no ADR yet and three
+# conditional templates. The counts are pinned because a count is what shows a zero in a pass
+# line, and a check that had stopped reading would print a zero.
+doctor "$base"
+look "Duplicate STEP numbers"
+expect "[PASS] no duplicate STEP numbers (1 STEP row(s))" "fresh project"
+look "Duplicate ADR numbers"
+expect "[PASS] no duplicate ADR numbers (0 ADR row(s))" "fresh project: no ADR yet passes"
+look "Statuses valid"
+expect "[PASS] all statuses valid (1 STEP row(s), 14 substep row(s))" "fresh project"
+look "Conditional-session template contract"
+expect "[PASS] all 3 conditional template(s)" "fresh project"
+case "$DOC_OUT" in
+  *"0 fail(s), 0 warning(s)"*) ;;
+  *) bad "fresh project — expected 0 fail(s), 0 warning(s)" ;;
+esac
+
+# --- 2. A STEP row under no Status column ---------------------------------------
+# A status is found by its column header's name, so a STEP row under a header that lost it is
+# never read. STEP-1 carries a bad status throughout: with the header intact the check fails on
+# it, which is what shows it is the rows under a renamed header that go unread.
+c="$(fixture renamed-header)"
+idx="$c/prompts/STEP-index.md"
+edit "$idx" 's/^(\| STEP-1 \| Architecture \| \| )Planned/${1}Bogus/' "setting STEP-1 to Bogus"
+doctor "$c"
+look "Statuses valid"
+expect "[FAIL] invalid status value(s):" "bad status, header intact"
+expect 'STEP-1 -> "Bogus"' "bad status, header intact"
+[ "$DOC_STATUS" -eq 1 ] || bad "bad status, header intact — expected exit 1, got $DOC_STATUS"
+
+edit "$idx" 's/^(\| STEP \| Title \| Owner \| )Status( \|)/${1}State$2/' "renaming the STEP table's Status header"
+doctor "$c"
+look "Statuses valid"
+expect "[WARN] read the status of 0 of 1 STEP row(s)" "renamed Status header"
+expect "templates/step-index-seed.md" "renamed Status header hint"
+refute "[PASS]" "renamed Status header"
+
+# A project grows a table per phase, and a header renamed in one of them leaves the rest read. A
+# count of statuses read against STEP rows present sees that; a check for zero does not.
+c="$(fixture second-phase)"
+cat >> "$c/prompts/STEP-index.md" <<'MD'
+
+## Phase 2 — Later
+
+| STEP | Title | Owner | State | Repos (projection) | Scope (one line) |
+|------|-------|-------|-------|--------------------|------------------|
+| STEP-2 | Later work | | Planned | | Fixture |
+MD
+doctor "$c"
+look "Statuses valid"
+expect "[WARN] read the status of 1 of 2 STEP row(s)" "renamed header in one phase table of two"
+refute "[PASS]" "renamed header in one phase table of two"
+
+# --- 3. An emptied STEP index ----------------------------------------------------
+# init.sh reserves STEP-1 and a STEP number is never deleted, so an index with no STEP row has
+# lost its table. Both checks that read the index warn, as both do when the file is deleted, and
+# a warning leaves the exit code alone.
+c="$(fixture empty-index)"
+: > "$c/prompts/STEP-index.md"
+doctor "$c"
+look "Duplicate STEP numbers"
+expect "[WARN] found no STEP rows in prompts/STEP-index.md" "emptied STEP index"
+expect "a STEP row starts at the left margin" "emptied STEP index hint"
+refute "[PASS]" "emptied STEP index"
+look "Statuses valid"
+expect "[WARN] found no STEP rows in prompts/STEP-index.md" "emptied STEP index"
+refute "[PASS]" "emptied STEP index"
+[ "$DOC_STATUS" -eq 0 ] || bad "emptied STEP index — a WARN must not change the exit code, got $DOC_STATUS"
+
+# --- 4. An emptied ADR registry ---------------------------------------------------
+# No ADR row is also how every project starts (case 1), so the row count cannot tell the two
+# apart. The registry table can: it ships with the file and stays while it is empty. The control
+# is a registry that lost its table but still holds a row — the check read that row, so it passes.
+c="$(fixture empty-adr)"
+adr="$c/Code/$SLUG-docs/adr/README.md"
+: > "$adr"
+doctor "$c"
+look "Duplicate ADR numbers"
+expect "[WARN] found no ADR rows and no registry table" "emptied ADR registry"
+expect "| ADR | Title | Status | Date |" "emptied ADR registry hint"
+refute "[PASS]" "emptied ADR registry"
+
+printf '| ADR-0001 | A decision | Accepted | 2026-01-15 |\n' > "$adr"
+doctor "$c"
+look "Duplicate ADR numbers"
+expect "[PASS] no duplicate ADR numbers (1 ADR row(s))" "an ADR row with no table header"
+refute "[WARN]" "an ADR row with no table header"
+
+# --- 5. The session-templates folder ----------------------------------------------
+# Conditional templates are optional, and a project may delete them on purpose: that passes. The
+# folder they live in holds the numbered sessions too, so a missing folder warns.
+sessions="Code/$SLUG-docs/templates/architecture-sessions"
+c="$(fixture no-conditionals)"
+rm -f "$c/$sessions"/conditional-*.md
+doctor "$c"
+look "Conditional-session template contract"
+expect "[PASS] no conditional-session templates found (nothing to check)" "conditional templates deleted on purpose"
+refute "[WARN]" "conditional templates deleted on purpose"
+
+c="$(fixture no-sessions)"
+rm -rf "${c:?}/$sessions"
+doctor "$c"
+look "Conditional-session template contract"
+expect "[WARN] no $sessions/ folder — skipping conditional-session check" "missing session-templates folder"
+refute "[PASS]" "missing session-templates folder"
+
+if [ "$failures" -ne 0 ]; then
+  printf 'check.sh nothing-to-inspect checks: %d FAILURE(S)\n' "$failures" >&2
+  exit 1
+fi
+echo "check.sh nothing-to-inspect checks: PASS"


### PR DESCRIPTION
## Summary

Four of the checks `scripts/check.sh` runs every time printed a clean PASS after reading nothing. Measured on a fresh multi project at the base of this branch:

- `prompts/STEP-index.md` emptied → `[PASS] no duplicate STEP numbers` and `[PASS] all statuses valid`
- `adr/README.md` emptied → `[PASS] no duplicate ADR numbers` (with the index also emptied the run ended `0 fail(s), 0 warning(s)`; deleting the same two files warns four times)
- the STEP table's `Status` header renamed to `State` → `[PASS] all statuses valid`, over a STEP-1 marked `Bogus` that fails with the header intact
- `templates/architecture-sessions/` removed → `[PASS] no conditional-session templates found (nothing to check)`

Each now warns. Where nothing is a normal state it still passes, so a fresh project — multi and mono, both run by hand — still ends `0 fail(s), 0 warning(s)`.

| Check | Warns when | Still passes when |
|---|---|---|
| Duplicate STEP numbers | the index has no left-margin `\| STEP-N` row (`init.sh` reserves STEP-1; a number is never deleted) | — |
| Duplicate ADR numbers | no ADR row **and** no `\| ADR \|` table header | no ADR row under the header — every new project |
| Statuses valid | no STEP row, or fewer statuses read than STEP rows (`read the status of 1 of 2 STEP row(s)`) — counted apart from the header walk, so one renamed phase table of several is caught | — |
| Conditional-session templates | the `templates/architecture-sessions/` folder is missing | the folder has no `conditional-*.md` — a project may delete them on purpose |

The first three pass lines now say how many rows they read: `no duplicate STEP numbers (1 STEP row(s))`, `no duplicate ADR numbers (0 ADR row(s))`, `all statuses valid (1 STEP row(s), 14 substep row(s))`. The new findings are warnings, so the exit code of every run is unchanged.

## Tests

New `tests/check-nothing-to-inspect.sh`: one generated project, a fresh copy per case, each finding read out of its own check's section (found by title, not number) with its severity marker. Every case that expects a WARN also refutes the section's PASS, and so does the bad-status control. The quiet half is asserted too: a fresh project, no ADR yet, conditional templates deleted on purpose, an ADR row with no table header. The no-row cases first delete just the STEP-1 row, or just the ADR table, with the rest of the file kept, and then empty the file, so the warnings are shown to key on the rows rather than on an empty file. The fresh project's substep count is read from the generated index rather than written down, so adding a session template does not break the test.

Proved by mutation, each mutation uncommitted in its own clone (28 mutations, all red; the unmutated clone green):

- `check.sh` reverted to the base → 27 failures, covering all four sites
- each site's fix removed alone → red for that site's assertions only
- narrowed or shifted triggers → red: the STEP and status zero-row warnings keyed on an empty file, or on the STEP header, instead of the row count; the ADR warning keyed on the header alone, on every zero, or on an empty file; the status warning reduced to zero-read only; a STEP row counted as read regardless of its header; a PASS printed beside a status FAIL; the templates-folder test inverted; the conditional check warning on none
- counts dropped or miscounted → red: STEP, ADR and substep counts dropped; separator rows counted as substeps
- the test's own guards → red: a heading renamed (section lookup); fixture edits that no longer match the header, the STEP-1 row or the substep rows; `warn` incrementing the fail count; a FAIL exiting 0; a bad status accepted

The whole suite passes locally, and `doc-contract.sh` still reads check 3's statuses by their shape.

## Release notes

`CHANGELOG.md` under Fixed; `UPDATING-THROUGHSTONE.md` gains a paragraph in the 1.8 migration section — nothing to do unless one of the new warnings appears. The section's running count is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
