### PR TITLE
Stop describing a check-in cadence setting on the website

### DIFF
--- a/brand/site/index.html
+++ b/brand/site/index.html
@@ -237,7 +237,7 @@
     <div class="flow">
       <div class="flow-step"><div class="num">01</div><h3>Design first</h3><p>Point the agent at AGENTS.md to kick off: it interviews you, then the architecture sessions capture scope, data, security, interfaces, testing, deployment, and ADRs before any app code.</p></div>
       <div class="flow-step"><div class="num">02</div><h3>Build in STEPs</h3><p>The planning session turns the locked architecture into implementation STEPs, each a focused substep prompt with verification, review, and archival.</p></div>
-      <div class="flow-step"><div class="num">03</div><h3>Check-ins</h3><p>On a cadence you set (about every 20 STEPs), reconcile the docs against the code, re-check risks, and run the full suite so drift can't pile up.</p></div>
+      <div class="flow-step"><div class="num">03</div><h3>Check-ins</h3><p>At a STEP or date you schedule (new projects start at STEP-20), reconcile the docs against the code, re-check risks, and run the full suite so drift can't pile up.</p></div>
     </div>
     <div class="flow-note">
       <div class="eyebrow">Beyond the build</div>
@@ -356,7 +356,7 @@
       <p>Design isn't just architecture. Throughstone plans for the full lifecycle — deployment, releases, incidents, and dependencies — with runbooks and registers for the maintenance work that often gets skipped until production exposes it.</p>
     </div>
     <div class="ops-grid">
-      <div class="op-card"><h3>Check-ins</h3><p>On a cadence you set (about every 20 STEPs), reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
+      <div class="op-card"><h3>Check-ins</h3><p>At a STEP or date you schedule (new projects start at STEP-20), reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
       <div class="op-card"><h3>Release and rollback</h3><p>Prepare the rollback path before deploy, verify during a watch window, and make the return lever explicit.</p></div>
       <div class="op-card"><h3>Incidents</h3><p>Stabilize first, then run root-cause analysis, search for similar bugs, fix, harden, and write the postmortem.</p></div>
       <div class="op-card"><h3>Dependencies</h3><p>Vet packages before adding them and audit installed dependencies for vulnerabilities, licenses, and provenance.</p></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -237,7 +237,7 @@
     <div class="flow">
       <div class="flow-step"><div class="num">01</div><h3>Design first</h3><p>Point the agent at AGENTS.md to kick off: it interviews you, then the architecture sessions capture scope, data, security, interfaces, testing, deployment, and ADRs before any app code.</p></div>
       <div class="flow-step"><div class="num">02</div><h3>Build in STEPs</h3><p>The planning session turns the locked architecture into implementation STEPs, each a focused substep prompt with verification, review, and archival.</p></div>
-      <div class="flow-step"><div class="num">03</div><h3>Check-ins</h3><p>On a cadence you set (about every 20 STEPs), reconcile the docs against the code, re-check risks, and run the full suite so drift can't pile up.</p></div>
+      <div class="flow-step"><div class="num">03</div><h3>Check-ins</h3><p>At a STEP or date you schedule (new projects start at STEP-20), reconcile the docs against the code, re-check risks, and run the full suite so drift can't pile up.</p></div>
     </div>
     <div class="flow-note">
       <div class="eyebrow">Beyond the build</div>
@@ -356,7 +356,7 @@
       <p>Design isn't just architecture. Throughstone plans for the full lifecycle — deployment, releases, incidents, and dependencies — with runbooks and registers for the maintenance work that often gets skipped until production exposes it.</p>
     </div>
     <div class="ops-grid">
-      <div class="op-card"><h3>Check-ins</h3><p>On a cadence you set (about every 20 STEPs), reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
+      <div class="op-card"><h3>Check-ins</h3><p>At a STEP or date you schedule (new projects start at STEP-20), reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite.</p></div>
       <div class="op-card"><h3>Release and rollback</h3><p>Prepare the rollback path before deploy, verify during a watch window, and make the return lever explicit.</p></div>
       <div class="op-card"><h3>Incidents</h3><p>Stabilize first, then run root-cause analysis, search for similar bugs, fix, harden, and write the postmortem.</p></div>
       <div class="op-card"><h3>Dependencies</h3><p>Vet packages before adding them and audit installed dependencies for vulnerabilities, licenses, and provenance.</p></div>


### PR DESCRIPTION
## What was wrong

The website says check-ins happen "On a cadence you set (about every 20 STEPs)", once in the three-step process (`03 Check-ins`) and once in the operations cards. 1.8 removes the cadence setting. `METHOD.md` §5 now says "When the next one is due is recorded, not calculated": `overview.md` holds a `NEXT-CHECK-IN` line with a STEP number or a date, written by whoever schedules the check-in (the planning session, the check-in itself before it closes, or the user), and a new project starts on the seeded STEP-20.

## The change

Both sentences now open "At a STEP or date you schedule (new projects start at STEP-20), …"; the rest of each is unchanged. The edit is in `brand/site/index.html` and is copied to `docs/index.html` by `brand/publish-site.sh`. Nothing else in `brand/`, `docs/` or `README.md` mentions a cadence.

The live site is served from `docs/` on `main`, so this reaches it only when `repo-record` merges to `main`.

No `CHANGELOG.md` line: of the last eight commits that changed `brand/site`, only one carried a CHANGELOG entry, and it covered a README change made in the same commit.

## Evidence

- `brand/publish-site.sh`, then `brand/publish-site.sh --check`: `site publish check: PASS`.
- `tests/site-publish.sh`: PASS.
- Rendered in a browser, the two `Check-ins` paragraphs read:
  - "At a STEP or date you schedule (new projects start at STEP-20), reconcile the docs against the code, re-check risks, and run the full suite so drift can't pile up."
  - "At a STEP or date you schedule (new projects start at STEP-20), reconcile docs against code, re-check conditional sessions, review risks, and run the full test suite."
- Full suite, `for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`: all 18 files pass locally; CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
