### PR TITLE
Say where to run the Upcoming Prompts listing from

### DIFF
--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -152,7 +152,7 @@ how a repo is brought into a project at all — in a second new runbook. Fast pa
     `/Upcoming Prompts/*`, then `!/Upcoming Prompts/.gitkeep` below it — and commit it. In that
     layout the root is the repository, so without them a plain `git add -A` commits the PLAN and
     substep prompts of the STEP in flight, which the method treats as per-machine scratch until the
-    STEP is archived into `prompts/`. Then run `git ls-files "Upcoming Prompts"`: the new lines
+    STEP is archived into `prompts/`. Then, from the workspace root, run `git ls-files "Upcoming Prompts"`: the new lines
     untrack nothing, so anything listed besides `.gitkeep` is still tracked. To untrack a sheet
     nobody meant to commit, `git rm --cached` it and commit — your copy stays on disk, but a
     teammate who pulls that commit loses an unedited copy of theirs, so leave each sheet to whoever


### PR DESCRIPTION
## What was wrong

The 1.8 migration's fast-path item 10 tells an existing mono-repo-for-now project to run
`git ls-files "Upcoming Prompts"` to find sheets that are already committed, but not where to run it
from. The path is relative to the current directory, so from any subfolder the command prints
nothing and exits 0. That reads as "nothing tracked", and a committed sheet stays tracked.

Measured on a mono project with a sheet already committed:

```
$ git ls-files "Upcoming Prompts"        # from the workspace root
Upcoming Prompts/.gitkeep
Upcoming Prompts/acme-STEP-2-PLAN.md
$ cd Code/acme-docs && git ls-files "Upcoming Prompts"
$                                         # nothing, exit 0
```

## The change

One line in `UPDATING-THROUGHSTONE.md`: "Then run" becomes "Then, from the workspace root, run". This
amends the item added in #217, so there is no separate `CHANGELOG.md` entry (that entry never names
the command). It is a prose change, so no test changes.

## Evidence

- `tests/doc-contract.sh` and `tests/links.sh` pass locally; CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
