### PR TITLE
Say where init.sh may run, and drop two stale counts in a test comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ checkout is the **Throughstone scaffold before project initialization**, not an 
 app/project workspace. In that mode, do **not** start the generated-project kickoff/resume
 flow. Treat the files under the template docs path as templates for future projects, and
 work on the scaffold repo like a normal repository unless the user explicitly asks to run
-`./init.sh` or to simulate/test a generated project.
+`./init.sh` or to simulate/test a generated project. `init.sh` deletes `.git` (reflog included),
+`.dev/` and `TODO.md`, among other files, so run it in this checkout only when it is a fresh clone
+meant to become the project; for anything else, run it in a throwaway copy.
 
 If the docs path below is a concrete project path such as `Code/<name>-docs/AGENTS.md`,
 ignore this guard and follow the normal handoff below.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ checkout is the **Throughstone scaffold before project initialization**, not an 
 app/project workspace. In that mode, do **not** start the generated-project kickoff/resume
 flow. Treat the files under the template docs path as templates for future projects, and
 work on the scaffold repo like a normal repository unless the user explicitly asks to run
-`./init.sh` or to simulate/test a generated project.
+`./init.sh` or to simulate/test a generated project. `init.sh` deletes `.git` (reflog included),
+`.dev/` and `TODO.md`, among other files, so run it in this checkout only when it is a fresh clone
+meant to become the project; for anything else, run it in a throwaway copy.
 
 If the docs path below is a concrete project path such as `Code/<name>-docs/AGENTS.md`,
 ignore this guard and follow the normal handoff below.

--- a/tests/setup-workspace-resilience.sh
+++ b/tests/setup-workspace-resilience.sh
@@ -270,7 +270,7 @@ assert_no_placeholders() {
   local leaked named actual="$TMP_ROOT/placeholders-$slug"
 
   # The three tokens init.sh has a value for. They have to be named rather than inferred from the
-  # file list, because fourteen of the files pinned above legitimately hold other {{ tokens: a
+  # file list, because many of the files pinned above legitimately hold other {{ tokens: a
   # {{PROJECT}} that survived inside one of those would leave the list below entirely unchanged.
   leaked="$( cd "$work" && grep -rlF --exclude-dir=.git \
     -e '{{PROJECT}}' -e '{{PROJECT_DESCRIPTION}}' -e '{{TRUNK_BRANCH}}' . 2>/dev/null \
@@ -291,7 +291,7 @@ assert_no_placeholders() {
 
   # Every other file still holding a {{ token has to be one the project is meant to keep. The
   # docs hub is named for the slug, so normalise that one directory out of the path; without it
-  # the two layouts spell the same twenty files two different ways.
+  # the two layouts spell the same files two different ways.
   ( cd "$work" && grep -rlF '{{' . --exclude-dir=.git 2>/dev/null ) \
     | sed -e 's|^\./||' -e "s|^Code/$slug-docs/|Code/DOCS/|" | sort > "$actual"
   diff -u "$RETAINED_PLACEHOLDERS" "$actual" \


### PR DESCRIPTION
## What was wrong

- The template-checkout guard at the top of the root `AGENTS.md` and `CLAUDE.md` lets an agent run `./init.sh` when the user asks, but never says where. `init.sh` deletes `.git` (reflog included), `.dev/` and `TODO.md`, among other files, so in a checkout where the scaffold itself is being worked on, a mistaken run loses unpushed history and untracked notes for good.
- `tests/setup-workspace-resilience.sh` calls its pinned placeholder list "the same twenty files" (the list has nineteen) and says "fourteen" of them hold other tokens. Both counts are out of date.

## The change

- Both guards gain one sentence: "`init.sh` deletes `.git` (reflog included), `.dev/` and `TODO.md`, among other files, so run it in this checkout only when it is a fresh clone meant to become the project; for anything else, run it in a throwaway copy." A new user's fresh clone shows an agent this same guard, and cloning and then running `./init.sh` there is the README's documented start, so the sentence allows that case rather than forbidding every run in place.
- The test comments now say "the same files" and "many of the files", which stay true as the list changes. No test logic changes.

No release note: both are scaffold-only files, and `init.sh` strips the guard block from every generated project.

## Evidence

- The two guard blocks, `THROUGHSTONE-TEMPLATE-GUARD:BEGIN` to `:END`, are byte-identical (`cmp`).
- A multi-repo project generated from this branch with `init.sh --non-interactive`: its `AGENTS.md` and `CLAUDE.md` contain neither the guard marker nor the new sentence.
- Full suite, `for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`: all 18 files pass locally; CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
