### PR TITLE
Stop saying nothing decides from added_as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,13 @@ any project built with it.
 - **Repo rows record how each repo arrived, and a split-out repo records where it came from.**
   `registries/repos.yml` gains **`added_as:`** (`created` | `adopted`) — whether Throughstone made
   the repo or took on one that was already there. It is a stamp for a human reader, written once
-  when the repo is registered and never changing afterwards: **nothing reads it and nothing decides
-  from it.** `type:` is documentation in the same way, and gains `mono` for the workspace root of a mono-repo-for-now project. A repo split out of
-  another one can also carry an optional **`provenance:`** block recording where it came from and
-  where the two histories part company; it is written at the split and nothing maintains it after.
+  when the repo is registered and never changing afterwards: **no script reads it, and the STEP
+  process must not branch on how a repo arrived.** When a repo is registered its licensing depends
+  on how it arrived, and any other case is a decision taken deliberately. `type:` is
+  documentation that no script reads either, and gains `mono` for the workspace root of a
+  mono-repo-for-now project. A repo split out of another one can also carry an optional
+  **`provenance:`** block recording where it came from and where the two histories part company;
+  it is written at the split and nothing maintains it after.
   **Nothing else is tracked per repo.** A row is an inventory entry, never a status board: the work
   of bringing a repo in is *done* at the time rather than recorded as a status, anything missed is
   found later by looking at the repo, and a case the registry does not cover is raised to a person
@@ -398,7 +401,7 @@ any project built with it.
   is written later, by the STEP this session is in the middle of outlining. A project can also be
   set up around a codebase that was already there, and a repo can be taken on in a phase long
   after the first. The person in the chair knows the answer in every case, so the session asks
-  them — nothing reads how a repo arrived, and that rule is unchanged.
+  them.
 
   **The question carries its own stop**, which is why there is no second rule to keep in step with
   it: it asks about code no check-in has run over yet, so a project re-planning a later phase does

--- a/Code/{{PROJECT}}-docs/METHOD.md
+++ b/Code/{{PROJECT}}-docs/METHOD.md
@@ -567,10 +567,12 @@ from someone else's machine must not be written to here even when it happens to 
 
 **What a row records, and what it does not.** A row is an inventory entry, never a status board;
 `registries/repos.yml` documents its fields. Two of them are **stamps for a reader** — `added_as`
-and `type`: nothing reads them and nothing decides from them, so the STEP process cannot tell how a
-repo arrived, and if anything ever branches on them, that is the bug. **Nothing else is tracked per
-repo.** The work of bringing a repo in is *done* at the time, never recorded as a status, and
-anything missed is found later by looking at the repo.
+and `type`: no script reads either, and the STEP process must not branch on how a repo arrived.
+When a repo is registered (`runbooks/register-repo.md`), its licensing depends on how it
+arrived: a repo the method created takes the project posture, an adopted one only the Throughstone
+notice. Any other case is a decision taken deliberately, not a pattern to reach for. **Nothing else
+is tracked per repo.** The work of bringing a repo in is *done* at the time, never recorded as a
+status, and anything missed is found later by looking at the repo.
 
 **The registry is checked at the check-in, not on the common path.** The set of repos changes only
 when one is created, adopted or split out, so `scripts/check.sh` checks it under `--check-in` alone,

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -453,9 +453,9 @@ New projects get this row from `init.sh`; `init.sh` runs once, so nothing adds i
 already exists. Multi-repo projects have nothing to add.
 
 **One new registry field, and nothing to do about it.** Rows may carry `added_as:`
-(`created` | `adopted`), recording how the repo arrived. **Nothing reads it and nothing decides from
-it** — it is a stamp for a human. Existing rows do not need it and are not rewritten; it is written
-when a repo is registered from here on.
+(`created` | `adopted`), recording how the repo arrived. **No script reads it** — it is a stamp for
+a human. Existing rows do not need it and are not rewritten; it is written when a repo is
+registered from here on.
 
 
 **Mono-repo-for-now? Your CI gate has probably never run.** `method-check.yml` ships inside the docs

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -34,11 +34,13 @@
 # `added_as:` — `created` if Throughstone made this repo, `adopted` if it already existed. It
 # records how the **repository** was formed, not where its contents came from: a repo split out
 # of another one is `created`, and the history it carries is recorded in `provenance:`. A
-# stamp, written once, never changing. **Nothing reads it and nothing decides from it**; it is
-# recorded so a person can later tell why a repo looks the way it does. The result is the same
-# however a repo arrived — if anything ever branches on this field, that is the bug.
+# stamp, written once, never changing, so a person can later tell why a repo looks the way it
+# does. **No script reads it, and the STEP process must not branch on how a repo arrived.** When
+# a repo is registered, its licensing depends on how it arrived: a created repo takes the project
+# posture, an adopted one only the Throughstone notice. Any other case is a decision taken
+# deliberately, not a pattern to reach for.
 #
-# `type:` — documentation for a human reader. Nothing reads it either.
+# `type:` — documentation for a human reader. No script reads it either.
 #
 # `provenance:` — records that a repo was **split out** of another one: where it came from and
 # where the two histories part company. Only a split-out repo carries it, it is written at the

--- a/Code/{{PROJECT}}-docs/runbooks/register-repo.md
+++ b/Code/{{PROJECT}}-docs/runbooks/register-repo.md
@@ -3,7 +3,7 @@
 Bring a repository into the project: record it, give it a README, and put our licence notice in
 it. Run this when a repo is created, adopted, or split out of another.
 
-The goal is that the **result** is the same however a repo arrived.
+The goal is that the **result** is the same however a repo arrived, except for licensing (step 3).
 
 ## Before you start
 


### PR DESCRIPTION
One of four PRs correcting how a repository is registered. They touch separate lines and merge in any order.

## What was wrong

These places said `added_as` is inert:

- `registries/repos.yml`: "**Nothing reads it and nothing decides from it** … if anything ever branches on this field, that is the bug."
- `METHOD.md` §7: "nothing reads them and nothing decides from them … if anything ever branches on them, that is the bug."
- `runbooks/register-repo.md`: "The goal is that the **result** is the same however a repo arrived."
- `CHANGELOG.md` and `UPDATING-THROUGHSTONE.md`, both unreleased 1.8 text: "nothing reads it and nothing decides from it".

But `runbooks/register-repo.md` step 3 picks the licensing by it:

- a repo the method created takes the project's licence posture;
- an adopted repo gets only `LICENSE-THROUGHSTONE`.

## The change

- The same places now say four things:
  - no script reads `added_as`;
  - the STEP process must not branch on how a repo arrived;
  - when a repo is registered, its licensing depends on how it arrived;
  - any other case is a decision taken deliberately.
- `register-repo.md`'s opening line names licensing as the exception.
- What is said of `type:` is unchanged: no script reads it either.
- The upgrade guide's paragraph on the field keeps only "No script reads it — it is a stamp for a human".
- The planning-session entry in `CHANGELOG.md` loses a clause that restated the old rule.

No behaviour changes. `added_as` has never shipped in a tag, so the two release-note sites are edited in place rather than added to.

## Evidence

- `git grep -n added_as` over `Code/{{PROJECT}}-docs/scripts/`, `doctor.sh` and `init.sh` finds only `init.sh`, which writes the mono root row and comments on it.
- With `added_as` removed from every row of a generated project, `setup-workspace.sh`, `check.sh --check-in` and `status.sh` print output byte-identical to the rows as seeded.
- `tests/doc-contract.sh` pins other sections of `METHOD.md`, not §7.
- **Whole change.** With the four PRs merged together, the full suite (`for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`) passes 18 of 18 test files. In freshly generated multi-repo and mono-repo projects, `doctor.sh check` and `doctor.sh links` both report `RESULT: OK`. The multi-repo `check` shows one warning: the root-hygiene check flagging this test's own `init.log` and `check.out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
