### PR TITLE
Make three tests fail when the code they guard breaks

### DIFF
--- a/tests/method-check-workflow.sh
+++ b/tests/method-check-workflow.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for the method-check workflow every generated project ships
+# (.github/workflows/method-check.yml): the commands in its doctor step must fail when the doctor
+# fails, and succeed when it passes. Only those commands are run; the step's other keys are not
+# read.
+#
+# The step is run the way GitHub Actions runs a `shell: bash` step — `bash --noprofile --norc -eo
+# pipefail`, with CI set — from the root of a fresh clone of the repository the workflow sits in.
+# It looks for the doctor in two places, and both are run: scripts/check.sh at the root of a docs
+# hub that is its own repository, as in multi-repo CI, and Code/<project>-docs/scripts/check.sh
+# under a mono project's workspace root.
+#
+# Nothing here parses YAML, so the step is lifted out of the workflow as text. A wrong lift cannot
+# pass: an empty one is reported, and every run must print the doctor's own RESULT line, so a step
+# that never reaches the doctor fails its case.
+
+set -uo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-method-check-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+SLUG="gate"
+WORKFLOW=".github/workflows/method-check.yml"
+failures=0
+bad() { printf 'FAIL: %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+# copy_template DEST — build a template fixture from HEAD, then overlay current worktree
+# changes. Archiving rather than copying the live tree leaves ignored maintainer files behind,
+# so the fixture is the shape a user downloads; the overlay keeps uncommitted edits under test.
+copy_template() {
+  local dest="$1" file
+  mkdir -p "$dest"
+  git -C "$ROOT" archive HEAD | tar -x -C "$dest"
+  while IFS= read -r -d '' file; do
+    if [ -e "$ROOT/$file" ]; then
+      mkdir -p "$dest/$(dirname "$file")"
+      cp -p "$ROOT/$file" "$dest/$file"
+    else
+      rm -f "$dest/$file"
+    fi
+  done < <(
+    {
+      git -C "$ROOT" diff --name-only -z HEAD
+      git -C "$ROOT" ls-files --others --exclude-standard -z
+    }
+  )
+}
+
+# bootstrap LAYOUT — generate a project in that layout and echo its workspace root.
+bootstrap() {
+  local work="$TMP_ROOT/$1"
+  copy_template "$work"
+  (
+    cd "$work"
+    ./init.sh \
+      --non-interactive \
+      --slug="$SLUG" \
+      --desc="Method-check workflow test" \
+      --license=mit \
+      --holder="Throughstone Test" \
+      --layout="$1" \
+      --collab=solo \
+      --remotes=no
+  ) >"$TMP_ROOT/$1.init.out" 2>&1 || {
+    bad "$1: init.sh failed"
+    sed -n '1,40p' "$TMP_ROOT/$1.init.out" >&2
+    return 1
+  }
+  printf '%s\n' "$work"
+}
+
+# doctor_step FILE — print the `run: |` block of the step named "Run method doctor", without its
+# YAML indentation. The block ends at the first line indented no deeper than its `run:` key.
+doctor_step() {
+  awk '
+    /^[[:space:]]*- name: Run method doctor/ { step = 1; next }
+    step && !body && /^[[:space:]]*run:[[:space:]]*\|[[:space:]]*$/ { match($0, /^ */); key = RLENGTH; body = 1; next }
+    body {
+      blank = ($0 ~ /^[[:space:]]*$/)
+      match($0, /^ */)
+      if (!blank && RLENGTH <= key) exit
+      if (!blank && !ind) ind = RLENGTH
+      print substr($0, ind + 1)
+    }
+  ' "$1"
+}
+
+# drift HUB — give the docs hub an architecture document with none of its required fields: one
+# hard failure, which the doctor reports in either layout.
+drift() {
+  mkdir -p "$1/architecture"
+  printf '# Drift\n' > "$1/architecture/01-drift.md"
+}
+
+# gate LABEL REPO HUB [BREAK] — clone REPO in place of the job's checkout step, run BREAK on the
+# docs hub inside the clone (HUB is its path there), then run the doctor step from the clone's
+# root. The clone sits two levels down because the doctor takes the workspace root to be two
+# folders above the docs hub, and that must stay inside this test's directory. GATE_STATUS is the
+# step's exit status and GATE_OUT what it printed.
+gate() {
+  local label="$1" repo="$2" hub="$3" break_with="${4:-}" clone step
+  clone="$TMP_ROOT/$label/ci/$(basename "$repo")"
+  step="$TMP_ROOT/$label.step.sh"
+  git clone -q "$repo" "$clone" || { bad "$label: could not clone $repo"; return 1; }
+  [ -z "$break_with" ] || "$break_with" "$clone/$hub"
+  doctor_step "$clone/$WORKFLOW" > "$step"
+  [ -s "$step" ] || { bad "$label: found no run step under \"Run method doctor\" in $WORKFLOW"; return 1; }
+  GATE_OUT="$(cd "$clone" && CI=true bash --noprofile --norc -eo pipefail "$step" 2>&1)"
+  GATE_STATUS=$?
+}
+
+# outcome LABEL WANT — WANT is pass or fail. The step's exit status must agree, and the doctor
+# must have printed the matching RESULT line.
+outcome() {
+  local label="$1" want="$2" result=OK
+  if [ "$want" = pass ]; then
+    [ "$GATE_STATUS" -eq 0 ] || bad "$label — expected the step to succeed, got exit $GATE_STATUS"
+  else
+    result=FAIL
+    [ "$GATE_STATUS" -ne 0 ] || bad "$label — expected the step to fail, got exit 0"
+  fi
+  case "$GATE_OUT" in
+    *"RESULT: $result"*) ;;
+    *) bad "$label — expected the doctor to run to RESULT: $result"; printf '%s\n' "$GATE_OUT" | tail -5 >&2 ;;
+  esac
+}
+
+multi="$(bootstrap multi)" || exit 1
+mono="$(bootstrap mono)"   || exit 1
+
+# A docs hub that is its own repository: CI checks out the hub, and the step finds scripts/check.sh
+# at its root.
+gate hub-healthy "$multi/Code/$SLUG-docs" . && outcome "hub repository, healthy project" pass
+gate hub-failing "$multi/Code/$SLUG-docs" . drift && outcome "hub repository, doctor failing" fail
+
+# A mono project: CI checks out the workspace root, and the step finds the docs hub under Code/.
+gate mono-healthy "$mono" "Code/$SLUG-docs" && outcome "mono workspace root, healthy project" pass
+gate mono-failing "$mono" "Code/$SLUG-docs" drift && outcome "mono workspace root, doctor failing" fail
+
+if [ "$failures" -ne 0 ]; then
+  printf 'method-check workflow: %d FAILURE(S)\n' "$failures" >&2
+  exit 1
+fi
+echo "method-check workflow: PASS"

--- a/tests/site-publish.sh
+++ b/tests/site-publish.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 export LC_ALL=C
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/throughstone-site-publish-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
 
 "$ROOT/brand/publish-site.sh" --check
 
@@ -16,6 +18,55 @@ grep -Fxq 'throughstone.org' "$ROOT/docs/CNAME" || {
 
 [ -f "$ROOT/docs/.nojekyll" ] || {
   printf 'FAIL: docs/.nojekyll is missing\n' >&2
+  exit 1
+}
+
+# --check never publishes. Run a real publish with a copy of the script, in a throwaway brand/ and
+# docs/ laid out where the script looks for them from its own path. docs/ starts with both Pages
+# files, which the script refuses to run without, and with what an earlier publish leaves behind:
+# a page brand/site/ no longer has, and a stale file inside a folder it still has.
+site="$TMP_ROOT/brand/site"
+pages="$TMP_ROOT/docs"
+mkdir -p "$site/sub" "$pages/sub"
+cp -p "$ROOT/brand/publish-site.sh" "$TMP_ROOT/brand/publish-site.sh"
+printf '<p>index</p>\n' > "$site/index.html"
+printf 'p { color: black; }\n' > "$site/sub/a.css"
+printf 'throughstone.org\n' > "$pages/CNAME"
+: > "$pages/.nojekyll"
+printf '<p>stale</p>\n' > "$pages/OLD.html"
+printf 'p { color: red; }\n' > "$pages/sub/OLD.css"
+
+set +e
+publish_out="$("$TMP_ROOT/brand/publish-site.sh" 2>&1)"
+publish_status=$?
+set -e
+
+[ "$publish_status" -eq 0 ] || {
+  printf 'FAIL: publishing the fixture site exited %s\n%s\n' "$publish_status" "$publish_out" >&2
+  exit 1
+}
+printf '%s\n' "$publish_out" | grep -Fxq 'site publish check: PASS' || {
+  printf 'FAIL: publishing did not verify what it wrote\n%s\n' "$publish_out" >&2
+  exit 1
+}
+for rel in index.html sub/a.css; do
+  cmp -s "$site/$rel" "$pages/$rel" || {
+    printf 'FAIL: publishing did not copy brand/site/%s to docs/%s\n' "$rel" "$rel" >&2
+    exit 1
+  }
+done
+for rel in OLD.html sub/OLD.css; do
+  [ ! -e "$pages/$rel" ] || {
+    printf 'FAIL: publishing left docs/%s, which brand/site/ does not have\n' "$rel" >&2
+    exit 1
+  }
+done
+grep -Fxq 'throughstone.org' "$pages/CNAME" || {
+  printf 'FAIL: publishing did not keep docs/CNAME\n' >&2
+  exit 1
+}
+[ -f "$pages/.nojekyll" ] || {
+  printf 'FAIL: publishing did not keep docs/.nojekyll\n' >&2
   exit 1
 }
 

--- a/tests/status-conditional-priority.sh
+++ b/tests/status-conditional-priority.sh
@@ -50,8 +50,19 @@ output="$(run_status "$index")"
 assert_contains "$output" \
   'Architecture follow-up required — STEP-12 (Conditional session: AI feature) is Planned.'
 
+# A conditional session is one whose title starts with the phrase. A planned STEP that only
+# mentions one is ordinary work, so the lowest-numbered planned STEP is still next.
+write_index "$index" \
+'| STEP-1 | Architecture | | Done | | Fixture |
+| STEP-2 | Ordinary implementation | | Planned | | Fixture |
+| STEP-12 | Follow-up from Conditional session: AI feature | | Planned | | Fixture |'
+output="$(run_status "$index")"
+assert_contains "$output" \
+  'Building — no STEP In progress; next up is STEP-2 (Ordinary implementation).'
+
 # Active ordinary implementation remains the user's current work and takes precedence over a
-# planned conditional follow-up.
+# planned conditional follow-up. Its guidance is the ordinary substep guidance, read from its own
+# title, even though the last row in the index is the conditional one.
 write_index "$index" \
 '| STEP-1 | Architecture | | Done | | Fixture |
 | STEP-2 | Ordinary implementation | | In progress | | Fixture |
@@ -59,6 +70,8 @@ write_index "$index" \
 output="$(run_status "$index")"
 assert_contains "$output" \
   'Building — STEP-2 (Ordinary implementation) is In progress.'
+assert_contains "$output" \
+  'identify its lowest open substep'
 
 # Active conditional work must emit by-name invocation guidance so agents do not run these
 # thin follow-up prompts by STEP number.
@@ -69,6 +82,15 @@ write_index "$index" \
 output="$(run_status "$index")"
 assert_contains "$output" \
   'identify its conditional template invocation BY NAME'
+
+# The same rule on the active arm: an In-progress STEP that only mentions a conditional session
+# gets the ordinary substep guidance, not the by-name invocation.
+write_index "$index" \
+'| STEP-1 | Architecture | | Done | | Fixture |
+| STEP-2 | Follow-up from Conditional session: AI feature | | In progress | | Fixture |'
+output="$(run_status "$index")"
+assert_contains "$output" \
+  'identify its lowest open substep'
 
 # With no conditional follow-up in the index, the resolver should select ordinary planned work.
 write_index "$index" \


### PR DESCRIPTION
Three tests stayed green when the code they exist to guard was broken. Each one now fails.

- **Conditional-session titles** (`tests/status-conditional-priority.sh`). `status.sh` treats a STEP as a conditional session only when its title *starts with* "Conditional session:". Every fixture title started that way, so dropping the `^` from either match left the test green. Two cases add a title that mentions the phrase partway through, one Planned and one In progress, and expect the ordinary guidance for both. The case where the conditional follow-up is the last row now also checks the In-progress STEP's guidance, which must come from its own title and not from the last row read.
- **Publishing the site** (`tests/site-publish.sh`). The test ran only `brand/publish-site.sh --check` against the committed `docs/`, so the publish itself never ran and `return 0` at the top of `publish_site()` left it green. The `--check` run stays, because it is what catches a `brand/site/` edit that was never published. Beside it, a real publish now runs on a copy of the script in a temporary `brand/` and `docs/`. It must copy both source files, and it must remove a page the site no longer has and a stale file inside a folder it still has. It must also keep `CNAME` and `.nojekyll` and verify its own output.
- **The generated project's CI gate** (new `tests/method-check-workflow.sh`). The doctor step in `method-check.yml` ends with `bash "$doctor"`. Appending `|| true` left the whole suite green, and the branch that finds the doctor when the docs hub is its own repository ran in no test. The new test generates a multi and a mono project, then clones the hub repository and the mono workspace root. It lifts the step's commands out of the workflow and runs them the way Actions runs a `shell: bash` step. On a healthy project they must succeed, and on one with a broken architecture document they must fail. Both runs must print the doctor's own `RESULT` line. The step's other YAML keys are not read.

Tests only. Nothing a generated project receives changes, so there are no release notes.

## Proof

Every new assertion was run against a deliberately broken copy of the code it guards, and against the real code:

| Break | Test before | Test after |
|---|---|---|
| `^` dropped at the Planned match only | pass | **fail** |
| `^` dropped at the In-progress match only | pass | **fail** |
| In-progress match reads the last row's title instead of its own | pass | **fail** |
| `return 0` at the top of `publish_site()` | pass | **fail** |
| delete step removed; `CNAME` not kept; subfolders not copied | pass | **fail** |
| delete step that removes only files, or uses `find -delete` | pass | **fail** |
| each file assertion alone, with the script's self-check disabled | pass | **fail** |
| `bash "$doctor" \|\| true` | pass (whole suite) | **fail** |
| hub-repository branch pointed at a missing file, or never taken | no test | **fail** |
| mono branch globbing the wrong folder | no test | **fail** |
| doctor step renamed, so nothing is lifted | no test | **fail**, naming the missing step |
| none | pass | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
