### PR TITLE
Say how to quote registry values, and check for 1.7's annotated example row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,10 @@ any project built with it.
   scripts that read it match line prefixes and know nothing about YAML: every value is a single-line
   scalar; a rewrite anchors on the whole row block rather than a bare line prefix; and **a `#` on a
   value line is part of the value, not a comment**, so `- name:`, `location:` and `remote:` must
-  carry nothing after the value. That last one has a concrete failure behind it — the readers strip a
-  closing quote only at end of line, so a trailing `# note` on a `remote:` line ends up inside the
-  clone URL.
+  carry nothing after the value and are quoted with double quotes or not at all. That last one has a
+  concrete failure behind it — the readers strip a double quote only from either end of the value, so
+  a trailing `# note` on a `remote:` line ends up inside the clone URL, and a single-quoted
+  `location:` becomes a folder whose name starts with the quote.
 
 - **`apply-project-license.sh --notice-only <repo>`** — write the Throughstone notice into a
   repository and nothing else. The script's one mode writes three files keyed on the project's

--- a/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
+++ b/Code/{{PROJECT}}-docs/UPDATING-THROUGHSTONE.md
@@ -77,9 +77,10 @@ not fail the check.
 
 ### 1.8 migration
 
-**Upgrading from 1.7? Nothing of yours is rewritten, and there are two things to look at in
+**Upgrading from 1.7? Nothing of yours is rewritten, and there are three things to look at in
 `registries/repos.yml`** — **whether any `location:` points outside the workspace root**, which 1.7
-allowed and this release does not, and, **if your project is mono-repo-for-now, whether the
+allowed and this release does not, **whether anything follows a `- name:`, `location:` or `remote:`
+value**, which 1.7's example row did, and, **if your project is mono-repo-for-now, whether the
 workspace root has a row at all** — **plus, for a mono-repo-for-now project, one thing to check**:
 whether your CI gate has ever actually run — **and one line to change** in `overview.md`, where the
 check-in cadence setting is replaced by the date or STEP your next check-in is due, **and, if your
@@ -104,7 +105,10 @@ how a repo is brought into a project at all — in a second new runbook. Fast pa
 3. **Check every `location:` in `registries/repos.yml`.** One that points outside the workspace
    root — an absolute path, or one reaching out with `..` — no longer works, and 1.7 said it was
    allowed. **Details at the end of this section**; this is the only change here that can leave your
-   registry describing a workspace nobody else can reproduce.
+   registry describing a workspace nobody else can reproduce. **While you are in each row, check
+   that nothing follows a `- name:`, `location:` or `remote:` value** — a row copied from 1.7's
+   commented-out example carries a note after its `remote:`, which has kept that repo from cloning
+   on anyone else's machine all along; details in the same place.
 4. **Mono-repo-for-now only: add a row for the workspace root** to `registries/repos.yml`, or the
    new check-in warning will be wrong about every repo you have — details at the end of this
    section.
@@ -436,8 +440,9 @@ and only two:
 A 1.7 registry lists the docs hub and `prompts/` — both folders inside your one repository — and has
 no row for the repository itself. The check treats a row whose `location` is `.` as the thing that
 contains the others, so without it you are told all your repos are unbacked-up even when the one
-real repo is pushed. Add it by hand — and **put nothing after any value**, because these readers
-treat a `#` on a value line as part of the value rather than as a comment. Drop the `remote:` line
+real repo is pushed. Add it by hand. **Put nothing after any value**: these readers treat a `#` on
+a value line as part of the value rather than as a comment. **Quote values with double quotes, as
+below, or not at all**: they read a single quote as part of the value too. Drop the `remote:` line
 if the repo has no remote yet:
 
 ```yaml
@@ -516,6 +521,14 @@ are directory names rather than paths to a home directory. `~/lib` used to clone
 a literal `~` folder under the workspace root and report it as an ordinary clone; it is now skipped.
 `$HOME/lib` still makes a literal `$HOME` directory, and no guard can tell that from a directory
 somebody meant to call that.
+
+**And check that nothing follows a `- name:`, `location:` or `remote:` value.** The scripts that
+read the registry take a `#` on those lines as part of the value, not as a comment. 1.7's
+commented-out example row carried `# team mode: setup-workspace.sh clones this` after its
+`remote:`, so a row copied from it records a clone URL that does not exist. `setup-workspace.sh`
+reports that repo as one that did not arrive, on every machine except the one that already has the
+checkout, where it says `exists` and nothing more; and the check-in counts the value as a recorded
+remote. Move the note to a line of its own, or delete it.
 
 **Templates and guidance text, with nothing to undo.** Three edits to
 `templates/architecture-sessions/*.md`, one to `METHOD.md` §3, one to

--- a/Code/{{PROJECT}}-docs/registries/repos.yml
+++ b/Code/{{PROJECT}}-docs/registries/repos.yml
@@ -53,8 +53,9 @@
 #    `- name:`, respecting indentation — never on a bare line prefix.
 # 3. **A `#` on a value line is part of the value, not a comment.** These readers skip only a line
 #    whose first non-blank character is `#`, so the fields they actually read — `- name:`,
-#    `location:` and `remote:` — must carry nothing after the value. (`type:` below carries an
-#    annotation; nothing reads that field.) The annotations in the example block are safe only
+#    `location:` and `remote:` — must carry nothing after the value, and are quoted with double
+#    quotes or not at all: a single quote is read as part of the value too. (`type:` below carries
+#    an annotation; no script reads that field.) The annotations in the example block are safe only
 #    because the whole block is commented out; move them off the value lines before uncommenting
 #    a row.
 

--- a/Code/{{PROJECT}}-docs/runbooks/register-repo.md
+++ b/Code/{{PROJECT}}-docs/runbooks/register-repo.md
@@ -36,7 +36,8 @@ The goal is that the **result** is the same however a repo arrived.
    **`remote:` is recorded if the repo has one** — registration records what is there; it never
    creates a remote and never repoints one. Put nothing after a `- name:`, `location:` or
    `remote:` value: the readers take the rest of the line as part of it, so a trailing `# note`
-   ends up inside the name, the path or the clone URL.
+   ends up inside the name, the path or the clone URL. Quote those values with double quotes, as
+   above, or not at all — a single quote is read as part of the value too.
 
    **A remote created for a repo that has none is created private** — widening is a separate
    decision, made deliberately later. Making a repo public takes an explicit instruction from the


### PR DESCRIPTION
One of four PRs correcting how a repository is registered. They touch separate lines and merge in any order.

## What was wrong

- **Nothing said how to quote a registry value.** The two readers of `registries/repos.yml`, `check.sh` and `setup-workspace.sh`, strip one double quote from each end of a value and nothing else. Single quotes are kept:

  ```
  location: 'Code/api'   ->  setup-workspace.sh: cloning … -> 'Code/api'   (a top-level folder named 'Code)
  location: '.'          ->  check.sh --check-in, mono: [WARN] repo(s) with no remote: demo-docs (Code/demo-docs/) prompts (prompts/)
  remote: '<url>'        ->  fatal: repository ''<url>'' does not exist
  ```

  In a multi-repo project the doctor's root-hygiene check does warn about the stray `'Code` entry. The registry check says nothing in any of these cases.

- **1.7's example row breaks the clone, and the upgrade guide did not say to check for it.** 1.7.0 and 1.7.1 shipped a commented-out example row with a note after its `remote:` value: `# team mode: setup-workspace.sh clones this`. A row copied from it never clones anywhere else:

  ```
  fatal: '<url>"   # team mode: setup-workspace.sh clones this' does not appear to be a git repository
  warning: could not clone … — continuing without it
  1 repo(s) above did not arrive.
  ```

  On the machine that already has the checkout, the script prints only `exists:`. `check.sh --check-in` counts the value as a recorded remote.

## The change

- **`registries/repos.yml` rule 3 and `runbooks/register-repo.md` step 1:** quote `- name:`, `location:` and `remote:` values with double quotes or not at all. Rule 3's aside about `type:` now says "no script reads that field".
- **`UPDATING-THROUGHSTONE.md`, 1.8 migration:**
  - The opening count is now three things to look at in `registries/repos.yml`.
  - Fast-path step 3 asks for the check while the upgrader is already in each row, with no renumbering.
  - A new paragraph after the location details says what the note does and how to fix it.
  - The mono root-row paragraph adds the quoting rule, and both of its instructions are now bold.
- **`CHANGELOG.md`:** the entry describing the header's rules adds the quoting rule and the single-quote failure.

No script changes.

## Evidence

All runs were in projects generated with `init.sh --non-interactive --remotes=no`, with a local bare remote holding one commit.

- **Quoting.** Double-quoted and bare `location:` values clone into `Code/api/`. The single-quoted cases behave as shown above. In a mono project, `location: "."` gives `[PASS] 3 row(s): all have a location, and a recorded remote covers every one`.
- **The 1.7.1 row.** It was uncommented as shipped, with the URL pointed at the local remote, and gave the output shown above. With the note moved to a line of its own, the run gives `cloning <url> -> Code/demo-api/`, and the checkout's HEAD matches the remote.
- **The shipped row.** Line 39 of `git show v1.7.1:'Code/{{PROJECT}}-docs/registries/repos.yml'` carries the note, and v1.7.0's file is identical.
- **Whole change.** With the four PRs merged together, the full suite (`for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`) passes 18 of 18 test files. In freshly generated multi-repo and mono-repo projects, `doctor.sh check` and `doctor.sh links` both report `RESULT: OK`. The multi-repo `check` shows one warning: the root-hygiene check flagging this test's own `init.log` and `check.out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
