### PR TITLE
Fix the licence step's path, and say what to do with a repo that is not checked out

### DIFF
--- a/Code/{{PROJECT}}-docs/runbooks/register-repo.md
+++ b/Code/{{PROJECT}}-docs/runbooks/register-repo.md
@@ -15,6 +15,9 @@ The goal is that the **result** is the same however a repo arrived.
   in `Code/{{PROJECT}}-docs/registries/repos.yml`.
 - **Do not invent any of these. Ask.** A description or a role you guessed reads exactly like one
   somebody decided.
+- **Steps 2 and 3 write into the repo itself**, so it has to be checked out at its `location:` on
+  this machine — a `.git` there, directly or through a symlink. If it is not, see *When something
+  does not work* before writing anything.
 
 ## The steps
 
@@ -68,12 +71,15 @@ The goal is that the **result** is the same however a repo arrived.
    | project `LICENSE` + `LICENSING.md` | written from the posture | **never** — their licensing is not ours to state |
    | `LICENSE-THROUGHSTONE` | written | written — our material there needs a notice |
 
-   - **Created by us** — `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh Code/<repo>/`
-   - **Adopted** — `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only Code/<repo>/`
+   - **Created by us** — `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh <location>`
+   - **Adopted** — `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <location>`
 
-   Check the path exists first. An existing notice is left alone. A **proprietary** posture writes
-   `LICENSING.md` and the notice but no project `LICENSE` — that is the posture doing its job, not
-   a failure.
+   `<location>` is the row's `location:` as written. An existing notice is left alone. In a repo we
+   created, an existing licence is never overridden without an explicit instruction from the user
+   naming that repo: if the script stops because a licence is already there, run the
+   `--notice-only` command instead, so the notice still lands, and raise the licence in the chat.
+   A **proprietary** posture writes `LICENSING.md` and the notice but no project `LICENSE` — that
+   is the posture doing its job, not a failure.
 
 4. **Add or refresh the Architecture Overview Repos entry** — the repo's role, the slice it owns,
    and where its detail lives. The doc is
@@ -99,6 +105,14 @@ A repo may not be on this machine, may have a dirty tree, may reject the write, 
 may sit inside another repo's work tree. In every case: **do the parts that work, name the parts
 that did not, and let the human decide.** They can commit, stash, grant access, or say skip it.
 
+**Nothing checked out at the row's `location:`** — no directory there, or an empty one — is a
+repo not on this machine. Write nothing there: an empty directory is not the repo, and writing
+into it stops the repo being cloned there. The row, the Architecture Overview entry and the
+docs-hub commit need only the docs hub, so do those; the README, the licence and the repo commit
+wait. The human decides the rest: clone it there, point you at a checkout elsewhere on this
+machine (step 1's symlink rule — remove the empty directory first, or the link lands inside it),
+or skip it. Re-running finishes whatever waited.
+
 ## Report — always, even when everything worked
 
 End the run with one block per repository. **A repo you skipped is named here too**; a silent
@@ -113,7 +127,7 @@ partial run reads as a complete one.
 
 ```
 {{PROJECT}}-api
-  row ✓   README ✓ (stamped)   licence ✓   arch entry ✓   docs commit ✓   repo commit ✓
+  row ✓   README ✓   licence ✓   arch entry ✓   docs commit ✓   repo commit ✓
 
 acme-billing
   row ✓   README —   licence ✓   arch entry ✓   docs commit ✓   repo commit —
@@ -121,7 +135,9 @@ acme-billing
   → repo commit: blocked by the same dirty tree; the notice is written but uncommitted.
 
 internal-tooling
-  SKIPPED — nothing is checked out at Code/internal-tooling/ on this machine.
+  row ✓   README —   licence —   arch entry ✓   docs commit ✓   repo commit —
+  → README, licence, repo commit: nothing is checked out at Code/internal-tooling/ on this
+    machine. Asked whether to clone it there, then re-run.
 ```
 
 `licence ✓` means every artifact that repo's posture requires landed: for one we created,

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -45,7 +45,7 @@
   If the repo has **no** README at all, stamp this file — but **drop `## Licensing`**, whose link
   points at a `LICENSING.md` that is never written into a repo Throughstone did not create.
   Either way, do **not** install CI and do **not** apply a project license; for the Throughstone
-  notice, and only where material of ours actually landed, run
+  notice, run
   `Code/{{PROJECT}}-docs/scripts/apply-project-license.sh --notice-only <this-repo-path>`.
 
   The whole procedure is `Code/{{PROJECT}}-docs/runbooks/register-repo.md`.


### PR DESCRIPTION
One of four PRs correcting how a repository is registered. They touch separate lines and merge in any order.

## What was wrong

- **The licence step used the wrong path.** `runbooks/register-repo.md` step 3 ran the helper on `Code/<repo>/`, but a row's `location:` can be any path inside the workspace. For a repo registered at `vendor/partner-lib/`:

  ```
  $ Code/demo-docs/scripts/apply-project-license.sh --notice-only Code/partner-lib/
  apply-project-license.sh: target directory does not exist: Code/partner-lib/      (exit 2)
  ```

- **Nothing said what to do when the repo is not checked out.** An empty directory at the location passed both step 2's "No README" and step 3's "Check the path exists first", so following the steps wrote a README and the notice into it. After that the repo can no longer be cloned there:

  ```
  fatal: destination path 'Code/internal-tooling' already exists and is not an empty directory.
  warning: could not clone … -> Code/internal-tooling/ — continuing without it
  1 repo(s) above did not arrive.
  ```

  The report example covered this with a `SKIPPED` line the legend does not define. It also skipped the row, the Architecture Overview entry and the docs-hub commit, which need only the docs hub.

- **Nothing said what happens to a licence already in a repo we created.** The helper refuses to replace one, and when it refuses it writes nothing at all, `LICENSE-THROUGHSTONE` included:

  ```
  apply-project-license.sh: project is proprietary, but target already has LICENSE: Code/haslic//LICENSE      (exit 1)
  ```

- **The README template put a condition on the notice.** It told a repo that already exists to take the Throughstone notice "only where material of ours actually landed". The notice goes in every repo, with no condition.

## The change

- **`runbooks/register-repo.md`**
  - Step 3 runs on `<location>`, the row's `location:` as written.
  - Step 3 adds that, in a repo we created, an existing licence is never overridden without an explicit instruction from the user naming that repo. If the helper stops because a licence is already there, run the `--notice-only` command so the notice still lands, and raise the licence in the chat. An adopted repo's rule is unchanged: never a project `LICENSE`.
  - *Before you start* gains one bullet: steps 2 and 3 write into the repo, so it has to be checked out at its location first. That means a `.git` there, directly or through a symlink.
  - *When something does not work* gains a paragraph for a location with nothing checked out. Write nothing there, and do the docs-hub parts. The human then decides: clone it there, point at a checkout elsewhere (remove the empty directory first, or `ln -s` puts the link inside it), or skip it. Then re-run.
  - The report example uses only the legend's own symbols. `SKIPPED` and the `(stamped)` annotation are gone.
- **`templates/repo-readme-template.md`**: the notice instruction loses its condition.

No `CHANGELOG.md` or `UPDATING-THROUGHSTONE.md` entry. The runbook and the template's existing-repo section are new in the unreleased 1.8, and none of the corrected wording has shipped.

## Evidence

All runs were in projects generated with `init.sh --non-interactive --layout=multi --remotes=no`, outside the checkout.

- **Licence path.** The runbook's old form failed as shown above. The row's location works: `--notice-only vendor/partner-lib/` gives `Throughstone license: vendor/partner-lib//LICENSE-THROUGHSTONE`, exit 0. The same holds for `prompts/` and for a location reached through a symlink.
- **A location with nothing checked out.** `setup-workspace.sh` was run on a registered row whose location was:
  - absent: it cloned;
  - an empty directory: it cloned;
  - a directory the steps had written into: `could not clone`, as shown above.
- **Existing licence.** In every mode the target's `LICENSE` has the same shasum before and after. After a refusal, `--notice-only` on the same repo gives `Throughstone license: Code/haslic//LICENSE-THROUGHSTONE`, exit 0.
- **Symlink onto an empty directory.** `ln -s <checkout> <empty directory>` exits 0 and nests the link inside the directory. Removing the directory first gives a location `setup-workspace.sh` reports as `exists`.
- **Whole change.** With the four PRs merged together, the full suite (`for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`) passes 18 of 18 test files. In freshly generated multi-repo and mono-repo projects, `doctor.sh check` and `doctor.sh links` both report `RESULT: OK`. The multi-repo `check` shows one warning: the root-hygiene check flagging this test's own `init.log` and `check.out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
