### PR TITLE
Make two doctor messages describe what their checks look at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,17 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **Two doctor messages now describe what their checks look at.** When `scripts/check.sh` finds an
+  unexpected entry at the root of a multi-repo workspace, its hint said to move durable content into
+  a repo — wrong for a repo registered at a path such as `backend/`, which may sit at any path inside
+  the workspace and never has to move. The hint now asks whether each entry is fine where it is, and
+  says anything else durable belongs in a repo. The architecture-session numbering check said a
+  template "does not instruct the agent to write architecture/NN-… in its Output section", but it
+  searches the whole file for a line that starts with ``Write `architecture/NN-``, so a template
+  whose instruction is a bullet, `- Write …`, was told it had no such instruction. It now says the
+  file has no line starting with that text. Neither check's logic changed.
+  `templates/ci/README.md` also no longer lists root hygiene among what CI's doctor run checks: that
+  check is skipped whenever `CI` is non-empty, as it is on GitHub Actions.
 - **A new mono-repo-for-now project no longer commits the STEP in flight.** In that layout the
   workspace root is the repository, and the `.gitignore` `init.sh` wrote there had no entry for
   `Upcoming Prompts/`, so the first ordinary `git add -A` committed whatever PLAN or substep prompt

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -280,7 +280,7 @@ else
   done
   if [ -n "$stray" ]; then
     warn "unexpected entr(ies) at workspace root:$stray — should these be inside a repo (usually the docs hub)?"
-    hint "move durable content into a repo (almost always Code/<project>-docs/); the root holds only per-machine pointers, the repo folders, and Upcoming Prompts/. See $DOCS_REL/METHOD.md §7."
+    hint "ask whether each entry is fine where it is: a repo registered in $DOCS_REL/registries/repos.yml may sit at any path inside the workspace and never has to move, and anything else durable belongs in a repo (almost always $DOCS_REL/). See $DOCS_REL/METHOD.md §7."
   else
     pass "only the expected pointers / repos at the workspace root"
   fi
@@ -352,7 +352,7 @@ else
     # exception: it produces a review doc after all numbered architecture docs exist.
     if [[ "$b" != *cross-cutting-review.md ]]; then
       if ! grep -Eq "^Write \`architecture/${prefix}-[^\`]+\`" "$f"; then
-        fail "$b does not instruct the agent to write architecture/${prefix}-… in its Output section"
+        fail "$b has no line starting with Write \`architecture/${prefix}-…\`"
         numbering_ok=0
       fi
       if [ -n "$seed_output" ] && ! printf '%s' "$seed_output" | grep -q "architecture/${prefix}-"; then

--- a/Code/{{PROJECT}}-docs/templates/ci/README.md
+++ b/Code/{{PROJECT}}-docs/templates/ci/README.md
@@ -8,7 +8,7 @@ checks and the test gate the Test Strategy architecture doc calls for
 ## 1. Method integrity — `method-check.yml`  *(ships live; no template step)*
 
 Runs the project "doctor" (`scripts/check.sh` in the docs hub): duplicate STEP/ADR numbers,
-invalid statuses, architecture-doc frontmatter, ADR registry vs. files on disk, root hygiene,
+invalid statuses, architecture-doc frontmatter, ADR registry vs. files on disk,
 numbered-session/seed alignment, the conditional-session template contract required by
 the Cross-Cutting Review and periodic check-in. It is **already installed** in the docs hub
 at `Code/{{PROJECT}}-docs/.github/workflows/method-check.yml`, so in a **multi-repo** project


### PR DESCRIPTION
## What was wrong

Two messages from `scripts/check.sh` described something other than what their checks do, and the CI starter's README listed a check that CI skips.

- **Workspace-root hygiene.** An unexpected entry at the root of a multi-repo workspace got the hint "move durable content into a repo". A repo registered in `registries/repos.yml` may sit at any path inside the workspace and never has to move (`METHOD.md` §7), so for a repo registered at `backend/` the hint prescribed the wrong fix.
- **Architecture-session numbering.** A failing template was told it "does not instruct the agent to write architecture/NN-… in its Output section". The check searches the whole file for a line starting with ``Write `architecture/NN-``, so a template that writes the instruction as a bullet was told the instruction is missing.
- **CI starter README.** `templates/ci/README.md` listed "root hygiene" among what the doctor checks in CI, but that check is skipped whenever `CI` is non-empty.

## The change

- `scripts/check.sh`: the hygiene hint now asks whether each entry is fine where it is: a registered repo may sit at any path inside the workspace and never has to move, and anything else durable belongs in a repo. The warning line above it is unchanged, since `tests/init-local-user-profile.sh` matches its text. The numbering check's failure now says the file has no line starting with `` Write `architecture/NN-…` ``. No logic changes.
- `templates/ci/README.md`: "root hygiene" is dropped from the list.
- `CHANGELOG.md`: one Fixed entry. No `UPDATING-THROUGHSTONE.md` line: an existing project has nothing to do.

## Evidence

A multi-repo project generated with `init.sh --non-interactive --layout=multi`, once at `599cd56` and once with this PR's changes. In each, a repo is registered at `backend/` (`git init backend` plus a `repos.yml` row), and the Write line of `02-phasing-roadmap.md` gets a bullet (`` - Write `architecture/02-phasing-roadmap.md` … ``). `env -u CI ./doctor.sh check`, sections 7 and 8:

Before:

```
7. Workspace-root hygiene (multi-repo only)
  [WARN] unexpected entr(ies) at workspace root: backend — should these be inside a repo (usually the docs hub)?
         → fix: move durable content into a repo (almost always Code/<project>-docs/); the root holds only per-machine pointers, the repo folders, and Upcoming Prompts/. See Code/acme-docs/METHOD.md §7.

8. Architecture-session template numbering
  [FAIL] 02-phasing-roadmap.md does not instruct the agent to write architecture/02-… in its Output section
         → fix: keep numbered session files, their '(Session 1.N)' headings, and Code/acme-docs/templates/step-index-seed.md rows in lockstep; the Cross-Cutting Review remains the final numbered session.
```

After:

```
7. Workspace-root hygiene (multi-repo only)
  [WARN] unexpected entr(ies) at workspace root: backend — should these be inside a repo (usually the docs hub)?
         → fix: ask whether each entry is fine where it is: a repo registered in Code/acme-docs/registries/repos.yml may sit at any path inside the workspace and never has to move, and anything else durable belongs in a repo (almost always Code/acme-docs/). See Code/acme-docs/METHOD.md §7.

8. Architecture-session template numbering
  [FAIL] 02-phasing-roadmap.md has no line starting with Write `architecture/02-…`
         → fix: keep numbered session files, their '(Session 1.N)' headings, and Code/acme-docs/templates/step-index-seed.md rows in lockstep; the Cross-Cutting Review remains the final numbered session.
```

The run's severities and exit code are the same before and after (one WARN, one FAIL, exit 1).

Full suite, `for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`: all 18 files pass locally; CI below. No test pins either changed text, so no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
