### PR TITLE
Stop saying CI parses the registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,8 @@ any project built with it.
   `skipped — run with --check-in`, and the generated CI workflow never passes the flag: a typo in the
   registry has no business failing a build on every push. `runbooks/check-in.md` is what passes it,
   where a person is already looking, and it says what to do with each finding — a `[FAIL]` gets
-  fixed, a `[WARN]` gets a decision rather than a reflex fix. `registries/README.md`, which named CI
-  among the file's readers, now names the check-in. `scripts/check.sh` also gains its first
+  fixed, a `[WARN]` gets a decision rather than a reflex fix. `registries/README.md` no longer
+  says CI reads the registries; its table names the check-in. `scripts/check.sh` also gains its first
   test, `tests/check-repo-registry.sh`, and the flag is listed in `./doctor.sh --help`, in the
   command list and in the examples.
 

--- a/Code/{{PROJECT}}-docs/registries/README.md
+++ b/Code/{{PROJECT}}-docs/registries/README.md
@@ -2,7 +2,7 @@
 
 Machine-readable **inventories of the project's state** — structured data, not prose. Unlike
 the other doc folders (whose README *is* the index), a registry's index is the data file
-itself, because tooling and CI parse it. Keep each file the **source of truth**; describe the
+itself, because tooling parses it. Keep each file the **source of truth**; describe the
 *why/when* here and the *schema* in the file's own header — don't duplicate one in the other.
 
 ## Files


### PR DESCRIPTION
## What was wrong

`registries/README.md` says a registry's index is the data file itself "because tooling and CI parse it". No CI workflow parses any registry. Over `.github/`, the docs hub's `.github/` and `templates/ci/`, the only mentions of a registry are about the ADR registry, apart from `method-check.yml`'s comment that the repo registry is deliberately not checked there. The same README's table made the same claim about `repos.yml` until #221.

## The change

- `registries/README.md`: "because tooling and CI parse it" becomes "because tooling parses it".
- `CHANGELOG.md`: the sentence #221 added about this README now reads "`registries/README.md` no longer says CI reads the registries; its table names the check-in", so it covers the intro as well as the table. No separate entry.

No `UPDATING-THROUGHSTONE.md` line: an existing project has nothing to do.

## Evidence

- The only `CI` left under `registries/` is `security-reviews.yml`'s advice to re-check after changes to a project's CI, which says nothing about parsing.
- `tests/links.sh` and `tests/doc-contract.sh` pass, within the full suite, `for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`: all 18 files pass locally; CI below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
