### PR TITLE
Scope the init.sh rule in the template guard to testing the framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ checkout is the **Throughstone scaffold before project initialization**, not an 
 app/project workspace. In that mode, do **not** start the generated-project kickoff/resume
 flow. Treat the files under the template docs path as templates for future projects, and
 work on the scaffold repo like a normal repository unless the user explicitly asks to run
-`./init.sh` or to simulate/test a generated project. `init.sh` deletes `.git` (reflog included),
-`.dev/` and `TODO.md`, among other files, so run it in this checkout only when it is a fresh clone
-meant to become the project; for anything else, run it in a throwaway copy.
+`./init.sh` or to simulate/test a generated project — and then do it in a throwaway copy, never in
+this checkout: `init.sh` turns whatever checkout it runs in into a generated project, which would
+pollute the framework's own file structure.
 
 If the docs path below is a concrete project path such as `Code/<name>-docs/AGENTS.md`,
 ignore this guard and follow the normal handoff below.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ checkout is the **Throughstone scaffold before project initialization**, not an 
 app/project workspace. In that mode, do **not** start the generated-project kickoff/resume
 flow. Treat the files under the template docs path as templates for future projects, and
 work on the scaffold repo like a normal repository unless the user explicitly asks to run
-`./init.sh` or to simulate/test a generated project. `init.sh` deletes `.git` (reflog included),
-`.dev/` and `TODO.md`, among other files, so run it in this checkout only when it is a fresh clone
-meant to become the project; for anything else, run it in a throwaway copy.
+`./init.sh` or to simulate/test a generated project — and then do it in a throwaway copy, never in
+this checkout: `init.sh` turns whatever checkout it runs in into a generated project, which would
+pollute the framework's own file structure.
 
 If the docs path below is a concrete project path such as `Code/<name>-docs/AGENTS.md`,
 ignore this guard and follow the normal handoff below.


### PR DESCRIPTION
## What was wrong

#223 gave the template-checkout guard in the root `AGENTS.md` and `CLAUDE.md` a rule about where `./init.sh` may run, with a carve-out: run it in the checkout "only when it is a fresh clone meant to become the project". That carve-out was written for new users, who are not what this guard is for. The guard is the override for developing Throughstone itself; a new user runs `init.sh` in their own new project directory, as the normal start. #223 also framed the reason as the files `init.sh` deletes, when the reason is that a test run would turn the framework checkout into a generated project.

## The change

The guard's last sentence, in both files, now reads: "…unless the user explicitly asks to run `./init.sh` or to simulate/test a generated project — and then do it in a throwaway copy, never in this checkout: `init.sh` turns whatever checkout it runs in into a generated project, which would pollute the framework's own file structure."

No release note: both are scaffold-only files, and `init.sh` strips the guard block from every generated project.

## Evidence

- The two guard blocks, `THROUGHSTONE-TEMPLATE-GUARD:BEGIN` to `:END`, are byte-identical (`cmp`).
- A multi-repo project generated from this branch with `init.sh --non-interactive`: its `AGENTS.md` and `CLAUDE.md` contain neither the guard marker nor the new sentence.
- A fresh reader given only the root `AGENTS.md`, asked "test init.sh with a multi-repo layout" or "run ./init.sh", makes a throwaway copy and runs it there. Asked to fix a typo in `Code/{{PROJECT}}-docs/METHOD.md`, it edits the file in place and starts no kickoff. A second pass checked the claim against `init.sh`: its own fresh-template check does not stop a run in this checkout, so this sentence is what does. No tracked file quotes the previous wording.
- Full suite, `for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`: all 18 files pass locally; CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
