### PR TITLE
Keep in-flight STEP sheets out of a mono project's repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,14 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **A mono-repo-for-now project no longer commits the STEP in flight.** In that layout the
+  workspace root is the repository, and the `.gitignore` `init.sh` wrote there had no entry for
+  `Upcoming Prompts/`, so the first ordinary `git add -A` committed whatever PLAN or substep prompt
+  was in progress — the working scratch `METHOD.md` calls un-versioned until the STEP is archived
+  into `prompts/`. A new mono project's root `.gitignore` now ignores what is inside the folder and
+  keeps its `.gitkeep` tracked, so a clone still arrives with the folder. Multi-repo projects were
+  never affected: their workspace root is not a repository. An existing mono project adds the two
+  lines itself, as the 1.8 migration notes describe.
 - **A doctor check that read nothing no longer passes.** Four of the checks `scripts/check.sh` runs
   every time read rows out of a table or templates out of a folder, and each printed a clean PASS
   when it found nothing there. Emptying `prompts/STEP-index.md` and `adr/README.md` passed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,7 +405,7 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
-- **A mono-repo-for-now project no longer commits the STEP in flight.** In that layout the
+- **A new mono-repo-for-now project no longer commits the STEP in flight.** In that layout the
   workspace root is the repository, and the `.gitignore` `init.sh` wrote there had no entry for
   `Upcoming Prompts/`, so the first ordinary `git add -A` committed whatever PLAN or substep prompt
   was in progress — the working scratch `METHOD.md` calls un-versioned until the STEP is archived

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,9 +410,11 @@ any project built with it.
   `Upcoming Prompts/`, so the first ordinary `git add -A` committed whatever PLAN or substep prompt
   was in progress — the working scratch `METHOD.md` calls un-versioned until the STEP is archived
   into `prompts/`. A new mono project's root `.gitignore` now ignores what is inside the folder and
-  keeps its `.gitkeep` tracked, so a clone still arrives with the folder. Multi-repo projects were
-  never affected: their workspace root is not a repository. An existing mono project adds the two
-  lines itself, as the 1.8 migration notes describe.
+  keeps its `.gitkeep` tracked, so a clone still arrives with the folder, and `init.sh`'s layout
+  menu and closing message, which told a mono user everything in the folder is tracked, now name
+  that exception. Multi-repo projects were never affected: their workspace root is not a
+  repository. An existing mono project adds the two lines itself, as `UPDATING-THROUGHSTONE.md`'s
+  1.8 section describes.
 - **A doctor check that read nothing no longer passes.** Four of the checks `scripts/check.sh` runs
   every time read rows out of a table or templates out of a folder, and each printed a clean PASS
   when it found nothing there. Emptying `prompts/STEP-index.md` and `adr/README.md` passed the

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -151,11 +151,13 @@ how a repo is brought into a project at all — in a second new runbook. Fast pa
 10. **Mono-repo-for-now only: add two lines to the `.gitignore` at your workspace root** —
     `/Upcoming Prompts/*`, then `!/Upcoming Prompts/.gitkeep` below it — and commit it. In that
     layout the root is the repository, so without them a plain `git add -A` commits the PLAN and
-    substep prompts of the STEP in flight, which the method keeps out of every repository until the
+    substep prompts of the STEP in flight, which the method treats as per-machine scratch until the
     STEP is archived into `prompts/`. New projects get the lines from `init.sh`, which runs once.
-    Then run `git ls-files "Upcoming Prompts"`: anything listed besides `.gitkeep` is already
-    tracked, and the new lines do not untrack it — `git rm --cached` it and commit; the file stays
-    on disk. Multi-repo projects have nothing to do: their workspace root is not a repository.
+    Then run `git ls-files "Upcoming Prompts"`: the new lines do not untrack anything listed there
+    besides `.gitkeep`. To untrack a sheet nobody meant to commit, `git rm --cached` it and commit —
+    your copy stays on disk, but a teammate who pulls that commit loses an unedited copy of theirs,
+    so leave each sheet to whoever owns its STEP. Multi-repo projects have nothing to do: their
+    workspace root is not a repository.
 11. Nothing else. A project that never splits reads none of the splitting material.
 
 **A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -82,7 +82,8 @@ not fail the check.
 allowed and this release does not, and, **if your project is mono-repo-for-now, whether the
 workspace root has a row at all** — **plus, for a mono-repo-for-now project, one thing to check**:
 whether your CI gate has ever actually run — **and one line to change** in `overview.md`, where the
-check-in cadence setting is replaced by the date or STEP your next check-in is due. Beyond the fast path below, nothing is
+check-in cadence setting is replaced by the date or STEP your next check-in is due, **and, if your
+project is mono-repo-for-now, two lines to add** to the `.gitignore` at your workspace root. Beyond the fast path below, nothing is
 required of you unless you are about to split a repository. The release adds a runbook for that, repeals one rule, and writes down
 how a repo is brought into a project at all — in a second new runbook. Fast path:
 
@@ -147,7 +148,15 @@ how a repo is brought into a project at all — in a second new runbook. Fast pa
    These templates travel with the group even though §2's buckets call templates future-only: a
    1.7 copy still tells an agent to explain a question's *what* and *why* together at Levels 1-2,
    which is half of the coupling this item removes.
-10. Nothing else. A project that never splits reads none of the splitting material.
+10. **Mono-repo-for-now only: add two lines to the `.gitignore` at your workspace root** —
+    `/Upcoming Prompts/*`, then `!/Upcoming Prompts/.gitkeep` below it — and commit it. In that
+    layout the root is the repository, so without them a plain `git add -A` commits the PLAN and
+    substep prompts of the STEP in flight, which the method keeps out of every repository until the
+    STEP is archived into `prompts/`. New projects get the lines from `init.sh`, which runs once.
+    Then run `git ls-files "Upcoming Prompts"`: anything listed besides `.gitkeep` is already
+    tracked, and the new lines do not untrack it — `git rm --cached` it and commit; the file stays
+    on disk. Multi-repo projects have nothing to do: their workspace root is not a repository.
+11. Nothing else. A project that never splits reads none of the splitting material.
 
 **A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run
 anywhere but a fresh template checkout. Unpacking the template into a repository you already had and

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -152,12 +152,11 @@ how a repo is brought into a project at all — in a second new runbook. Fast pa
     `/Upcoming Prompts/*`, then `!/Upcoming Prompts/.gitkeep` below it — and commit it. In that
     layout the root is the repository, so without them a plain `git add -A` commits the PLAN and
     substep prompts of the STEP in flight, which the method treats as per-machine scratch until the
-    STEP is archived into `prompts/`. New projects get the lines from `init.sh`, which runs once.
-    Then run `git ls-files "Upcoming Prompts"`: the new lines do not untrack anything listed there
-    besides `.gitkeep`. To untrack a sheet nobody meant to commit, `git rm --cached` it and commit —
-    your copy stays on disk, but a teammate who pulls that commit loses an unedited copy of theirs,
-    so leave each sheet to whoever owns its STEP. Multi-repo projects have nothing to do: their
-    workspace root is not a repository.
+    STEP is archived into `prompts/`. Then run `git ls-files "Upcoming Prompts"`: the new lines
+    untrack nothing, so anything listed besides `.gitkeep` is still tracked. To untrack a sheet
+    nobody meant to commit, `git rm --cached` it and commit — your copy stays on disk, but a
+    teammate who pulls that commit loses an unedited copy of theirs, so leave each sheet to whoever
+    owns its STEP.
 11. Nothing else. A project that never splits reads none of the splitting material.
 
 **A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run

--- a/init.sh
+++ b/init.sh
@@ -1180,6 +1180,11 @@ fi
 # write_gitignore DIR — write the shared baseline ignore file for each generated repo.
 # The contents are intentionally small: editor cruft, per-machine agent config, and local
 # secrets. Project-specific ignores can be added after bootstrap.
+# A mono root also ignores what is inside Upcoming Prompts/: there the workspace root is the
+# repository, and the in-flight STEP's sheets are per-machine scratch until the STEP is archived
+# into prompts/ (METHOD.md §5). Its .gitkeep stays tracked so every clone has the folder. A multi
+# root is not a repository, so the hub and prompts/ get neither line. The lines must be written
+# here, before init_repo's `git add -A`, or a new project starts with a modified .gitignore.
 write_gitignore() {
   cat > "$1/.gitignore" <<'GI'
 # OS / editor cruft
@@ -1202,6 +1207,15 @@ write_gitignore() {
 !.env.example
 .secrets/
 GI
+  if [ "$LAYOUT" = "2" ] && [ "$1" = "." ]; then
+    cat >> "$1/.gitignore" <<'GI'
+
+# The STEP in flight (per-machine scratch until it is archived into prompts/). The .gitkeep stays
+# tracked so every clone has the folder.
+/Upcoming Prompts/*
+!/Upcoming Prompts/.gitkeep
+GI
+  fi
 }
 
 # stamp_license DIR — write the selected project LICENSE for open-source projects.

--- a/init.sh
+++ b/init.sh
@@ -617,7 +617,8 @@ else
   echo "  1) multi-repo now  (prompts/ and Code/${SLUG}-docs/ each become their own repo;"
   echo "                      this folder is not itself a repo, so anything left here is"
   echo "                      not tracked or backed up)"
-  echo "  2) mono-repo for now  (one repo at this folder, so everything here is tracked;"
+  echo "  2) mono-repo for now  (one repo at this folder, so everything here is tracked"
+  echo "                         except the STEP in flight in Upcoming Prompts/;"
   echo "                         split into separate repos later)"
   # No default: the layout is structural and fixed at creation, so Enter cannot be allowed to
   # pick it. The answer is taken through an assignment rather than passed straight to
@@ -1535,8 +1536,9 @@ fi
 # whichever is true. It also names the commit, which neither layout used to mention at all.
 if [ "$LAYOUT" = "2" ]; then
   SAVED_TIP="You can start now; your project is committed locally with Git — everything in this
-  folder is in that repository. For backup, sharing, and working from another computer, put the
-  project on a Git host when you're ready."
+  folder is in that repository except the STEP in flight in Upcoming Prompts/, which stays on this
+  computer until it is archived into prompts/. For backup, sharing, and working from another
+  computer, put the project on a Git host when you're ready."
 else
   SAVED_TIP="You can start now; both repositories here are committed locally with Git —
   Code/${SLUG}-docs/ and prompts/. Files at the workspace root are not in any repository, as the

--- a/init.sh
+++ b/init.sh
@@ -1180,11 +1180,10 @@ fi
 # write_gitignore DIR — write the shared baseline ignore file for each generated repo.
 # The contents are intentionally small: editor cruft, per-machine agent config, and local
 # secrets. Project-specific ignores can be added after bootstrap.
-# A mono root also ignores what is inside Upcoming Prompts/: there the workspace root is the
-# repository, and the in-flight STEP's sheets are per-machine scratch until the STEP is archived
-# into prompts/ (METHOD.md §5). Its .gitkeep stays tracked so every clone has the folder. A multi
-# root is not a repository, so the hub and prompts/ get neither line. The lines must be written
-# here, before init_repo's `git add -A`, or a new project starts with a modified .gitignore.
+# A mono root also ignores the in-flight STEP's sheets in Upcoming Prompts/ (METHOD.md §5), since
+# there the workspace root is the repository. A multi root is not a repository, so the hub and
+# prompts/ get neither line. The lines must be written here, before init_repo's `git add -A`, or a
+# new project starts with a modified .gitignore.
 write_gitignore() {
   cat > "$1/.gitignore" <<'GI'
 # OS / editor cruft

--- a/tests/init-local-user-profile.sh
+++ b/tests/init-local-user-profile.sh
@@ -147,8 +147,8 @@ rm -f "$mono_work/$sheet" "$mono_work/add-probe.txt"
 }
 # Only the folder's contents are ignored: its placeholder stays committed, so a clone of a mono
 # project still has the folder the next PLAN is written into.
-git -C "$mono_work" ls-files --error-unmatch "Upcoming Prompts/.gitkeep" >/dev/null 2>&1 || {
-  printf 'FAIL: the mono bootstrap commit does not track Upcoming Prompts/.gitkeep\n' >&2
+git -C "$mono_work" cat-file -e "HEAD:Upcoming Prompts/.gitkeep" 2>/dev/null || {
+  printf 'FAIL: the mono bootstrap commit does not contain Upcoming Prompts/.gitkeep\n' >&2
   exit 1
 }
 

--- a/tests/init-local-user-profile.sh
+++ b/tests/init-local-user-profile.sh
@@ -129,4 +129,27 @@ copy_template "$mono_work"
 
 assert_profile_output "$mono_work" "Code/$mono-docs"
 
+# In the mono layout the workspace root is the repository, so its ignore file is all that keeps an
+# ordinary `git add -A` from committing the in-flight STEP's sheets, which METHOD.md §5 calls
+# un-versioned. Ask git rather than reading .gitignore: a line git does not honour would still
+# match. The probe is a file the dry run has to name, so a dry run that saw nothing cannot pass, and
+# matching the whole output also catches an ignore file the bootstrap commit left modified.
+sheet="Upcoming Prompts/$mono-STEP-2-PLAN.md"
+printf '# in-flight plan\n' >"$mono_work/$sheet"
+printf 'probe\n' >"$mono_work/add-probe.txt"
+dry_run="$(git -C "$mono_work" add -A --dry-run)"
+rm -f "$mono_work/$sheet" "$mono_work/add-probe.txt"
+[ "$dry_run" = "add 'add-probe.txt'" ] || {
+  printf 'FAIL: git add -A in a fresh mono project should list only add-probe.txt, not %s; got:\n' \
+    "$sheet" >&2
+  printf '%s\n' "$dry_run" >&2
+  exit 1
+}
+# Only the folder's contents are ignored: its placeholder stays committed, so a clone of a mono
+# project still has the folder the next PLAN is written into.
+git -C "$mono_work" ls-files --error-unmatch "Upcoming Prompts/.gitkeep" >/dev/null 2>&1 || {
+  printf 'FAIL: the mono bootstrap commit does not track Upcoming Prompts/.gitkeep\n' >&2
+  exit 1
+}
+
 echo "init.sh local user profile output: PASS"


### PR DESCRIPTION
## What was wrong

In a mono-repo-for-now project the workspace root is the repository. The `.gitignore` that `init.sh`
writes there had no entry for `Upcoming Prompts/`, so the first ordinary `git add -A` committed
whatever PLAN or substep prompt was in flight — the scratch `METHOD.md` §5 calls un-versioned until
the STEP is archived into `prompts/`. Multi-repo projects are not affected: their workspace root is
not a repository.

Reproduced on a fresh mono project generated from `repo-record`, with
`Upcoming Prompts/acme-STEP-2-PLAN.md` written:

```
$ git ls-files "Upcoming Prompts"
Upcoming Prompts/.gitkeep
$ git add -A --dry-run
add 'Upcoming Prompts/acme-STEP-2-PLAN.md'
```

## The change

- **`init.sh`**
  - `write_gitignore` appends `/Upcoming Prompts/*` and `!/Upcoming Prompts/.gitkeep` to the mono
    root's ignore file only, before the bootstrap commit. The folder's contents are ignored and its
    `.gitkeep` stays tracked, so a mono clone still arrives with the folder, and
    `runbooks/splitting-repos.md` stays true as written. Multi's root, hub and `prompts/` ignore
    files are byte-identical to before.
  - The mono layout menu and closing message said everything in the folder is tracked, which this
    makes untrue for the STEP in flight. Both now name that exception, keeping the phrases
    `tests/init-license-validation.sh` checks for.
- **`tests/init-local-user-profile.sh`** — in a fresh mono project, writes a sheet and a probe file
  and asserts `git add -A --dry-run` lists only the probe: an empty dry run cannot pass, and an
  ignore file modified after the bootstrap commit fails too. It also asserts the bootstrap commit
  contains `Upcoming Prompts/.gitkeep`. Both ask git rather than reading the ignore file.
- **`CHANGELOG.md`** — a Fixed entry.
- **`UPDATING-THROUGHSTONE.md`** — the 1.8 migration's opening count gains the two lines, and a new
  fast-path item 10 tells an existing mono project to add them, and how to untrack a sheet that is
  already committed without deleting a teammate's copy. "Nothing else" moves to item 11; nothing
  cited item 10.

## Evidence

- **Mutation-tested**, each in a fresh clone against the new test:
  - unfixed `init.sh` → red
  - the negation line removed → red
  - the whole folder ignored → red
  - the folder name misspelt → red
  - the lines appended after the bootstrap commit → red
  - `.gitkeep` staged after the bootstrap commit but never committed → red
  - the lines written into every repo's ignore file → green, as expected: it is a no-op in multi, so
    that case was checked by hand instead (above)
- **By hand, on fresh projects before and after:** the mono tree is clean after init, a sheet is
  ignored, and `.gitkeep` is tracked. `./doctor.sh check` prints the same result on mono and multi.
- **The migration steps, measured:** adding the lines does not untrack a committed sheet.
  `git rm --cached` keeps the runner's copy. A teammate's unedited copy is removed when they pull,
  and an edited one stops the pull.
- **Suite:** all 18 tests pass locally; CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
