### PR TITLE
Correct two false sentences about the repo-registry check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,8 @@ any project built with it.
   `skipped — run with --check-in`, and the generated CI workflow never passes the flag: a typo in the
   registry has no business failing a build on every push. `runbooks/check-in.md` is what passes it,
   where a person is already looking, and it says what to do with each finding — a `[FAIL]` gets
-  fixed, a `[WARN]` gets a decision rather than a reflex fix. `scripts/check.sh` also gains its first
+  fixed, a `[WARN]` gets a decision rather than a reflex fix. `registries/README.md`, which named CI
+  among the file's readers, now names the check-in. `scripts/check.sh` also gains its first
   test, `tests/check-repo-registry.sh`, and the flag is listed in `./doctor.sh --help`, in the
   command list and in the examples.
 
@@ -179,8 +180,8 @@ any project built with it.
   nothing enforces it: it stays advice, and §10 rule 7 still never becomes the next action.
 
   **What went with it.** The cadence setting and its default; the DUE/OVERDUE windows and the
-  arithmetic around them; the doctor check that validated the setting (which renumbers the
-  repo-registry check from 11 to 10); and the `Check-in` title rule as a machine contract — it
+  arithmetic around them; the doctor check that validated the setting; and the `Check-in` title
+  rule as a machine contract — it
   survives in the documents as a plain roadmap convention, policed by nothing. New projects are
   seeded `STEP-20`, a starting suggestion rather than a rule. One hazard survives and stays
   guarded: a hand-written `STEP-08` is forced to base 10, because `$(( ))` reads a leading zero as

--- a/Code/{{PROJECT}}-docs/registries/README.md
+++ b/Code/{{PROJECT}}-docs/registries/README.md
@@ -9,7 +9,7 @@ itself, because tooling and CI parse it. Keep each file the **source of truth**;
 
 | File | What | Consumed by |
 |------|------|-------------|
-| [`repos.yml`](repos.yml) | The repo inventory — which repos exist, what each is, and where its docs live. See its header and `METHOD.md` §7. | `scripts/setup-workspace.sh` (clones from `remote:` into locations the workspace owns); `runbooks/collaboration.md` (STEP-number reservation); CI. |
+| [`repos.yml`](repos.yml) | The repo inventory — which repos exist, what each is, and where its docs live. See its header and `METHOD.md` §7. | `scripts/setup-workspace.sh` (clones from `remote:` into locations the workspace owns); `runbooks/collaboration.md` (STEP-number reservation); `scripts/check.sh --check-in` (the periodic check-in's registry check). |
 | [`risks.yml`](risks.yml) | The accepted risk / tech-debt index — known risks, conscious deferrals, and debt with owners, revisit triggers, and references to the artifact that explains the detail. | Security session deferrals; dependency audits; incident follow-ups; `runbooks/check-in.md`. |
 | [`security-reviews.yml`](security-reviews.yml) | The security review ledger — latest S0/S1/S2 review dates, cadence, report paths, reviewed commit, rough SLOC snapshot, and deltas since the previous run. | `runbooks/security-review.md`; `runbooks/check-in.md` security gate. |
 


### PR DESCRIPTION
## What was wrong

Two sentences about the repo-registry check are not true.

- `registries/README.md` lists **CI** among the readers of `repos.yml`. No CI workflow reads it: the docs hub's `.github/workflows/method-check.yml` says the repo registry is deliberately not checked there, and runs the doctor without `--check-in`. The claim has been in that table since the table was written, so it ships in 1.6.0, 1.7.0 and 1.7.1.
- `CHANGELOG.md`'s entry for removing the check-in cadence says removing its doctor check "renumbers the repo-registry check from 11 to 10". No release had a check 11: 1.6.0 had eight checks, and 1.7.0 and 1.7.1 had ten, the tenth being the cadence marker. The registry check first ships as check 10.

## The change

- `registries/README.md`: "CI." becomes `` `scripts/check.sh --check-in` (the periodic check-in's registry check) ``.
- `CHANGELOG.md`: the parenthetical is dropped. The `--check-in` entry, which already says the generated CI workflow never passes the flag, gains one sentence noting the README correction.

No `UPDATING-THROUGHSTONE.md` line: an existing project has nothing to do.

## Evidence

- `git grep -n -i registr` over `.github/`, the docs hub's `.github/` and `templates/ci/`: every hit is about the ADR registry, apart from `method-check.yml`'s comment that the repo registry is not checked.
- The check list at the top of `scripts/check.sh` in each release (`git show <tag>:…`): v1.6.0 lists 1–8; v1.7.0 and v1.7.1 list 1–10, with 10 the `CHECK-IN-CADENCE` marker. Nothing else in the repo mentions a check 11.
- `tests/links.sh` and `tests/doc-contract.sh` pass, within the full suite, `for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`: all 18 files pass locally; CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
