### PR TITLE
Fail the status check on a Status of only dashes, or blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,16 @@ any project built with it.
   on in phase 3 still gets its one run even though the roadmap is full of earlier check-ins.
 
 ### Fixed
+- **The status check no longer passes a row whose Status is only dashes, or blank.** To step over
+  each table's separator line, `scripts/check.sh` skipped every row whose Status cell was empty or
+  made only of dashes, so a STEP or substep row with a Status of `-`, `--` or `:-:`, or none at all,
+  passed. `./doctor.sh status` skips the same rows without a word: with STEP-2's Status set to `-`
+  and STEP-3 Planned, it reported no STEP in progress and named STEP-3 as next up, and with substep
+  1.1's set to `-` it left 1.1 out and sent you to 1.2. A row now counts as the separator only when
+  its first cell is dashes as well, so a dash or blank Status on any other row fails the check like
+  any other value outside the vocabulary. `./doctor.sh status` is unchanged; the failing check is
+  what points at the row. A project with such a row sees the check fail after upgrading, and
+  `UPDATING-THROUGHSTONE.md`'s 1.8 section says what to do.
 - **Two doctor messages now describe what their checks look at.** When `scripts/check.sh` finds an
   unexpected entry at the root of a multi-repo workspace, its hint said to move durable content into
   a repo — wrong for a repo registered at a path such as `backend/`, which may sit at any path inside

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -157,7 +157,12 @@ how a repo is brought into a project at all — in a second new runbook. Fast pa
     nobody meant to commit, `git rm --cached` it and commit — your copy stays on disk, but a
     teammate who pulls that commit loses an unedited copy of theirs, so leave each sheet to whoever
     owns its STEP.
-11. Nothing else. A project that never splits reads none of the splitting material.
+11. **If `./doctor.sh check` now fails a Status that is only dashes, or blank**, write that STEP's or
+    substep's real status in `prompts/STEP-index.md`. The doctor used to skip such a row as though
+    it were the table's separator line, and `./doctor.sh status` still does — so until it is fixed,
+    the helper answers as if the row were not in the index at all. A project whose statuses are all
+    filled in sees no change.
+12. Nothing else. A project that never splits reads none of the splitting material.
 
 **A bootstrap fix, with nothing for you to do.** 1.8 also fixes `init.sh` so that it refuses to run
 anywhere but a fresh template checkout. Unpacking the template into a repository you already had and

--- a/Code/{{PROJECT}}-docs/scripts/check.sh
+++ b/Code/{{PROJECT}}-docs/scripts/check.sh
@@ -167,7 +167,9 @@ if [ -f "$INDEX" ]; then
       if (!inrow || statuscol == 0) next
       stepread += steprow
       sc = trim($statuscol)
-      if (sc == "" || sc ~ /^:?-+:?$/) next                            # blank or separator row
+      # The separator row is the one whose first cell is dashes too. A data row whose Status is
+      # dashes or blank is checked like any other value, and fails.
+      if (sc ~ /^:?-+:?$/ && trim($2) ~ /^:?-+:?$/) next
       subread += subtable
       if (sc != "Planned" && sc != "In progress" && sc != "Done" && sc != "Deferred" && sc != "Abandoned" && sc != "N/A")
         print trim($2) " -> \"" sc "\""

--- a/tests/check-nothing-to-inspect.sh
+++ b/tests/check-nothing-to-inspect.sh
@@ -2,12 +2,15 @@
 #
 # Regression coverage for the every-run doctor checks that read rows out of a table, or templates
 # out of a folder, when there is nothing there to read: scripts/check.sh's duplicate-STEP,
-# duplicate-ADR, status and conditional-template checks.
+# duplicate-ADR, status and conditional-template checks — and for the one row the status check
+# skips on purpose, a table's separator, which a data row with a Status of only dashes, or none,
+# must not pass for.
 #
-# The defect under test is a clean PASS from a check that read nothing — an emptied STEP index or
-# ADR registry, a STEP table whose Status header was renamed, a missing session-templates folder.
-# So every case refutes its section's PASS as well as expecting the WARN: the WARN alone could be
-# printed beside a PASS that still vouches for rows nobody read.
+# The defect under test is a clean PASS over rows the check never read — an emptied STEP index or
+# ADR registry, a STEP table whose Status header was renamed, a missing session-templates folder,
+# or a data row skipped as a separator. So every case refutes its section's PASS as well as
+# expecting the WARN or FAIL: that finding alone could be printed beside a PASS that still vouches
+# for rows nobody read.
 #
 # Half of the rule is staying quiet. Some zeros are how a project starts — no ADR yet — or a
 # choice a project may make — deleting the optional conditional templates — and a doctor that
@@ -232,6 +235,27 @@ doctor "$c"
 look "Conditional-session template contract"
 expect "[WARN] no $sessions/ folder — skipping conditional-session check" "missing session-templates folder"
 refute "[PASS]" "missing session-templates folder"
+
+# --- 6. A Status of only dashes, or none ------------------------------------------
+# The status check skips a table's separator row, whose cells are all dashes. A data row keeps its
+# id in the first cell, so a Status of `-`, or a blank one, on a STEP or substep row is read like
+# any other value and fails the run. A separator written with spaces and alignment colons is still
+# skipped.
+c="$(fixture dash-status)"
+idx="$c/prompts/STEP-index.md"
+edit "$idx" 's/^(\| STEP-1 \| Architecture \| \| )Planned/${1}-/' "setting STEP-1 to -"
+edit "$idx" 's/^(\| 1\.1 \| [^|]*\| )Planned/${1}-/' "setting substep 1.1 to -"
+edit "$idx" 's/^(\| 1\.2 \| [^|]*\| )Planned/${1}/' "blanking substep 1.2"
+edit "$idx" 's/^\|-+\|-+\|-+\|-+\|$/| :------ | ------- | :----: | ---------- |/' "spacing and aligning the substep separator"
+doctor "$c"
+look "Statuses valid"
+expect "[FAIL] invalid status value(s):" "dash or blank status"
+expect 'STEP-1 -> "-"' "a STEP row whose Status is -"
+expect '1.1 -> "-"' "a substep row whose Status is -"
+expect '1.2 -> ""' "a substep row with a blank Status"
+refute ':----:' "a separator written with spaces and colons"
+refute "[PASS]" "dash or blank status"
+[ "$DOC_STATUS" -eq 1 ] || bad "dash or blank status — expected exit 1, got $DOC_STATUS"
 
 if [ "$failures" -ne 0 ]; then
   printf 'check.sh nothing-to-inspect checks: %d FAILURE(S)\n' "$failures" >&2


### PR DESCRIPTION
## What was wrong

`scripts/check.sh`'s status check steps over each table's separator row by looking at its Status cell alone: `if (sc == "" || sc ~ /^:?-+:?$/) next`. That also skipped every data row whose Status was only dashes (`-`, `--`, `:-:`) or blank, so the check passed them. The line has been there since the doctor was added, and ships in 1.6.0, 1.7.0 and 1.7.1.

`./doctor.sh status` skips the same rows, so a stray `-` silently changes what it tells you. Measured on a generated multi-repo project past kickoff:

```
STEP-1 In progress, substep 1.1 In progress      ->  0/14 substeps complete; Run STEP-1.1
STEP-1 In progress, substep 1.1 "-"              ->  0/13 substeps complete; Run STEP-1.2

STEP-1 Done, STEP-2 In progress, STEP-3 Planned  ->  STEP-2 (Build the first slice) is In progress
STEP-1 Done, STEP-2 "-",         STEP-3 Planned  ->  no STEP In progress; next up is STEP-3
```

## The change

- `scripts/check.sh`: a row counts as the separator only when its first cell is dashes as well. Every other row's Status is checked, so a dash or blank one fails like any other value outside the vocabulary (`STEP-1 -> "-"`, `1.2 -> ""`).
- A blank Status is caught too, because nothing shipped has one. Across every tracked table with a Status column, the only blank cells are the placeholder rows in `adr/README.md` and `architecture/README.md`, which this check never reads; a freshly generated `prompts/STEP-index.md` has none; and the example STEP rows the docs show outside a table all carry a real status.
- `status.sh` is unchanged. The failing check is what points at the row.
- `tests/check-nothing-to-inspect.sh`: a new case sets STEP-1 and substep 1.1 to `-`, blanks substep 1.2, and rewrites the substep table's separator with spaces and alignment colons (`| :------ | ------- | :----: | ---------- |`). It expects each of the three rows named under `[FAIL] invalid status value(s):`, the separator not named, no PASS, and exit 1. The file's header now covers the one row the status check skips on purpose.

## Evidence

Mutations of the new line, each in its own clone, running `tests/check-nothing-to-inspect.sh`:

| Mutation | Result |
|---|---|
| none | PASS |
| the old line restored | red: 6 of the case's 7 assertions (the old line skipped the spaced separator too) |
| blank Status still skipped | red: only the blank-row assertion |
| dash Status still skipped | red: only the two dash-row assertions |
| separator skip deleted | red: the fresh-project case, an exit-code check in another case, and the separator assertion |
| first cell not trimmed | red: only the separator assertion |
| no colons allowed in the first cell | red: only the separator assertion |
| no colons allowed in either cell | red: only the separator assertion |

Full suite, `for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`: all 18 files pass locally; CI below.

## Release notes

`CHANGELOG.md` under Fixed. `UPDATING-THROUGHSTONE.md`'s 1.8 fast path gains item 11 — if the doctor now fails a dash or blank Status, write that row's real status — and "Nothing else" becomes item 12. The section's opening tally is unchanged: like item 7, the new item applies only to a project that has such a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
