### PR TITLE
Correct init.sh's comment on the seeded added_as field

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1154,7 +1154,7 @@ fi
 if [ "$LAYOUT" = "2" ]; then
   # The registry is the source of truth for which repos exist, and the only repository a mono
   # project has is the workspace root — so its row is seeded here. `added_as: created` is a
-  # stamp for a human reader: nothing reads it and nothing decides from it.
+  # stamp for a human reader; no script reads it.
   if [ -f "$DOCS/registries/repos.yml" ]; then
     SLUG="$SLUG" perl -0pi -e '
       my $row = qq{  - name: "$ENV{SLUG}"\n}


### PR DESCRIPTION
## What was wrong

`init.sh` seeds a mono-repo-for-now project's root row with `added_as: created`. The comment above that code called the field a stamp that "nothing reads … and nothing decides from".

That isn't true: registration does decide by how a repo arrived. Its licensing step gives a created repo the project's licence posture, and an adopted repo gets only `LICENSE-THROUGHSTONE`.

#228 corrected the same sentence in `registries/repos.yml`, `METHOD.md` and the release notes. This comment was the last copy.

## The change

One comment line in `init.sh`:

```diff
-  # stamp for a human reader: nothing reads it and nothing decides from it.
+  # stamp for a human reader; no script reads it.
```

The change is comment only, so there is no behaviour, test or release-note change.

## Evidence

- Outside `CHANGELOG.md`, `git grep -n -F 'nothing decides from it'` found only this line, so no test or document depends on the old text.
- `bash -n init.sh` passes, and the diff is exactly one line in one file (`git diff --numstat` gives `1 1 init.sh`).
- The full suite (`for t in tests/*.sh; do env -u CI bash --noprofile --norc "$t"; done`) passes 18 of 18 test files on this commit, including the `init-*` tests, which run `init.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
