### PR TITLE
Say which file is a repo's README, and keep an existing ARCHITECTURE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,8 +105,11 @@ any project built with it.
   included. Five steps: write its `registries/repos.yml` row, give it a README, apply the
   licensing artifacts, record it in the Architecture Overview, and commit once per repository.
   **Which README a repo gets is decided by what is in the repo, not by how the repo arrived** — a
-  repo with no README is stamped from `templates/repo-readme-template.md`, one that already has a
-  README keeps it and gains a short `## Role in <project>` section, and no repo ends up with two.
+  repo with no README is stamped from `templates/repo-readme-template.md` as `README.md`, one that
+  already has a README keeps it under its own name and gains a short `## Role in <project>` section
+  in that file's own markup, and registration never adds a second. A README is any regular file at
+  the repo root whose name starts with `readme`, in any capitalisation and format; where there is
+  more than one, the runbook asks which is canonical instead of picking.
   Licensing shows its two artifacts separately, because they answer different questions: a repo the
   method created follows the project's own posture, while an adopted repo gets `LICENSE-THROUGHSTONE`
   for the Throughstone-authored material in it and never a project `LICENSE` or `LICENSING.md` —

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -312,7 +312,7 @@ procedure for it — whether Throughstone creates the repo or takes on one that 
 everything that changes the set of repositories your project has goes through it, the split
 included. **Which README a repo gets is decided by what is in the repo, not by how the repo
 arrived**: no README means one stamped from the template, an existing README keeps it and gains a
-`## Role in <project>` section, and no repo ends up with two. An adopted repo gets
+`## Role in <project>` section, and registration never adds a second. An adopted repo gets
 `LICENSE-THROUGHSTONE` and never a project `LICENSE` — choosing a licence for code the method did
 not write is not the method's to do. The per-posture licensing detail that used to sit in
 `METHOD.md` §7 moved into the runbook, beside the step that performs it, so §7 no longer answers

--- a/Code/{{PROJECT}}-docs/runbooks/register-repo.md
+++ b/Code/{{PROJECT}}-docs/runbooks/register-repo.md
@@ -54,11 +54,18 @@ The goal is that the **result** is the same however a repo arrived.
    location, or a repo pushed to a host for the first time. One that holds a **different** value
    is **raised and changed by nobody** — a repo that moved or was repointed is a decision.
 
-2. **The README — decided by what is in the repo.**
-   - **No README** — stamp `Code/{{PROJECT}}-docs/templates/repo-readme-template.md`.
-   - **A README already there** — leave it and add a `## Role in <project>` section, shape in the
-     same template. If that section is already present, **update it in place; never append a
-     second one.**
+2. **The README — decided by what is in the repo.** A README is a regular file at the repo root
+   whose name starts with `readme` in any capitalisation — `README.md`, `readme.rst`, a bare
+   `README`; a symlink or a `readme` directory is not one. **With more than one, ask which is
+   canonical** before writing to any of them.
+   - **No README** — stamp `Code/{{PROJECT}}-docs/templates/repo-readme-template.md` as
+     `README.md`.
+   - **A README already there** — leave it under its own name and add a `## Role in <project>`
+     section, shape in the same template, written in that file's own markup; a format you do not
+     recognise is plain text. If that section is already present, **update it in place; never
+     append a second one.**
+
+   A repo that already has an `ARCHITECTURE.md` keeps it, exactly as its README is kept.
 
 3. **Licensing — decided by whether we created the repo. Two separate artifacts, and they do not
    travel together.**

--- a/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
+++ b/Code/{{PROJECT}}-docs/templates/repo-readme-template.md
@@ -39,8 +39,9 @@
   it explicitly does not*, and a link to the architecture doc that defines it. Not a bare pointer
   — the boundary statement is the thing a newcomer cannot get quickly from the code. Default to
   appending it at the end, and offer to place it higher: placement is content, and content is the
-  owner's to shape. That heading through to the next `##` is the whole of Throughstone's part of
-  the file, which is what a check-in sweeps. If the section is already there, update it in place.
+  owner's to shape. That heading through to the next heading at its level is the whole of
+  Throughstone's part of the file, which is what a check-in sweeps. If the section is already
+  there, update it in place.
 
   If the repo has **no** README at all, stamp this file — but **drop `## Licensing`**, whose link
   points at a `LICENSING.md` that is never written into a repo Throughstone did not create.


### PR DESCRIPTION
One of four PRs correcting how a repository is registered. They touch separate lines and merge in any order.

## What was wrong

`runbooks/register-repo.md` step 2 splits on "No README" and "A README already there", but never says which file counts as the README. That leaves an agent to guess in two cases:

- **A repo with `readme.rst`.** The `## Role in <project>` section is Markdown, so appending it to an RST file shows it as literal text.
- **A repo with both `README.md` and `README.zh-CN.md`.** Nothing says which one gets the section.

Nothing said an `ARCHITECTURE.md` already in the repo is kept.

## The change

- **`runbooks/register-repo.md` step 2**
  - Defines a README: a regular file at the repo root whose name starts with `readme`, in any capitalisation. A symlink or a `readme` directory is not one.
  - **More than one:** ask which is canonical before writing to any of them.
  - **None:** stamp the template as `README.md`.
  - **One already there:** it keeps its name, and the Role section is written in that file's own markup. A format nobody recognises is treated as plain text.
  - An `ARCHITECTURE.md` already in the repo is kept, as its README is. This is worded by what is in the repo, not by how the repo arrived.
- **`templates/repo-readme-template.md`**: Throughstone's part of an existing README now runs to the next heading at its level, not to the next `##`, which an RST or plain-text README does not have.
- **`CHANGELOG.md`**: the entry for the runbook describes the rule.
- **`CHANGELOG.md` and `UPDATING-THROUGHSTONE.md`**: both now say "registration never adds a second" instead of "no repo ends up with two". The old wording is not true of a repo that arrives with two.

## Evidence

The rule was applied literally to fixture repos with `find <repo> -maxdepth 1 -type f -iname 'readme*'`:

| repo root holds | candidates | result |
|---|---|---|
| `README.md` | 1 | use it |
| `readme.rst` | 1 | use it, RST markup |
| bare `README` | 1 | use it |
| `README.md` + `README.rst` | 2 | ask |
| `README.md` + `README.zh-CN.md` | 2 | ask |
| symlink `README.md` | 0 | not a candidate |
| `readme/` directory | 0 | not a candidate |

No test pins the replaced sentences: `git grep` over `tests/` finds none.

**Whole change.** With the four PRs merged together, the full suite (`for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`) passes 18 of 18 test files. In freshly generated multi-repo and mono-repo projects, `doctor.sh check` and `doctor.sh links` both report `RESULT: OK`. The multi-repo `check` shows one warning: the root-hygiene check flagging this test's own `init.log` and `check.out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
